### PR TITLE
Add analysis tab with time chart, CSV export

### DIFF
--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime, date, timedelta
 from typing import List, Optional
 import csv
+import os
 import io
 import logging
 import threading
@@ -1455,12 +1456,15 @@ def get_analysis_temporal(
     if cal_from > cal_to:
         raise HTTPException(status_code=400, detail="calendar_from must be <= calendar_to")
 
+    analysis_tz = (os.getenv("ANALYSIS_TIMEZONE") or "America/Los_Angeles").strip() or "America/Los_Angeles"
+
     by_hour = [{"hour": h, "count": 0} for h in range(24)]
     by_weekday = [{"weekday": w, "count": 0} for w in range(7)]
     tutor_usage_by_day: list = []
     timezone_note = (
-        "Timestamps come from PostgreSQL `events.created_at` (typically UTC). "
-        "Hour, weekday, and daily counts use the database session time zone for `DATE` / `EXTRACT`."
+        f"Tutor usage uses PostgreSQL `events.created_at` (stored as timestamptz, usually UTC). "
+        f"Hours, weekdays, and calendar days are grouped in `{analysis_tz}` so the axes match that "
+        "zone’s local wall clock (set `ANALYSIS_TIMEZONE` to another IANA name to change)."
     )
     tutor_usage_error: Optional[str] = None
 
@@ -1468,11 +1472,13 @@ def get_analysis_temporal(
         with ext_engine.connect() as conn:
             hour_rows = conn.execute(
                 text("""
-                    SELECT EXTRACT(HOUR FROM created_at)::int AS hour, COUNT(*)::bigint AS cnt
+                    SELECT EXTRACT(HOUR FROM (created_at AT TIME ZONE :tz))::int AS hour,
+                           COUNT(*)::bigint AS cnt
                     FROM events
                     WHERE event_type = 'tutor_query'
                     GROUP BY 1
-                """)
+                """),
+                {"tz": analysis_tz},
             ).mappings().all()
             for r in hour_rows:
                 h = int(r["hour"])
@@ -1481,11 +1487,13 @@ def get_analysis_temporal(
 
             dow_rows = conn.execute(
                 text("""
-                    SELECT EXTRACT(DOW FROM created_at)::int AS weekday, COUNT(*)::bigint AS cnt
+                    SELECT EXTRACT(DOW FROM (created_at AT TIME ZONE :tz))::int AS weekday,
+                           COUNT(*)::bigint AS cnt
                     FROM events
                     WHERE event_type = 'tutor_query'
                     GROUP BY 1
-                """)
+                """),
+                {"tz": analysis_tz},
             ).mappings().all()
             for r in dow_rows:
                 w = int(r["weekday"])
@@ -1494,14 +1502,14 @@ def get_analysis_temporal(
 
             tutor_daily_rows = conn.execute(
                 text("""
-                    SELECT created_at::date AS d, COUNT(*)::bigint AS cnt
+                    SELECT (created_at AT TIME ZONE :tz)::date AS d, COUNT(*)::bigint AS cnt
                     FROM events
                     WHERE event_type = 'tutor_query'
-                      AND created_at::date >= :d0
-                      AND created_at::date <= :d1
+                      AND (created_at AT TIME ZONE :tz)::date >= :d0
+                      AND (created_at AT TIME ZONE :tz)::date <= :d1
                     GROUP BY 1
                 """),
-                {"d0": cal_from, "d1": cal_to},
+                {"tz": analysis_tz, "d0": cal_from, "d1": cal_to},
             ).mappings().all()
             day_counts: dict[str, int] = {}
             for r in tutor_daily_rows:
@@ -1606,6 +1614,7 @@ def get_analysis_temporal(
             "by_hour": by_hour,
             "by_weekday": by_weekday,
             "by_day": tutor_usage_by_day,
+            "display_timezone": analysis_tz,
             "timezone_note": timezone_note,
             "error": tutor_usage_error,
         },

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1,8 +1,13 @@
 from contextlib import asynccontextmanager
-from datetime import datetime
+from collections import defaultdict
+from datetime import datetime, date, timedelta
 from typing import List, Optional
+import csv
+import io
+import logging
 import threading
-from fastapi import FastAPI, Depends, HTTPException, Response, BackgroundTasks
+from calendar import monthrange
+from fastapi import FastAPI, Depends, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import func, text, update
 from sqlalchemy.engine import Connection
@@ -81,6 +86,8 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+logger = logging.getLogger(__name__)
 
 app.add_middleware(
     CORSMiddleware,
@@ -728,6 +735,7 @@ def get_queue_history(
 
     # Batch fetch message text from cache (one query for all page items)
     page_keys = [(e["chatlog_id"], e["message_index"]) for e in page]
+    page_key_set = set(page_keys)
     cached_msgs = db.exec(select(MessageCache)).all()
     cache_lookup = {(c.chatlog_id, c.message_index): c for c in cached_msgs}
 
@@ -746,7 +754,7 @@ def get_queue_history(
         ).all()
         for cid, midx, name in label_rows:
             key = (cid, midx)
-            if key in {(e["chatlog_id"], e["message_index"]) for e in page}:
+            if key in page_key_set:
                 labels_by_msg.setdefault(key, []).append(name)
 
     result = []
@@ -1298,25 +1306,369 @@ def get_embed_status(db: Session = Depends(get_session)):
 
 
 @app.get("/api/analysis/summary")
-def get_analysis_summary():
+def get_analysis_summary(db: Session = Depends(get_session)):
+    label_rows = db.exec(
+        select(LabelDefinition.name, func.count(LabelApplication.id))
+        .select_from(LabelApplication)
+        .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+        .group_by(LabelDefinition.name)
+    ).all()
+    label_counts = {name: int(cnt) for name, cnt in label_rows}
+
+    human_rows = db.exec(
+        select(LabelDefinition.name, func.count(LabelApplication.id))
+        .select_from(LabelApplication)
+        .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+        .where(LabelApplication.applied_by == "human")
+        .group_by(LabelDefinition.name)
+    ).all()
+    human_label_counts = {name: int(cnt) for name, cnt in human_rows}
+
+    ai_rows = db.exec(
+        select(LabelDefinition.name, func.count(LabelApplication.id))
+        .select_from(LabelApplication)
+        .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+        .where(LabelApplication.applied_by == "ai")
+        .group_by(LabelDefinition.name)
+    ).all()
+    ai_label_counts = {name: int(cnt) for name, cnt in ai_rows}
+
+    pos_rows = db.exec(
+        select(LabelApplication.message_index, LabelDefinition.name)
+        .select_from(LabelApplication)
+        .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+    ).all()
+    pos_acc: dict[str, dict[str, int]] = defaultdict(lambda: {"early": 0, "mid": 0, "late": 0})
+    for msg_idx, lbl_name in pos_rows:
+        if msg_idx <= 2:
+            pos_acc[lbl_name]["early"] += 1
+        elif msg_idx <= 6:
+            pos_acc[lbl_name]["mid"] += 1
+        else:
+            pos_acc[lbl_name]["late"] += 1
+    position_distribution = {k: dict(v) for k, v in pos_acc.items()}
+
+    human_pairs = set()
+    ai_pairs = set()
+    for row in db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index, LabelApplication.applied_by)
+    ).all():
+        cid, mid, applied_by = row
+        if applied_by == "human":
+            human_pairs.add((cid, mid))
+        elif applied_by == "ai":
+            ai_pairs.add((cid, mid))
+    human_labeled = len(human_pairs)
+    ai_labeled = len(ai_pairs)
+    labeled_any = len(human_pairs | ai_pairs)
+
+    notebook_breakdown: dict = {}
+    total = 0
+    try:
+        with ext_engine.connect() as conn:
+            total = int(
+                conn.execute(text("SELECT COUNT(*) FROM events WHERE event_type = 'tutor_query'")).scalar_one()
+            )
+            nb_rows = conn.execute(
+                text("""
+                    SELECT MIN(id) AS chatlog_id, MAX(payload->>'notebook') AS notebook
+                    FROM events
+                    WHERE event_type IN ('tutor_query', 'tutor_response')
+                      AND payload->>'conversation_id' IS NOT NULL
+                    GROUP BY payload->>'conversation_id'
+                """)
+            ).mappings().all()
+            chatlog_notebook = {}
+            for r in nb_rows:
+                cid = int(r["chatlog_id"])
+                nb = r["notebook"] if r["notebook"] else "unknown"
+                chatlog_notebook[cid] = nb
+
+            nb_counts: dict = defaultdict(lambda: defaultdict(int))
+            for lbl_name, chatlog_id in db.exec(
+                select(LabelDefinition.name, LabelApplication.chatlog_id)
+                .select_from(LabelApplication)
+                .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+            ).all():
+                nb_key = chatlog_notebook.get(int(chatlog_id), "unknown")
+                nb_counts[nb_key][lbl_name] += 1
+            notebook_breakdown = {k: dict(v) for k, v in nb_counts.items()}
+    except Exception:
+        total = 0
+        notebook_breakdown = {}
+
+    unlabeled = max(0, total - labeled_any)
+
     return {
-        "label_counts": {"Concept Question": 22, "Clarification": 18},
-        "notebook_breakdown": {"lab01": {"Concept Question": 10}},
+        "label_counts": label_counts,
+        "human_label_counts": human_label_counts,
+        "ai_label_counts": ai_label_counts,
+        "notebook_breakdown": notebook_breakdown,
         "coverage": {
-            "human_labeled": 40,
-            "ai_labeled": 0,
-            "unlabeled": 260,
-            "total": 300,
+            "human_labeled": human_labeled,
+            "ai_labeled": ai_labeled,
+            "unlabeled": unlabeled,
+            "total": total,
         },
+        "position_distribution": position_distribution,
+    }
+
+
+def _normalize_heatmap_rows(raw: list[list[float]]) -> list[list[float]]:
+    out = []
+    for row in raw:
+        s = sum(row)
+        out.append([float(x) / s if s > 0 else 0.0 for x in row])
+    return out
+
+
+def _normalize_heatmap_columns(raw: list[list[float]]) -> list[list[float]]:
+    if not raw:
+        return []
+    rows_n = len(raw)
+    cols_n = len(raw[0])
+    col_sums = [sum(raw[r][c] for r in range(rows_n)) for c in range(cols_n)]
+    return [
+        [float(raw[r][c]) / col_sums[c] if col_sums[c] > 0 else 0.0 for c in range(cols_n)]
+        for r in range(rows_n)
+    ]
+
+
+@app.get("/api/analysis/temporal")
+def get_analysis_temporal(
+    db: Session = Depends(get_session),
+    calendar_from: Optional[date] = Query(None, alias="calendar_from"),
+    calendar_to: Optional[date] = Query(None, alias="calendar_to"),
+):
+    today = date.today()
+    if calendar_from is None and calendar_to is None:
+        cal_from = date(today.year, today.month, 1)
+        cal_to = date(today.year, today.month, monthrange(today.year, today.month)[1])
+    elif calendar_from is None or calendar_to is None:
+        raise HTTPException(
+            status_code=400,
+            detail="calendar_from and calendar_to must both be set, or both omitted (defaults to current month).",
+        )
+    else:
+        cal_from = calendar_from
+        cal_to = calendar_to
+    if cal_from > cal_to:
+        raise HTTPException(status_code=400, detail="calendar_from must be <= calendar_to")
+
+    by_hour = [{"hour": h, "count": 0} for h in range(24)]
+    by_weekday = [{"weekday": w, "count": 0} for w in range(7)]
+    tutor_usage_by_day: list = []
+    timezone_note = (
+        "Timestamps come from PostgreSQL `events.created_at` (typically UTC). "
+        "Hour, weekday, and daily counts use the database session time zone for `DATE` / `EXTRACT`."
+    )
+    tutor_usage_error: Optional[str] = None
+
+    try:
+        with ext_engine.connect() as conn:
+            hour_rows = conn.execute(
+                text("""
+                    SELECT EXTRACT(HOUR FROM created_at)::int AS hour, COUNT(*)::bigint AS cnt
+                    FROM events
+                    WHERE event_type = 'tutor_query'
+                    GROUP BY 1
+                """)
+            ).mappings().all()
+            for r in hour_rows:
+                h = int(r["hour"])
+                if 0 <= h <= 23:
+                    by_hour[h]["count"] = int(r["cnt"])
+
+            dow_rows = conn.execute(
+                text("""
+                    SELECT EXTRACT(DOW FROM created_at)::int AS weekday, COUNT(*)::bigint AS cnt
+                    FROM events
+                    WHERE event_type = 'tutor_query'
+                    GROUP BY 1
+                """)
+            ).mappings().all()
+            for r in dow_rows:
+                w = int(r["weekday"])
+                if 0 <= w <= 6:
+                    by_weekday[w]["count"] = int(r["cnt"])
+
+            tutor_daily_rows = conn.execute(
+                text("""
+                    SELECT created_at::date AS d, COUNT(*)::bigint AS cnt
+                    FROM events
+                    WHERE event_type = 'tutor_query'
+                      AND created_at::date >= :d0
+                      AND created_at::date <= :d1
+                    GROUP BY 1
+                """),
+                {"d0": cal_from, "d1": cal_to},
+            ).mappings().all()
+            day_counts: dict[str, int] = {}
+            for r in tutor_daily_rows:
+                d = r["d"]
+                dk = d.isoformat() if hasattr(d, "isoformat") else str(d)
+                day_counts[dk] = int(r["cnt"])
+            cur = cal_from
+            while cur <= cal_to:
+                ds = cur.isoformat()
+                tutor_usage_by_day.append({"date": ds, "count": day_counts.get(ds, 0)})
+                cur += timedelta(days=1)
+    except Exception as e:
+        logger.warning("tutor_usage aggregates skipped: %s", e)
+        tutor_usage_error = str(e)[:300]
+        tutor_usage_by_day = []
+
+    labels_list: list[str] = []
+    notebooks_list: list[str] = []
+    raw_matrix: list[list[int]] = []
+    row_norm: list[list[float]] = []
+    col_norm: list[list[float]] = []
+
+    try:
+        with ext_engine.connect() as conn:
+            nb_rows = conn.execute(
+                text("""
+                    SELECT MIN(id) AS chatlog_id, MAX(payload->>'notebook') AS notebook
+                    FROM events
+                    WHERE event_type IN ('tutor_query', 'tutor_response')
+                      AND payload->>'conversation_id' IS NOT NULL
+                    GROUP BY payload->>'conversation_id'
+                """)
+            ).mappings().all()
+            chatlog_notebook: dict[int, str] = {}
+            for r in nb_rows:
+                cid = int(r["chatlog_id"])
+                nb = r["notebook"] if r["notebook"] else "unknown"
+                chatlog_notebook[cid] = nb
+
+            pair_counts: dict = defaultdict(lambda: defaultdict(int))
+            label_names_seen: set = set()
+            notebook_names_seen: set = set()
+            for lbl_name, chatlog_id in db.exec(
+                select(LabelDefinition.name, LabelApplication.chatlog_id)
+                .select_from(LabelApplication)
+                .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+            ).all():
+                nb_key = chatlog_notebook.get(int(chatlog_id), "unknown")
+                pair_counts[nb_key][lbl_name] += 1
+                label_names_seen.add(lbl_name)
+                notebook_names_seen.add(nb_key)
+
+            labels_list = sorted(label_names_seen)
+            notebooks_list = sorted(notebook_names_seen)
+            raw_matrix = [
+                [int(pair_counts[nb].get(lbl, 0)) for lbl in labels_list] for nb in notebooks_list
+            ]
+            raw_float = [[float(x) for x in row] for row in raw_matrix]
+            row_norm = _normalize_heatmap_rows(raw_float)
+            col_norm = _normalize_heatmap_columns(raw_float)
+    except Exception:
+        labels_list = []
+        notebooks_list = []
+        raw_matrix = []
+        row_norm = []
+        col_norm = []
+
+    daily: dict = defaultdict(lambda: {"human": 0, "ai": 0})
+    for row in db.exec(
+        select(
+            func.date(LabelApplication.created_at),
+            LabelApplication.applied_by,
+            func.count(LabelApplication.id),
+        )
+        .select_from(LabelApplication)
+        .group_by(func.date(LabelApplication.created_at), LabelApplication.applied_by)
+    ).all():
+        d_raw, applied_by, cnt = row
+        if d_raw is None:
+            continue
+        ds = d_raw.isoformat() if hasattr(d_raw, "isoformat") else str(d_raw)
+        if applied_by == "human":
+            daily[ds]["human"] += int(cnt)
+        elif applied_by == "ai":
+            daily[ds]["ai"] += int(cnt)
+
+    labeling_throughput: list = []
+    if daily:
+        dates_sorted = sorted(daily.keys())
+        d0 = date.fromisoformat(dates_sorted[0])
+        d1 = date.fromisoformat(dates_sorted[-1])
+        cur = d0
+        while cur <= d1:
+            ds = cur.isoformat()
+            h = daily[ds]["human"]
+            a = daily[ds]["ai"]
+            labeling_throughput.append({"date": ds, "human": h, "ai": a, "total": h + a})
+            cur += timedelta(days=1)
+
+    return {
+        "tutor_usage": {
+            "by_hour": by_hour,
+            "by_weekday": by_weekday,
+            "by_day": tutor_usage_by_day,
+            "timezone_note": timezone_note,
+            "error": tutor_usage_error,
+        },
+        "notebook_label_heatmap": {
+            "labels": labels_list,
+            "notebooks": notebooks_list,
+            "raw_counts": raw_matrix,
+            "row_normalized": row_norm,
+            "column_normalized": col_norm,
+        },
+        "labeling_throughput": labeling_throughput,
     }
 
 
 @app.get("/api/export/csv")
-def export_csv():
+def export_csv(db: Session = Depends(get_session)):
+    rows = db.exec(
+        select(
+            LabelApplication.chatlog_id,
+            LabelApplication.message_index,
+            LabelDefinition.name,
+            LabelApplication.applied_by,
+            LabelApplication.created_at,
+        )
+        .select_from(LabelApplication)
+        .join(LabelDefinition, LabelDefinition.id == LabelApplication.label_id)
+        .order_by(
+            LabelApplication.chatlog_id,
+            LabelApplication.message_index,
+            LabelApplication.id,
+        )
+    ).all()
+
+    keys = {(r[0], r[1]) for r in rows}
+    text_by_key: dict = {}
+    if keys:
+        for mc in db.exec(select(MessageCache)).all():
+            k = (mc.chatlog_id, mc.message_index)
+            if k in keys:
+                text_by_key[k] = mc.message_text or ""
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        ["chatlog_id", "message_index", "message_text", "label_name", "applied_by", "created_at"]
+    )
+    for chatlog_id, message_index, label_name, applied_by, created_at in rows:
+        msg_text = text_by_key.get((chatlog_id, message_index), "")
+        writer.writerow(
+            [
+                chatlog_id,
+                message_index,
+                msg_text,
+                label_name,
+                applied_by,
+                created_at.isoformat() if hasattr(created_at, "isoformat") else str(created_at),
+            ]
+        )
+
     return Response(
-        content="chatlog_id,message_index,label,applied_by\n",
-        media_type="text/csv",
-        headers={"Content-Disposition": "attachment; filename=labels.csv"},
+        content=buf.getvalue(),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": "attachment; filename=chatsight-labels.csv"},
     )
 
 

--- a/server/python/tests/test_analysis.py
+++ b/server/python/tests/test_analysis.py
@@ -1,0 +1,99 @@
+# server/python/tests/test_analysis.py
+import csv
+import io
+from models import LabelDefinition, LabelApplication
+
+
+def _seed(session):
+    """Insert sample labels and applications for testing."""
+    lbl_concept = LabelDefinition(name="Concept Question")
+    lbl_debug = LabelDefinition(name="Debug Help")
+    session.add(lbl_concept)
+    session.add(lbl_debug)
+    session.commit()
+    session.refresh(lbl_concept)
+    session.refresh(lbl_debug)
+
+    apps = [
+        LabelApplication(label_id=lbl_concept.id, chatlog_id=1, message_index=0, applied_by="human"),
+        LabelApplication(label_id=lbl_concept.id, chatlog_id=1, message_index=1, applied_by="human"),
+        LabelApplication(label_id=lbl_concept.id, chatlog_id=2, message_index=5, applied_by="ai"),
+        LabelApplication(label_id=lbl_debug.id, chatlog_id=3, message_index=10, applied_by="human"),
+        LabelApplication(label_id=lbl_debug.id, chatlog_id=3, message_index=4, applied_by="ai"),
+    ]
+    for a in apps:
+        session.add(a)
+    session.commit()
+    return lbl_concept, lbl_debug
+
+
+def test_summary_empty(client):
+    r = client.get("/api/analysis/summary")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["label_counts"] == {}
+    assert data["coverage"]["human_labeled"] == 0
+    assert data["coverage"]["ai_labeled"] == 0
+    assert data["position_distribution"] == {}
+
+
+def test_summary_label_counts(client, session):
+    _seed(session)
+    r = client.get("/api/analysis/summary")
+    data = r.json()
+    assert data["label_counts"]["Concept Question"] == 3
+    assert data["label_counts"]["Debug Help"] == 2
+    assert data["human_label_counts"]["Concept Question"] == 2
+    assert data["human_label_counts"]["Debug Help"] == 1
+    assert data["ai_label_counts"]["Concept Question"] == 1
+    assert data["ai_label_counts"]["Debug Help"] == 1
+
+
+def test_summary_coverage(client, session):
+    _seed(session)
+    r = client.get("/api/analysis/summary")
+    data = r.json()
+    assert data["coverage"]["human_labeled"] == 3
+    assert data["coverage"]["ai_labeled"] == 2
+
+
+def test_summary_position_distribution(client, session):
+    _seed(session)
+    r = client.get("/api/analysis/summary")
+    data = r.json()
+    pos = data["position_distribution"]
+    # Concept Question: index 0 (early), 1 (early), 5 (mid)
+    assert pos["Concept Question"]["early"] == 2
+    assert pos["Concept Question"]["mid"] == 1
+    assert pos["Concept Question"]["late"] == 0
+    # Debug Help: index 10 (late), 4 (mid)
+    assert pos["Debug Help"]["early"] == 0
+    assert pos["Debug Help"]["mid"] == 1
+    assert pos["Debug Help"]["late"] == 1
+
+
+def test_export_csv_empty(client):
+    r = client.get("/api/export/csv")
+    assert r.status_code == 200
+    assert "text/csv" in r.headers["content-type"]
+    reader = csv.reader(io.StringIO(r.text))
+    rows = list(reader)
+    assert rows[0] == ["chatlog_id", "message_index", "message_text", "label_name", "applied_by", "created_at"]
+    assert len(rows) == 1
+
+
+def test_export_csv_with_data(client, session):
+    _seed(session)
+    r = client.get("/api/export/csv")
+    assert r.status_code == 200
+    reader = csv.reader(io.StringIO(r.text))
+    rows = list(reader)
+    header = rows[0]
+    assert "chatlog_id" in header
+    assert "label_name" in header
+    assert "applied_by" in header
+    # 5 applications + 1 header row
+    assert len(rows) == 6
+    label_names = {row[header.index("label_name")] for row in rows[1:]}
+    assert "Concept Question" in label_names
+    assert "Debug Help" in label_names

--- a/server/python/tests/test_temporal_analysis.py
+++ b/server/python/tests/test_temporal_analysis.py
@@ -25,6 +25,7 @@ def test_temporal_response_shape(client):
     assert len(data["tutor_usage"]["by_weekday"]) == 7
     assert data["tutor_usage"]["by_weekday"][0]["weekday"] == 0
     assert "timezone_note" in data["tutor_usage"]
+    assert data["tutor_usage"].get("display_timezone")
     assert "by_day" in data["tutor_usage"]
     assert isinstance(data["tutor_usage"]["by_day"], list)
 

--- a/server/python/tests/test_temporal_analysis.py
+++ b/server/python/tests/test_temporal_analysis.py
@@ -1,0 +1,98 @@
+# server/python/tests/test_temporal_analysis.py
+from datetime import datetime
+
+from models import LabelDefinition, LabelApplication
+
+
+def _seed_labels(session):
+    a = LabelDefinition(name="Alpha")
+    b = LabelDefinition(name="Beta")
+    session.add(a)
+    session.add(b)
+    session.commit()
+    session.refresh(a)
+    session.refresh(b)
+    return a, b
+
+
+def test_temporal_response_shape(client):
+    r = client.get("/api/analysis/temporal")
+    assert r.status_code == 200
+    data = r.json()
+    assert "tutor_usage" in data
+    assert len(data["tutor_usage"]["by_hour"]) == 24
+    assert data["tutor_usage"]["by_hour"][0]["hour"] == 0
+    assert len(data["tutor_usage"]["by_weekday"]) == 7
+    assert data["tutor_usage"]["by_weekday"][0]["weekday"] == 0
+    assert "timezone_note" in data["tutor_usage"]
+    assert "by_day" in data["tutor_usage"]
+    assert isinstance(data["tutor_usage"]["by_day"], list)
+
+    hm = data["notebook_label_heatmap"]
+    assert "labels" in hm and "notebooks" in hm
+    assert "raw_counts" in hm and "row_normalized" in hm and "column_normalized" in hm
+
+    assert isinstance(data["labeling_throughput"], list)
+
+
+def test_temporal_throughput_by_day_and_source(client, session):
+    a, b = _seed_labels(session)
+    day = datetime(2026, 4, 10, 15, 30, 0)
+    session.add(
+        LabelApplication(
+            label_id=a.id, chatlog_id=1, message_index=0, applied_by="human", created_at=day
+        )
+    )
+    session.add(
+        LabelApplication(
+            label_id=a.id, chatlog_id=2, message_index=0, applied_by="human", created_at=day
+        )
+    )
+    session.add(
+        LabelApplication(
+            label_id=b.id, chatlog_id=3, message_index=0, applied_by="ai", created_at=day
+        )
+    )
+    session.commit()
+
+    r = client.get("/api/analysis/temporal")
+    data = r.json()
+    row = next(x for x in data["labeling_throughput"] if x["date"] == "2026-04-10")
+    assert row["human"] == 2
+    assert row["ai"] == 1
+    assert row["total"] == 3
+
+
+def test_temporal_throughput_fills_gap_days(client, session):
+    a, _ = _seed_labels(session)
+    session.add(
+        LabelApplication(
+            label_id=a.id,
+            chatlog_id=1,
+            message_index=0,
+            applied_by="human",
+            created_at=datetime(2026, 5, 1, 10, 0, 0),
+        )
+    )
+    session.add(
+        LabelApplication(
+            label_id=a.id,
+            chatlog_id=2,
+            message_index=0,
+            applied_by="human",
+            created_at=datetime(2026, 5, 3, 10, 0, 0),
+        )
+    )
+    session.commit()
+
+    r = client.get("/api/analysis/temporal")
+    data = r.json()
+    dates = [x["date"] for x in data["labeling_throughput"]]
+    assert dates == ["2026-05-01", "2026-05-02", "2026-05-03"]
+    mid = next(x for x in data["labeling_throughput"] if x["date"] == "2026-05-02")
+    assert mid["human"] == 0 and mid["ai"] == 0 and mid["total"] == 0
+
+
+def test_temporal_calendar_params_must_be_paired(client):
+    r = client.get("/api/analysis/temporal?calendar_from=2026-01-01")
+    assert r.status_code == 400

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -96,6 +96,7 @@ export const mockApi = {
         { weekday: 5, count: 40 },
         { weekday: 6, count: 30 },
       ],
+      display_timezone: 'America/Los_Angeles',
       timezone_note: 'Mock data — connect to Postgres for real tutor_query timestamps.',
       error: null,
       by_day: Array.from({ length: 31 }, (_, i) => {

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,5 +1,8 @@
 // src/mocks/index.ts
-import type { LabelDefinition, QueueItem, LabelingSession, SuggestResponse, HistoryItem } from '../types'
+import type {
+  LabelDefinition, QueueItem, LabelingSession, SuggestResponse, HistoryItem, AnalysisSummary,
+  TemporalAnalysis,
+} from '../types'
 
 export const mockApi = {
   queue: [
@@ -39,6 +42,96 @@ export const mockApi = {
   } satisfies SuggestResponse,
 
   queuePosition: { position: 15, total_remaining: 85 },
+
+  analysisSummary: {
+    label_counts: {
+      'Concept Question': 45,
+      Clarification: 28,
+      'Debug Help': 22,
+      'Syntax / API': 12,
+    },
+    human_label_counts: {
+      'Concept Question': 28,
+      Clarification: 19,
+      'Debug Help': 10,
+      'Syntax / API': 4,
+    },
+    ai_label_counts: {
+      'Concept Question': 17,
+      Clarification: 9,
+      'Debug Help': 12,
+      'Syntax / API': 8,
+    },
+    notebook_breakdown: {
+      lab01: { 'Concept Question': 12, Clarification: 8, 'Debug Help': 5 },
+      lab02: { 'Concept Question': 18, Clarification: 11, 'Debug Help': 9, 'Syntax / API': 6 },
+      homework03: { 'Concept Question': 15, Clarification: 9, 'Syntax / API': 6 },
+    },
+    coverage: {
+      human_labeled: 52,
+      ai_labeled: 38,
+      unlabeled: 210,
+      total: 300,
+    },
+    position_distribution: {
+      'Concept Question': { early: 18, mid: 15, late: 12 },
+      Clarification: { early: 10, mid: 12, late: 6 },
+      'Debug Help': { early: 6, mid: 9, late: 7 },
+      'Syntax / API': { early: 8, mid: 3, late: 1 },
+    },
+  } satisfies AnalysisSummary,
+
+  temporalAnalysis: {
+    tutor_usage: {
+      by_hour: Array.from({ length: 24 }, (_, hour) => ({
+        hour,
+        count: hour >= 9 && hour <= 22 ? 12 + (hour % 5) : 2,
+      })),
+      by_weekday: [
+        { weekday: 0, count: 45 },
+        { weekday: 1, count: 120 },
+        { weekday: 2, count: 110 },
+        { weekday: 3, count: 95 },
+        { weekday: 4, count: 88 },
+        { weekday: 5, count: 40 },
+        { weekday: 6, count: 30 },
+      ],
+      timezone_note: 'Mock data — connect to Postgres for real tutor_query timestamps.',
+      error: null,
+      by_day: Array.from({ length: 31 }, (_, i) => {
+        const day = i + 1
+        return {
+          date: `2026-03-${String(day).padStart(2, '0')}`,
+          count: day % 7 === 0 ? 42 + day : day % 3 === 0 ? 15 : 5,
+        }
+      }),
+    },
+    notebook_label_heatmap: {
+      labels: ['Concept Question', 'Clarification', 'Debug Help'],
+      notebooks: ['homework03', 'lab01', 'lab02'],
+      raw_counts: [
+        [10, 8, 4],
+        [12, 6, 5],
+        [18, 11, 9],
+      ],
+      row_normalized: [
+        [0.45, 0.36, 0.18],
+        [0.52, 0.26, 0.22],
+        [0.47, 0.29, 0.24],
+      ],
+      column_normalized: [
+        [0.25, 0.36, 0.39],
+        [0.29, 0.27, 0.44],
+        [0.45, 0.37, 0.18],
+      ],
+    },
+    labeling_throughput: [
+      { date: '2026-03-20', human: 5, ai: 0, total: 5 },
+      { date: '2026-03-21', human: 12, ai: 0, total: 12 },
+      { date: '2026-03-22', human: 8, ai: 15, total: 23 },
+      { date: '2026-03-23', human: 3, ai: 42, total: 45 },
+    ],
+  } satisfies TemporalAnalysis,
 
   history: [
     {

--- a/src/pages/AnalysisPage.tsx
+++ b/src/pages/AnalysisPage.tsx
@@ -3,12 +3,9 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Cell,
   Legend,
   Line,
   LineChart,
-  Pie,
-  PieChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -16,8 +13,6 @@ import {
 } from 'recharts'
 import type { AnalysisSummary, TemporalAnalysis } from '../types'
 import { api } from '../services/api'
-
-const PIE_COLORS = ['#22c55e', '#6366f1', '#737373']
 
 const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
@@ -262,11 +257,15 @@ export function AnalysisPage() {
     .map(([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count)
 
-  const coverageData = [
-    { name: 'Human-labeled', value: summary.coverage.human_labeled },
-    { name: 'AI-labeled', value: summary.coverage.ai_labeled },
-    { name: 'Unlabeled', value: summary.coverage.unlabeled },
-  ]
+  const covTotal = Math.max(1, summary.coverage.total)
+  const covHuman = summary.coverage.human_labeled
+  const covAi = summary.coverage.ai_labeled
+  const covUnlabeled = summary.coverage.unlabeled
+  const pctOfTotal = (n: number) => (n / covTotal) * 100
+  /** Stacked bar: scale if human+AI+unlabeled shares exceed 100% of total (rare overlap). */
+  const rawBarPctSum = pctOfTotal(covHuman) + pctOfTotal(covAi) + pctOfTotal(covUnlabeled)
+  const barScale = rawBarPctSum > 100 ? 100 / rawBarPctSum : 1
+  const barPct = (n: number) => pctOfTotal(n) * barScale
 
   const posData = Object.entries(summary.position_distribution)
     .map(([label, buckets]) => ({
@@ -344,7 +343,7 @@ export function AnalysisPage() {
           </button>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:items-start">
           <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[280px]">
             <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
               <h2 className="text-sm font-medium text-neutral-300">Label Frequency</h2>
@@ -411,30 +410,84 @@ export function AnalysisPage() {
           </section>
 
           <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[280px]">
-            <h2 className="text-sm font-medium text-neutral-300 mb-4">Coverage</h2>
-            <ResponsiveContainer width="100%" height={260}>
-              <PieChart>
-                <Pie
-                  data={coverageData}
-                  dataKey="value"
-                  nameKey="name"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={88}
-                  label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-                >
-                  {coverageData.map((_, i) => (
-                    <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} stroke="#262626" />
-                  ))}
-                </Pie>
-                <Tooltip
-                  contentStyle={{ backgroundColor: '#171717', border: '1px solid #404040', borderRadius: 8 }}
+            <h2 className="text-sm font-medium text-neutral-300 mb-1">Coverage</h2>
+            <p className="text-xs text-neutral-500 mb-4">
+              Share of all student messages in Postgres (<code className="text-neutral-400">tutor_query</code> total).
+              Human vs AI counts are unique messages with at least one label from that source.
+            </p>
+            <div className="space-y-4">
+              <div
+                className="flex h-10 w-full overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900"
+                role="img"
+                aria-label="Coverage stacked bar: human, AI, unlabeled"
+              >
+                <div
+                  className="h-full bg-emerald-500 min-w-0 transition-[width] duration-300"
+                  style={{ width: `${barPct(covHuman)}%` }}
+                  title={`Human-labeled: ${covHuman}`}
                 />
-              </PieChart>
-            </ResponsiveContainer>
+                <div
+                  className="h-full bg-indigo-500 min-w-0 transition-[width] duration-300"
+                  style={{ width: `${barPct(covAi)}%` }}
+                  title={`AI-labeled: ${covAi}`}
+                />
+                <div
+                  className="h-full bg-neutral-600 min-w-0 transition-[width] duration-300"
+                  style={{ width: `${barPct(covUnlabeled)}%` }}
+                  title={`Unlabeled: ${covUnlabeled}`}
+                />
+              </div>
+              <div className="flex flex-wrap gap-4 text-xs text-neutral-400">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 shrink-0 rounded-sm bg-emerald-500" />
+                  Human-labeled
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 shrink-0 rounded-sm bg-indigo-500" />
+                  AI-labeled
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-2 w-2 shrink-0 rounded-sm bg-neutral-600" />
+                  Unlabeled
+                </span>
+              </div>
+              <div className="overflow-hidden rounded-lg border border-neutral-800">
+                <table className="w-full text-xs text-left">
+                  <thead className="bg-neutral-900/80 text-neutral-400">
+                    <tr>
+                      <th className="p-2 font-medium">Category</th>
+                      <th className="p-2 font-medium text-right tabular-nums">Count</th>
+                      <th className="p-2 font-medium text-right tabular-nums">% of total</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-neutral-200">
+                    <tr className="border-t border-neutral-800">
+                      <td className="p-2">Human-labeled</td>
+                      <td className="p-2 text-right tabular-nums">{covHuman.toLocaleString()}</td>
+                      <td className="p-2 text-right tabular-nums">{pctOfTotal(covHuman).toFixed(1)}%</td>
+                    </tr>
+                    <tr className="border-t border-neutral-800">
+                      <td className="p-2">AI-labeled</td>
+                      <td className="p-2 text-right tabular-nums">{covAi.toLocaleString()}</td>
+                      <td className="p-2 text-right tabular-nums">{pctOfTotal(covAi).toFixed(1)}%</td>
+                    </tr>
+                    <tr className="border-t border-neutral-800">
+                      <td className="p-2">Unlabeled</td>
+                      <td className="p-2 text-right tabular-nums">{covUnlabeled.toLocaleString()}</td>
+                      <td className="p-2 text-right tabular-nums">{pctOfTotal(covUnlabeled).toFixed(1)}%</td>
+                    </tr>
+                    <tr className="border-t border-neutral-800 bg-neutral-900/60 font-medium text-neutral-100">
+                      <td className="p-2">Total messages</td>
+                      <td className="p-2 text-right tabular-nums">{summary.coverage.total.toLocaleString()}</td>
+                      <td className="p-2 text-right tabular-nums">100%</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </section>
 
-          <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[300px]">
+          <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[300px] lg:col-span-2">
             <h2 className="text-sm font-medium text-neutral-300 mb-4">Conversation Position</h2>
             {posData.length === 0 ? (
               <p className="text-sm text-neutral-500">No position data yet.</p>
@@ -454,7 +507,7 @@ export function AnalysisPage() {
                     Late (7+)
                   </span>
                 </div>
-                <div className="grid grid-cols-2 gap-3 max-h-[420px] overflow-y-auto pr-1">
+                <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-3 max-h-[480px] overflow-y-auto pr-1">
                   {posData.map((row) => (
                     <div key={row.label} className="rounded-lg border border-neutral-800 bg-neutral-900/60 p-3">
                       <p className="text-xs text-neutral-200 truncate mb-2" title={row.label}>{row.label}</p>

--- a/src/pages/AnalysisPage.tsx
+++ b/src/pages/AnalysisPage.tsx
@@ -1,8 +1,822 @@
-// src/pages/AnalysisPage.tsx
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { AnalysisSummary, TemporalAnalysis } from '../types'
+import { api } from '../services/api'
+
+const PIE_COLORS = ['#22c55e', '#6366f1', '#737373']
+
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+type HeatmapMode = 'raw' | 'row' | 'column'
+type AssignmentKind = 'due' | 'late' | 'release'
+type LabelFreqMode = 'combined' | 'human' | 'ai'
+
+interface AssignmentMilestone {
+  title: string
+  date: string // YYYY-MM-DD
+  kind: AssignmentKind
+  note?: string
+}
+
+/** DSC10 WI26 — due / late / quiz dates from Gradescope (PDT). */
+const ASSIGNMENT_MILESTONES: AssignmentMilestone[] = [
+  { title: 'Lab 0', date: '2026-01-12', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Pretest', date: '2026-01-12', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Grade Report', date: '2026-01-13', kind: 'due', note: 'Due 3:09 PM' },
+  { title: 'Lab 0', date: '2026-01-14', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Pretest', date: '2026-01-14', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Lab 1', date: '2026-01-20', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'HW 1', date: '2026-01-21', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Quiz 1 (A/B)', date: '2026-01-23', kind: 'release', note: 'In-class' },
+  { title: 'HW 1', date: '2026-01-23', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Lab 2', date: '2026-01-26', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'HW 2', date: '2026-01-28', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Lab 2', date: '2026-01-28', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'HW 2', date: '2026-01-30', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Lab 3', date: '2026-02-02', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'HW 3', date: '2026-02-04', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Lab 3', date: '2026-02-04', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'HW 3', date: '2026-02-06', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Quiz 2 (A/B/C)', date: '2026-02-06', kind: 'release', note: 'In-class' },
+  { title: 'Research Assessment 1 (pre-test)', date: '2026-02-10', kind: 'due', note: 'Due (Gradescope)' },
+  { title: 'Midterm Exam (A/B)', date: '2026-02-11', kind: 'release', note: 'In-class' },
+  { title: 'Midterm Project', date: '2026-02-13', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Lab 4', date: '2026-02-17', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Midterm Project', date: '2026-02-17', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'HW 4', date: '2026-02-18', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Lab 4', date: '2026-02-19', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'HW 4', date: '2026-02-20', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Lab 5', date: '2026-02-23', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'HW 5', date: '2026-02-25', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Lab 5', date: '2026-02-25', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Quiz 3 (A/B/C)', date: '2026-02-27', kind: 'release', note: 'In-class' },
+  { title: 'HW 5', date: '2026-02-27', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Lab 6', date: '2026-03-02', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Lab 6', date: '2026-03-04', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'HW 6', date: '2026-03-05', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Quiz 4 (A/B/C)', date: '2026-03-06', kind: 'release', note: 'In-class' },
+  { title: 'HW 6', date: '2026-03-07', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Lab 7', date: '2026-03-09', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'SETs', date: '2026-03-10', kind: 'release', note: 'Opens 12:00 PM' },
+  { title: 'Lab 7', date: '2026-03-11', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Final Project', date: '2026-03-12', kind: 'due', note: 'Due 11:59 PM' },
+  { title: 'Research Assessment 2 (post-test)', date: '2026-03-13', kind: 'due', note: 'Due (Gradescope)' },
+  { title: 'Final Project', date: '2026-03-14', kind: 'late', note: 'Late 11:59 PM' },
+  { title: 'Final Exam', date: '2026-03-14', kind: 'due', note: 'Gradescope' },
+  { title: 'SETs', date: '2026-03-14', kind: 'due', note: 'Due 8:00 AM' },
+]
+
+function monthRangeISO(d: Date): { from: string; to: string } {
+  const y = d.getFullYear()
+  const m = d.getMonth()
+  const last = new Date(y, m + 1, 0).getDate()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return { from: `${y}-${pad(m + 1)}-01`, to: `${y}-${pad(m + 1)}-${pad(last)}` }
+}
+
+function addCalendarMonth(d: Date, delta: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + delta, 1)
+}
+
 export function AnalysisPage() {
+  const [summary, setSummary] = useState<AnalysisSummary | null>(null)
+  const [temporal, setTemporal] = useState<TemporalAnalysis | null>(null)
+  const [temporalError, setTemporalError] = useState<string | null>(null)
+  const [temporalLoading, setTemporalLoading] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [heatmapMode, setHeatmapMode] = useState<HeatmapMode>('row')
+  const [labelFreqMode, setLabelFreqMode] = useState<LabelFreqMode>('combined')
+  const [calMonth, setCalMonth] = useState(() => {
+    const n = new Date()
+    return new Date(n.getFullYear(), n.getMonth(), 1)
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    api
+      .getAnalysisSummary()
+      .then((s) => {
+        if (!cancelled) setSummary(s)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setTemporalLoading(true)
+    setTemporalError(null)
+    const { from, to } = monthRangeISO(calMonth)
+    api
+      .getTemporalAnalysis({ calendarFrom: from, calendarTo: to })
+      .then((t) => {
+        if (!cancelled) {
+          setTemporal(t)
+          setTemporalError(null)
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setTemporal(null)
+          setTemporalError(e instanceof Error ? e.message : String(e))
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setTemporalLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [calMonth])
+
+  const byDayMap = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const row of temporal?.tutor_usage.by_day ?? []) {
+      m.set(row.date, Number(row.count ?? 0))
+    }
+    return m
+  }, [temporal])
+
+  const assignmentByDay = useMemo(() => {
+    const m = new Map<string, AssignmentMilestone[]>()
+    for (const item of ASSIGNMENT_MILESTONES) {
+      const arr = m.get(item.date) ?? []
+      arr.push(item)
+      m.set(item.date, arr)
+    }
+    return m
+  }, [])
+
+  const calendarCells = useMemo(() => {
+    const y = calMonth.getFullYear()
+    const m = calMonth.getMonth()
+    const last = new Date(y, m + 1, 0).getDate()
+    const firstWd = new Date(y, m, 1).getDay()
+    const cells: {
+      key: string; day: number | null; dateStr: string | null; count: number; milestones: AssignmentMilestone[]
+    }[] = []
+    for (let i = 0; i < firstWd; i++) {
+      cells.push({ key: `pad-${i}`, day: null, dateStr: null, count: 0, milestones: [] })
+    }
+    const p2 = (n: number) => String(n).padStart(2, '0')
+    for (let d = 1; d <= last; d++) {
+      const ds = `${y}-${p2(m + 1)}-${p2(d)}`
+      cells.push({
+        key: ds,
+        day: d,
+        dateStr: ds,
+        count: byDayMap.get(ds) ?? 0,
+        milestones: assignmentByDay.get(ds) ?? [],
+      })
+    }
+    return cells
+  }, [calMonth, byDayMap, assignmentByDay])
+
+  const maxDayCount = useMemo(() => {
+    const rows = temporal?.tutor_usage.by_day ?? []
+    if (!rows.length) return 1
+    return Math.max(1, ...rows.map((r) => Number(r.count ?? 0)))
+  }, [temporal])
+
+  function dayCellBg(count: number): string {
+    const t = maxDayCount > 0 ? count / maxDayCount : 0
+    return `rgba(56, 189, 248, ${0.08 + t * 0.82})`
+  }
+
+  function milestoneKindColor(kind: AssignmentKind): string {
+    if (kind === 'due') return 'bg-rose-400'
+    if (kind === 'late') return 'bg-amber-400'
+    return 'bg-cyan-400'
+  }
+
+  function milestoneKindLabel(kind: AssignmentKind): string {
+    if (kind === 'due') return 'Due'
+    if (kind === 'late') return 'Late'
+    return 'Release'
+  }
+
+  async function handleExport() {
+    try {
+      const blob = await api.exportCsv()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'chatsight-labels.csv'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-neutral-400 text-sm">
+        Loading analysis…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-red-400 text-sm px-4 text-center">
+        {error}
+      </div>
+    )
+  }
+
+  if (!summary) return null
+
+  const selectedLabelCounts =
+    labelFreqMode === 'human'
+      ? summary.human_label_counts
+      : labelFreqMode === 'ai'
+        ? summary.ai_label_counts
+        : summary.label_counts
+
+  const freqData = Object.entries(selectedLabelCounts)
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+
+  const coverageData = [
+    { name: 'Human-labeled', value: summary.coverage.human_labeled },
+    { name: 'AI-labeled', value: summary.coverage.ai_labeled },
+    { name: 'Unlabeled', value: summary.coverage.unlabeled },
+  ]
+
+  const posData = Object.entries(summary.position_distribution)
+    .map(([label, buckets]) => ({
+      label,
+      early: buckets.early,
+      mid: buckets.mid,
+      late: buckets.late,
+    }))
+    .sort((a, b) => b.early + b.mid + b.late - (a.early + a.mid + a.late))
+  const posMax = posData.length
+    ? Math.max(...posData.flatMap((d) => [d.early, d.mid, d.late]))
+    : 1
+
+  const hourChartData =
+    temporal?.tutor_usage.by_hour.map((h) => ({
+      label: `${h.hour}:00`,
+      hour: h.hour,
+      count: Number(h.count ?? 0),
+    })) ?? []
+
+  const weekdayChartData =
+    temporal?.tutor_usage.by_weekday.map((w) => ({
+      weekday: WEEKDAY_SHORT[Number(w.weekday)] ?? String(w.weekday),
+      count: Number(w.count ?? 0),
+    })) ?? []
+
+  const tutorUsageErr = temporal?.tutor_usage.error
+  const tutorHourMax = hourChartData.length ? Math.max(...hourChartData.map((d) => d.count)) : 0
+  const tutorWeekdayMax = weekdayChartData.length ? Math.max(...weekdayChartData.map((d) => d.count)) : 0
+  const tutorUsageEmpty = !tutorUsageErr && tutorHourMax === 0 && tutorWeekdayMax === 0
+
+  const throughputData = temporal?.labeling_throughput ?? []
+
+  const hm = temporal?.notebook_label_heatmap
+  let heatmapDisplay: number[][] = []
+  if (hm) {
+    if (heatmapMode === 'raw') {
+      heatmapDisplay = hm.raw_counts.map((row) => row.map((v) => Number(v)))
+    } else if (heatmapMode === 'row') {
+      heatmapDisplay = hm.row_normalized
+    } else {
+      heatmapDisplay = hm.column_normalized
+    }
+  }
+
+  const heatmapMaxRaw = hm
+    ? Math.max(1, ...hm.raw_counts.flatMap((r) => r.map((x) => Number(x))))
+    : 1
+
+  function heatmapCellBg(value: number): string {
+    if (heatmapMode === 'raw') {
+      const t = heatmapMaxRaw > 0 ? value / heatmapMaxRaw : 0
+      return `rgba(96, 165, 250, ${0.12 + t * 0.78})`
+    }
+    const t = Math.max(0, Math.min(1, value))
+    return `rgba(96, 165, 250, ${0.12 + t * 0.78})`
+  }
+
   return (
-    <div className="flex-1 flex items-center justify-center text-neutral-500 text-sm">
-      Analysis — coming soon
+    <div className="flex-1 overflow-auto p-6 bg-neutral-950 text-neutral-100 min-h-0">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold text-neutral-100">Analysis</h1>
+            <p className="text-sm text-neutral-500 mt-1">
+              How student messages are labeled (human vs AI) across notebooks and conversation depth
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleExport}
+            className="px-4 py-2 rounded-lg bg-neutral-800 hover:bg-neutral-700 text-sm text-neutral-100 border border-neutral-700"
+          >
+            Download CSV
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[280px]">
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <h2 className="text-sm font-medium text-neutral-300">Label Frequency</h2>
+              <div className="flex gap-2 text-xs">
+                <button
+                  type="button"
+                  onClick={() => setLabelFreqMode('combined')}
+                  className={`px-2 py-1 rounded border ${
+                    labelFreqMode === 'combined'
+                      ? 'bg-neutral-700 border-neutral-500 text-neutral-100'
+                      : 'bg-neutral-900 border-neutral-700 text-neutral-400 hover:border-neutral-600'
+                  }`}
+                >
+                  Combined
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLabelFreqMode('human')}
+                  className={`px-2 py-1 rounded border ${
+                    labelFreqMode === 'human'
+                      ? 'bg-neutral-700 border-neutral-500 text-neutral-100'
+                      : 'bg-neutral-900 border-neutral-700 text-neutral-400 hover:border-neutral-600'
+                  }`}
+                >
+                  Human only
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLabelFreqMode('ai')}
+                  className={`px-2 py-1 rounded border ${
+                    labelFreqMode === 'ai'
+                      ? 'bg-neutral-700 border-neutral-500 text-neutral-100'
+                      : 'bg-neutral-900 border-neutral-700 text-neutral-400 hover:border-neutral-600'
+                  }`}
+                >
+                  AI only
+                </button>
+              </div>
+            </div>
+            {freqData.length === 0 ? (
+              <p className="text-sm text-neutral-500">
+                No labels for this source yet.
+              </p>
+            ) : (
+              <ResponsiveContainer width="100%" height={Math.max(220, freqData.length * 36)}>
+                <BarChart data={freqData} layout="vertical" margin={{ left: 8, right: 16, top: 8 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#333" horizontal={false} />
+                  <XAxis type="number" stroke="#737373" tick={{ fill: '#a3a3a3', fontSize: 11 }} />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    width={130}
+                    stroke="#737373"
+                    tick={{ fill: '#a3a3a3', fontSize: 11 }}
+                  />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: '#171717', border: '1px solid #404040', borderRadius: 8 }}
+                    labelStyle={{ color: '#e5e5e5' }}
+                  />
+                  <Bar dataKey="count" fill="#60a5fa" radius={[0, 4, 4, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </section>
+
+          <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[280px]">
+            <h2 className="text-sm font-medium text-neutral-300 mb-4">Coverage</h2>
+            <ResponsiveContainer width="100%" height={260}>
+              <PieChart>
+                <Pie
+                  data={coverageData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={88}
+                  label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                >
+                  {coverageData.map((_, i) => (
+                    <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} stroke="#262626" />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{ backgroundColor: '#171717', border: '1px solid #404040', borderRadius: 8 }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </section>
+
+          <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[300px]">
+            <h2 className="text-sm font-medium text-neutral-300 mb-4">Conversation Position</h2>
+            {posData.length === 0 ? (
+              <p className="text-sm text-neutral-500">No position data yet.</p>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-4 text-xs text-neutral-400">
+                  <span className="inline-flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-sm bg-emerald-400" />
+                    Early (0–2)
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-sm bg-sky-400" />
+                    Mid (3–6)
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <span className="h-2 w-2 rounded-sm bg-violet-400" />
+                    Late (7+)
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-3 max-h-[420px] overflow-y-auto pr-1">
+                  {posData.map((row) => (
+                    <div key={row.label} className="rounded-lg border border-neutral-800 bg-neutral-900/60 p-3">
+                      <p className="text-xs text-neutral-200 truncate mb-2" title={row.label}>{row.label}</p>
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-2">
+                          <span className="w-12 text-[10px] text-neutral-400">Early</span>
+                          <div className="flex-1 h-2 rounded bg-neutral-800 overflow-hidden">
+                            <div className="h-full bg-emerald-400" style={{ width: `${(row.early / posMax) * 100}%` }} />
+                          </div>
+                          <span className="w-7 text-right text-[10px] text-neutral-300 tabular-nums">{row.early}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="w-12 text-[10px] text-neutral-400">Mid</span>
+                          <div className="flex-1 h-2 rounded bg-neutral-800 overflow-hidden">
+                            <div className="h-full bg-sky-400" style={{ width: `${(row.mid / posMax) * 100}%` }} />
+                          </div>
+                          <span className="w-7 text-right text-[10px] text-neutral-300 tabular-nums">{row.mid}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="w-12 text-[10px] text-neutral-400">Late</span>
+                          <div className="flex-1 h-2 rounded bg-neutral-800 overflow-hidden">
+                            <div className="h-full bg-violet-400" style={{ width: `${(row.late / posMax) * 100}%` }} />
+                          </div>
+                          <span className="w-7 text-right text-[10px] text-neutral-300 tabular-nums">{row.late}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+
+        <div className="border-t border-neutral-800 pt-8 space-y-6">
+          <div>
+            <h2 className="text-lg font-medium text-neutral-200">Temporal &amp; usage context</h2>
+            {temporal && (
+              <p className="text-xs text-neutral-500 mt-1 max-w-3xl">{temporal.tutor_usage.timezone_note}</p>
+            )}
+            {temporalError && (
+              <p className="text-sm text-amber-500/90 mt-2">
+                Temporal charts unavailable: {temporalError}
+              </p>
+            )}
+            {temporalLoading && !temporal && (
+              <p className="text-sm text-neutral-500 mt-2">Loading temporal analysis…</p>
+            )}
+          </div>
+
+          {temporal && (
+            <>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[260px]">
+                  <h3 className="text-sm font-medium text-neutral-300 mb-4">Tutor usage (hour of day)</h3>
+                  <p className="text-xs text-neutral-500 mb-2">
+                    Aggregate student messages (<code className="text-neutral-400">tutor_query</code>) from
+                    Postgres.
+                  </p>
+                  {tutorUsageErr ? (
+                    <p className="text-sm text-amber-500/90">{tutorUsageErr}</p>
+                  ) : tutorUsageEmpty ? (
+                    <p className="text-sm text-neutral-500">
+                      No <code className="text-neutral-400">tutor_query</code> rows found — charts stay empty when
+                      every hour is zero. Check port-forward and that the external DB has student messages.
+                    </p>
+                  ) : (
+                    <ResponsiveContainer width="100%" height={220}>
+                      <BarChart data={hourChartData} margin={{ top: 8, right: 8, left: 4, bottom: 8 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#333" vertical={false} />
+                        <XAxis
+                          dataKey="label"
+                          stroke="#737373"
+                          tick={{ fill: '#a3a3a3', fontSize: 9 }}
+                          interval={2}
+                        />
+                        <YAxis
+                          stroke="#737373"
+                          tick={{ fill: '#a3a3a3', fontSize: 11 }}
+                          domain={[0, (dataMax: number) => (dataMax > 0 ? Math.ceil(dataMax * 1.1) : 1)]}
+                          allowDecimals={false}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: '#171717',
+                            border: '1px solid #404040',
+                            borderRadius: 8,
+                          }}
+                        />
+                        <Bar
+                          dataKey="count"
+                          fill="#38bdf8"
+                          background={false}
+                          isAnimationActive={false}
+                          radius={[0, 0, 0, 0]}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </section>
+
+                <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[260px]">
+                  <h3 className="text-sm font-medium text-neutral-300 mb-4">Tutor usage (day of week)</h3>
+                  <p className="text-xs text-neutral-500 mb-2">0 = Sunday … 6 = Saturday (Postgres DOW).</p>
+                  {tutorUsageErr ? (
+                    <p className="text-sm text-amber-500/90">{tutorUsageErr}</p>
+                  ) : tutorUsageEmpty ? (
+                    <p className="text-sm text-neutral-500">
+                      Same data as the hour chart — when all counts are zero, bars have no height (nothing to see).
+                    </p>
+                  ) : (
+                    <ResponsiveContainer width="100%" height={220}>
+                      <BarChart data={weekdayChartData} margin={{ top: 8, right: 8, left: 4, bottom: 8 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#333" vertical={false} />
+                        <XAxis dataKey="weekday" stroke="#737373" tick={{ fill: '#a3a3a3', fontSize: 11 }} />
+                        <YAxis
+                          stroke="#737373"
+                          tick={{ fill: '#a3a3a3', fontSize: 11 }}
+                          domain={[0, (dataMax: number) => (dataMax > 0 ? Math.ceil(dataMax * 1.1) : 1)]}
+                          allowDecimals={false}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: '#171717',
+                            border: '1px solid #404040',
+                            borderRadius: 8,
+                          }}
+                        />
+                        <Bar
+                          dataKey="count"
+                          fill="#a78bfa"
+                          background={false}
+                          isAnimationActive={false}
+                          radius={[0, 0, 0, 0]}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </section>
+              </div>
+
+              <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+                  <h3 className="text-sm font-medium text-neutral-300">Tutor usage (calendar)</h3>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      aria-label="Previous month"
+                      onClick={() => setCalMonth((d) => addCalendarMonth(d, -1))}
+                      className="px-2 py-1 rounded border border-neutral-700 bg-neutral-900 text-neutral-300 text-xs hover:bg-neutral-800"
+                    >
+                      ←
+                    </button>
+                    <span className="text-sm text-neutral-200 min-w-[11rem] text-center tabular-nums">
+                      {calMonth.toLocaleString('en-US', { month: 'long', year: 'numeric' })}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label="Next month"
+                      onClick={() => setCalMonth((d) => addCalendarMonth(d, 1))}
+                      className="px-2 py-1 rounded border border-neutral-700 bg-neutral-900 text-neutral-300 text-xs hover:bg-neutral-800"
+                    >
+                      →
+                    </button>
+                  </div>
+                </div>
+                <p className="text-xs text-neutral-500 mb-3">
+                  Daily <code className="text-neutral-400">tutor_query</code> counts for the visible month (from
+                  Postgres). Darker = more messages. Hover a date for tutor volume and assignment details.
+                </p>
+                {tutorUsageErr ? (
+                  <p className="text-sm text-amber-500/90">{tutorUsageErr}</p>
+                ) : temporalLoading ? (
+                  <p className="text-sm text-neutral-500">Updating calendar…</p>
+                ) : (
+                  <>
+                    <div className="grid grid-cols-7 gap-1 text-center text-[10px] uppercase tracking-wide text-neutral-500 mb-1">
+                      {WEEKDAY_SHORT.map((d) => (
+                        <div key={d}>{d}</div>
+                      ))}
+                    </div>
+                    <div className="grid grid-cols-7 gap-1 overflow-visible">
+                      {calendarCells.map((cell) =>
+                        cell.day === null ? (
+                          <div key={cell.key} className="min-h-[44px]" />
+                        ) : (
+                          <div
+                            key={cell.key}
+                            className="group relative min-h-[44px] rounded border border-neutral-700/80 flex flex-col items-center justify-center gap-0.5 px-0.5 py-1 text-neutral-100"
+                            style={{ backgroundColor: dayCellBg(cell.count) }}
+                            aria-label={`${cell.dateStr}: ${cell.count} tutor messages${
+                              cell.milestones.length ? `; ${cell.milestones.length} assignment event(s)` : ''
+                            }`}
+                          >
+                            <span className="text-[10px] text-neutral-400 leading-none">{cell.day}</span>
+                            <span className="text-[11px] font-medium tabular-nums leading-none">{cell.count}</span>
+                            {cell.milestones.length > 0 && (
+                              <div className="flex items-center gap-0.5">
+                                {cell.milestones.slice(0, 3).map((m, i) => (
+                                  <span
+                                    key={`${cell.key}-${m.title}-${i}`}
+                                    className={`h-1.5 w-1.5 rounded-full ${milestoneKindColor(m.kind)}`}
+                                  />
+                                ))}
+                                {cell.milestones.length > 3 && (
+                                  <span className="text-[9px] text-neutral-300 leading-none">+{cell.milestones.length - 3}</span>
+                                )}
+                              </div>
+                            )}
+                            <div
+                              className="pointer-events-none absolute left-1/2 z-50 w-[min(16rem,calc(100vw-2rem))] -translate-x-1/2 rounded-lg border border-neutral-600 bg-neutral-950 px-2.5 py-2 text-left text-[10px] leading-snug text-neutral-200 shadow-xl opacity-0 shadow-black/40 transition-opacity duration-150 group-hover:opacity-100"
+                              style={{ bottom: 'calc(100% + 6px)' }}
+                              role="tooltip"
+                            >
+                              <div className="font-medium text-neutral-100">{cell.dateStr}</div>
+                              <div className="text-neutral-400">{cell.count} tutor messages</div>
+                              {cell.milestones.length > 0 ? (
+                                <ul className="mt-1.5 max-h-40 space-y-1 overflow-y-auto border-t border-neutral-800 pt-1.5">
+                                  {cell.milestones.map((m, i) => (
+                                    <li key={`${cell.key}-tip-${m.title}-${i}`} className="flex gap-1.5">
+                                      <span
+                                        className={`mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full ${milestoneKindColor(m.kind)}`}
+                                      />
+                                      <span>
+                                        <span className="text-neutral-500">{milestoneKindLabel(m.kind)}:</span>{' '}
+                                        {m.title}
+                                        {m.note ? <span className="text-neutral-500"> — {m.note}</span> : null}
+                                      </span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : (
+                                <p className="mt-1.5 border-t border-neutral-800 pt-1.5 text-neutral-500">
+                                  No assignment milestones on this date.
+                                </p>
+                              )}
+                              <div className="pointer-events-none absolute left-1/2 top-full h-0 w-0 -translate-x-1/2 border-x-[6px] border-t-[6px] border-x-transparent border-t-neutral-600" />
+                            </div>
+                          </div>
+                        ),
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-4 mt-3 text-[11px] text-neutral-400">
+                      <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-rose-400" />Due</span>
+                      <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-amber-400" />Late due</span>
+                      <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-cyan-400" />Release / posted</span>
+                    </div>
+                  </>
+                )}
+              </section>
+
+              <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                  <h3 className="text-sm font-medium text-neutral-300">Notebook × label heatmap</h3>
+                  <div className="flex gap-2 text-xs">
+                    {(['raw', 'row', 'column'] as const).map((m) => (
+                      <button
+                        key={m}
+                        type="button"
+                        onClick={() => setHeatmapMode(m)}
+                        className={`px-2 py-1 rounded border ${
+                          heatmapMode === m
+                            ? 'bg-neutral-700 border-neutral-500 text-neutral-100'
+                            : 'bg-neutral-900 border-neutral-700 text-neutral-400 hover:border-neutral-600'
+                        }`}
+                      >
+                        {m === 'raw' ? 'Raw counts' : m === 'row' ? 'Row %' : 'Column %'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                {!hm || hm.notebooks.length === 0 || hm.labels.length === 0 ? (
+                  <p className="text-sm text-neutral-500">
+                    No notebook × label matrix yet (needs Postgres + labeled applications).
+                  </p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="text-xs border-collapse min-w-[320px]">
+                      <thead>
+                        <tr>
+                          <th className="border border-neutral-700 bg-neutral-800/80 px-2 py-1.5 text-left text-neutral-400 font-medium">
+                            Notebook
+                          </th>
+                          {hm.labels.map((lbl) => (
+                            <th
+                              key={lbl}
+                              className="border border-neutral-700 bg-neutral-800/80 px-2 py-1.5 text-neutral-300 font-medium max-w-[140px]"
+                            >
+                              {lbl}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {hm.notebooks.map((nb, ri) => (
+                          <tr key={nb}>
+                            <td className="border border-neutral-700 bg-neutral-800/40 px-2 py-1.5 text-neutral-300 whitespace-nowrap">
+                              {nb}
+                            </td>
+                            {hm.labels.map((lbl, ci) => {
+                              const rawVal = hm.raw_counts[ri]?.[ci] ?? 0
+                              const disp = heatmapDisplay[ri]?.[ci] ?? 0
+                              const title =
+                                heatmapMode === 'raw'
+                                  ? `${rawVal} applications`
+                                  : `${lbl} · ${nb}: raw ${rawVal}, ${heatmapMode === 'row' ? 'row' : 'column'} fraction ${disp.toFixed(3)}`
+                              return (
+                                <td
+                                  key={lbl}
+                                  className="border border-neutral-700 px-2 py-1.5 text-center text-neutral-200 tabular-nums"
+                                  style={{ backgroundColor: heatmapCellBg(heatmapMode === 'raw' ? rawVal : disp) }}
+                                  title={title}
+                                >
+                                  {heatmapMode === 'raw' ? rawVal : disp.toFixed(2)}
+                                </td>
+                              )
+                            })}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+
+              <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[280px]">
+                <h3 className="text-sm font-medium text-neutral-300 mb-4">Labeling throughput</h3>
+                <p className="text-xs text-neutral-500 mb-2">
+                  SQLite <code className="text-neutral-400">LabelApplication.created_at</code> by day —
+                  human vs AI pipeline volume.
+                </p>
+                {throughputData.length === 0 ? (
+                  <p className="text-sm text-neutral-500">No labels with timestamps yet.</p>
+                ) : (
+                  <ResponsiveContainer width="100%" height={260}>
+                    <LineChart data={throughputData} margin={{ top: 8, right: 8, left: 4, bottom: 8 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                      <XAxis dataKey="date" stroke="#737373" tick={{ fill: '#a3a3a3', fontSize: 10 }} />
+                      <YAxis stroke="#737373" tick={{ fill: '#a3a3a3', fontSize: 11 }} />
+                      <Tooltip
+                        contentStyle={{ backgroundColor: '#171717', border: '1px solid #404040', borderRadius: 8 }}
+                      />
+                      <Legend wrapperStyle={{ fontSize: 11 }} />
+                      <Line type="monotone" dataKey="human" name="Human" stroke="#22c55e" strokeWidth={2} dot={false} />
+                      <Line type="monotone" dataKey="ai" name="AI" stroke="#6366f1" strokeWidth={2} dot={false} />
+                      <Line
+                        type="monotone"
+                        dataKey="total"
+                        name="Total"
+                        stroke="#737373"
+                        strokeWidth={1}
+                        strokeDasharray="4 4"
+                        dot={false}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/pages/AnalysisPage.tsx
+++ b/src/pages/AnalysisPage.tsx
@@ -246,16 +246,43 @@ export function AnalysisPage() {
 
   if (!summary) return null
 
-  const selectedLabelCounts =
-    labelFreqMode === 'human'
-      ? summary.human_label_counts
-      : labelFreqMode === 'ai'
-        ? summary.ai_label_counts
-        : summary.label_counts
+  /** `label` = category (Y-axis). Avoid `name` on rows — it conflicts with Recharts `<Bar name="…">` for stacked series. */
+  let freqData: { label: string; count: number; human: number; ai: number }[]
+  if (labelFreqMode === 'human') {
+    freqData = Object.entries(summary.human_label_counts)
+      .map(([label, count]) => ({
+        label,
+        count: Number(count),
+        human: Number(count),
+        ai: 0,
+      }))
+      .sort((a, b) => b.count - a.count)
+  } else if (labelFreqMode === 'ai') {
+    freqData = Object.entries(summary.ai_label_counts)
+      .map(([label, count]) => ({
+        label,
+        count: Number(count),
+        human: 0,
+        ai: Number(count),
+      }))
+      .sort((a, b) => b.count - a.count)
+  } else {
+    const names = new Set([
+      ...Object.keys(summary.human_label_counts),
+      ...Object.keys(summary.ai_label_counts),
+      ...Object.keys(summary.label_counts),
+    ])
+    freqData = [...names]
+      .map((label) => {
+        const human = Number(summary.human_label_counts[label] ?? 0)
+        const ai = Number(summary.ai_label_counts[label] ?? 0)
+        const count = human + ai
+        return { label, human, ai, count }
+      })
+      .sort((a, b) => b.count - a.count)
+  }
 
-  const freqData = Object.entries(selectedLabelCounts)
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count)
+  const freqChartMax = freqData.length ? Math.max(1, ...freqData.map((d) => d.count)) : 1
 
   const covTotal = Math.max(1, summary.coverage.total)
   const covHuman = summary.coverage.human_labeled
@@ -387,14 +414,89 @@ export function AnalysisPage() {
               <p className="text-sm text-neutral-500">
                 No labels for this source yet.
               </p>
+            ) : labelFreqMode === 'combined' ? (
+              <div className="space-y-2">
+                <p className="text-[10px] text-neutral-500 pl-[138px] pr-12">
+                  Bar length is vs the largest label total (human + AI). Green / indigo split is the mix within that
+                  label.
+                </p>
+                <div
+                  className="max-h-[min(520px,60vh)] overflow-y-auto pr-1 space-y-1.5"
+                  role="list"
+                  aria-label="Label counts by human vs AI"
+                >
+                  {freqData.map((row) => {
+                    const denom = row.count > 0 ? row.count : 1
+                    const wHuman = (row.human / denom) * 100
+                    const wAi = (row.ai / denom) * 100
+                    const lenPct = row.count === 0 ? 0 : Math.max((row.count / freqChartMax) * 100, 1.2)
+                    return (
+                      <div key={row.label} className="flex items-center gap-2 text-xs min-h-[26px]">
+                        <div
+                          className="w-[130px] shrink-0 truncate text-neutral-300 text-right pr-1"
+                          title={row.label}
+                        >
+                          {row.label}
+                        </div>
+                        <div className="flex-1 min-w-0 h-6 rounded-md bg-neutral-800/60 border border-neutral-800/80 relative">
+                          {row.count > 0 && (
+                            <div
+                              className="absolute left-0 top-0 bottom-0 flex rounded overflow-hidden border border-neutral-800 shadow-sm"
+                              style={{
+                                width: `${lenPct}%`,
+                                minWidth: row.count > 0 ? 3 : 0,
+                              }}
+                              title={`${row.label}: human ${row.human}, AI ${row.ai}, total ${row.count} (${lenPct.toFixed(0)}% of max label)`}
+                            >
+                              {row.human > 0 && (
+                                <div
+                                  className="h-full bg-emerald-500 min-w-0 shrink-0"
+                                  style={{ width: `${wHuman}%` }}
+                                  title={`Human: ${row.human}`}
+                                />
+                              )}
+                              {row.ai > 0 && (
+                                <div
+                                  className="h-full bg-indigo-500 min-w-0 shrink-0"
+                                  style={{ width: `${wAi}%` }}
+                                  title={`AI: ${row.ai}`}
+                                />
+                              )}
+                            </div>
+                          )}
+                        </div>
+                        <span className="w-10 shrink-0 text-right tabular-nums text-neutral-400">
+                          {row.count.toLocaleString()}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+                <div className="flex flex-wrap gap-4 pt-1 text-xs text-neutral-500">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2 w-2 shrink-0 rounded-sm bg-emerald-500" />
+                    Human
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2 w-2 shrink-0 rounded-sm bg-indigo-500" />
+                    AI
+                  </span>
+                </div>
+              </div>
             ) : (
               <ResponsiveContainer width="100%" height={Math.max(220, freqData.length * 36)}>
                 <BarChart data={freqData} layout="vertical" margin={{ left: 8, right: 16, top: 8 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#333" horizontal={false} />
-                  <XAxis type="number" stroke="#737373" tick={{ fill: '#a3a3a3', fontSize: 11 }} />
+                  <XAxis
+                    type="number"
+                    domain={[0, freqChartMax]}
+                    allowDecimals={false}
+                    stroke="#737373"
+                    tick={{ fill: '#a3a3a3', fontSize: 11 }}
+                  />
                   <YAxis
                     type="category"
-                    dataKey="name"
+                    dataKey="label"
                     width={130}
                     stroke="#737373"
                     tick={{ fill: '#a3a3a3', fontSize: 11 }}
@@ -403,7 +505,12 @@ export function AnalysisPage() {
                     contentStyle={{ backgroundColor: '#171717', border: '1px solid #404040', borderRadius: 8 }}
                     labelStyle={{ color: '#e5e5e5' }}
                   />
-                  <Bar dataKey="count" fill="#60a5fa" radius={[0, 4, 4, 0]} />
+                  <Bar
+                    dataKey="count"
+                    fill={labelFreqMode === 'human' ? '#22c55e' : '#6366f1'}
+                    radius={[0, 4, 4, 0]}
+                    isAnimationActive={false}
+                  />
                 </BarChart>
               </ResponsiveContainer>
             )}

--- a/src/pages/AnalysisPage.tsx
+++ b/src/pages/AnalysisPage.tsx
@@ -512,7 +512,11 @@ export function AnalysisPage() {
                   <h3 className="text-sm font-medium text-neutral-300 mb-4">Tutor usage (hour of day)</h3>
                   <p className="text-xs text-neutral-500 mb-2">
                     Aggregate student messages (<code className="text-neutral-400">tutor_query</code>) from
-                    Postgres.
+                    Postgres. Hours are local wall clock in{' '}
+                    <code className="text-neutral-400">
+                      {temporal.tutor_usage.display_timezone ?? 'America/Los_Angeles'}
+                    </code>{' '}
+                    (see note above).
                   </p>
                   {tutorUsageErr ? (
                     <p className="text-sm text-amber-500/90">{tutorUsageErr}</p>
@@ -558,7 +562,13 @@ export function AnalysisPage() {
 
                 <section className="rounded-xl border border-neutral-800 bg-neutral-900/50 p-4 min-h-[260px]">
                   <h3 className="text-sm font-medium text-neutral-300 mb-4">Tutor usage (day of week)</h3>
-                  <p className="text-xs text-neutral-500 mb-2">0 = Sunday … 6 = Saturday (Postgres DOW).</p>
+                  <p className="text-xs text-neutral-500 mb-2">
+                    0 = Sunday … 6 = Saturday in{' '}
+                    <code className="text-neutral-400">
+                      {temporal.tutor_usage.display_timezone ?? 'America/Los_Angeles'}
+                    </code>
+                    .
+                  </p>
                   {tutorUsageErr ? (
                     <p className="text-sm text-amber-500/90">{tutorUsageErr}</p>
                   ) : tutorUsageEmpty ? (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import type {
   LabelDefinition, QueueItem, LabelingSession, SuggestResponse,
   QueueStats, ApplyLabelRequest, CreateLabelRequest, UpdateLabelRequest,
   HistoryItem, OrphanedMessagesResponse, ArchiveResponse,
-  ConceptCandidate, EmbedStatus,
+  ConceptCandidate, EmbedStatus, AnalysisSummary, TemporalAnalysis,
 } from '../types'
 import { mockApi } from '../mocks'
 
@@ -145,4 +145,31 @@ export const api = {
   getEmbedStatus: (): Promise<EmbedStatus> =>
     USE_MOCK ? Promise.resolve({ cached: 0, total_unlabeled: 0, running: false })
              : req('/api/concepts/embed-status'),
+
+  getAnalysisSummary: (): Promise<AnalysisSummary> =>
+    USE_MOCK ? Promise.resolve(mockApi.analysisSummary)
+             : req('/api/analysis/summary'),
+
+  getTemporalAnalysis: (opts?: { calendarFrom: string; calendarTo: string }): Promise<TemporalAnalysis> => {
+    if (USE_MOCK) return Promise.resolve(mockApi.temporalAnalysis)
+    const q = new URLSearchParams()
+    if (opts) {
+      q.set('calendar_from', opts.calendarFrom)
+      q.set('calendar_to', opts.calendarTo)
+    }
+    const suffix = q.toString() ? `?${q.toString()}` : ''
+    return req(`/api/analysis/temporal${suffix}`)
+  },
+
+  exportCsv: async (): Promise<Blob> => {
+    if (USE_MOCK) {
+      const header = 'chatlog_id,message_index,message_text,label_name,applied_by,created_at\n'
+      return new Blob([header + '1,0,"Hello",Concept Question,human,2026-01-01T00:00:00\n'], {
+        type: 'text/csv',
+      })
+    }
+    const res = await fetch('/api/export/csv')
+    if (!res.ok) throw new Error(`${res.status} ${await res.text()}`)
+    return res.blob()
+  },
 }

--- a/src/tests/AnalysisPage.test.tsx
+++ b/src/tests/AnalysisPage.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AnalysisPage } from '../pages/AnalysisPage'
+import { api } from '../services/api'
+import { mockApi } from '../mocks'
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 500, height: 300 }}>{children}</div>
+    ),
+  }
+})
+
+vi.mock('../services/api', () => ({
+  api: {
+    getAnalysisSummary: vi.fn(),
+    getTemporalAnalysis: vi.fn(),
+    exportCsv: vi.fn(),
+  },
+}))
+
+const mockedApi = api as {
+  getAnalysisSummary: ReturnType<typeof vi.fn>
+  getTemporalAnalysis: ReturnType<typeof vi.fn>
+  exportCsv: ReturnType<typeof vi.fn>
+}
+
+function renderPage() {
+  return render(<MemoryRouter><AnalysisPage /></MemoryRouter>)
+}
+
+beforeEach(() => {
+  mockedApi.getAnalysisSummary.mockResolvedValue(mockApi.analysisSummary)
+  mockedApi.getTemporalAnalysis.mockResolvedValue(mockApi.temporalAnalysis)
+  mockedApi.exportCsv.mockResolvedValue(new Blob(['test'], { type: 'text/csv' }))
+})
+
+test('shows loading state initially', () => {
+  mockedApi.getAnalysisSummary.mockReturnValue(new Promise(() => {}))
+  mockedApi.getTemporalAnalysis.mockReturnValue(new Promise(() => {}))
+  renderPage()
+  expect(screen.getByText('Loading analysis…')).toBeInTheDocument()
+})
+
+test('renders main chart headings after data loads', async () => {
+  renderPage()
+  await waitFor(() => {
+    expect(screen.getByText('Label Frequency')).toBeInTheDocument()
+  })
+  expect(screen.getByText('Coverage')).toBeInTheDocument()
+  expect(screen.getByText('Conversation Position')).toBeInTheDocument()
+})
+
+test('renders temporal section headings after data loads', async () => {
+  renderPage()
+  await waitFor(() => {
+    expect(screen.getByText('Temporal & usage context')).toBeInTheDocument()
+  })
+  expect(screen.getByText('Tutor usage (hour of day)')).toBeInTheDocument()
+  expect(screen.getByText('Tutor usage (day of week)')).toBeInTheDocument()
+  expect(screen.getByText('Notebook × label heatmap')).toBeInTheDocument()
+  expect(screen.getByText('Labeling throughput')).toBeInTheDocument()
+})
+
+test('renders the CSV export button', async () => {
+  renderPage()
+  await waitFor(() => {
+    expect(screen.getByText('Download CSV')).toBeInTheDocument()
+  })
+})
+
+test('shows error state on API failure', async () => {
+  mockedApi.getAnalysisSummary.mockRejectedValue(new Error('Network error'))
+  renderPage()
+  await waitFor(() => {
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+  })
+})
+
+test('shows summary when temporal fails but summary succeeds', async () => {
+  mockedApi.getTemporalAnalysis.mockRejectedValue(new Error('Temporal unavailable'))
+  renderPage()
+  await waitFor(() => {
+    expect(screen.getByText('Label Frequency')).toBeInTheDocument()
+  })
+  await waitFor(() => {
+    expect(screen.getByText(/Temporal charts unavailable/)).toBeInTheDocument()
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,13 +43,15 @@ export interface AnalysisSummary {
   position_distribution: Record<string, { early: number; mid: number; late: number }>
 }
 
-/** Weekday 0 = Sunday … 6 = Saturday (PostgreSQL DOW). */
+/** Weekday 0 = Sunday … 6 = Saturday in `display_timezone` (same convention as PostgreSQL DOW). */
 export interface TemporalAnalysis {
   tutor_usage: {
     by_hour: Array<{ hour: number; count: number }>
     by_weekday: Array<{ weekday: number; count: number }>
     /** One row per calendar day from `calendar_from` … `calendar_to` (inclusive). */
     by_day: Array<{ date: string; count: number }>
+    /** IANA zone used to bucket tutor_query timestamps (e.g. America/Los_Angeles). */
+    display_timezone?: string
     timezone_note: string
     /** Set when Postgres could not be queried (otherwise null/omitted). */
     error?: string | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,8 @@ export interface SuggestResponse {
 
 export interface AnalysisSummary {
   label_counts: Record<string, number>
+  human_label_counts: Record<string, number>
+  ai_label_counts: Record<string, number>
   notebook_breakdown: Record<string, Record<string, number>>
   coverage: {
     human_labeled: number
@@ -38,6 +40,33 @@ export interface AnalysisSummary {
     unlabeled: number
     total: number
   }
+  position_distribution: Record<string, { early: number; mid: number; late: number }>
+}
+
+/** Weekday 0 = Sunday … 6 = Saturday (PostgreSQL DOW). */
+export interface TemporalAnalysis {
+  tutor_usage: {
+    by_hour: Array<{ hour: number; count: number }>
+    by_weekday: Array<{ weekday: number; count: number }>
+    /** One row per calendar day from `calendar_from` … `calendar_to` (inclusive). */
+    by_day: Array<{ date: string; count: number }>
+    timezone_note: string
+    /** Set when Postgres could not be queried (otherwise null/omitted). */
+    error?: string | null
+  }
+  notebook_label_heatmap: {
+    labels: string[]
+    notebooks: string[]
+    raw_counts: number[][]
+    row_normalized: number[][]
+    column_normalized: number[][]
+  }
+  labeling_throughput: Array<{
+    date: string
+    human: number
+    ai: number
+    total: number
+  }>
 }
 
 export interface QueueStats {


### PR DESCRIPTION
Summary:
- add analysis dashboard with label frequency, coverage, notebook breakdown heatmap, conversation position
- add backend analysis + endpoints and CSV export 
- add frontend and backend tests for functionality
