### PR TITLE
Fix drag and drop module expansion (fix #18)

### DIFF
--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -302,6 +302,9 @@ export function Workspace({ modules, setModules, selectedConversationId }: Works
       {Array.from({ length: 6 }, (_, index) => {
         const module = positionMap.get(index);
         const isEmpty = !module;
+        
+        const row = Math.floor(index / 3) + 1;
+        const col = (index % 3) + 1;
 
         return (
           <div
@@ -312,7 +315,10 @@ export function Workspace({ modules, setModules, selectedConversationId }: Works
                     gridColumn: `${module.startIndex % 3 + 1} / span ${module.colSpan}`,
                     gridRow: `${Math.floor(module.startIndex / 3) + 1} / span ${module.rowSpan}`,
                   }
-                : {}
+                : {
+                    gridColumn: col,
+                    gridRow: row,
+                  }
             }
             onDragOver={(e) => handleDragOver(e, index)}
             onDragLeave={handleDropZoneDragLeave}


### PR DESCRIPTION
Issue #18 - "when modules are expanded, the position doesn't seem to maintain for when other modules are dragged and dropped."

Problem: CSS Grid has this auto-place feature. If you don't define where 'empty' grids should go, it will autoplace them. So when you expand a module, it shifts down all the empty placements, so that when you try to place another module, it will be displayed in the next box. 

Fix: Gave grid positioning to empty grid-boxes (divs), using their row column to assign empty divs a position. So, when react renders the grid, if there's no module there (empty), it gets assigned base on their row/col. 

