### PR TITLE
RAG-style concept induction rework

### DIFF
--- a/docs/superpowers/plans/2026-05-01-concept-induction-rag.md
+++ b/docs/superpowers/plans/2026-05-01-concept-induction-rag.md
@@ -1,0 +1,3622 @@
+# Concept Induction RAG Rework — Implementation Plan
+
+> **For agentic workers:** This plan is executed iteratively in the main session per user preference (no subagent dispatch). Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Commit policy:** Claude does NOT run `git commit` or `git add`. Each phase ends with a **STOP** — pause for the user to review the diff and commit themselves. Suggested commit messages are noted at each STOP.
+
+**Goal:** Replace the KMeans-based concept induction feature with a RAG-style discovery pipeline that proposes broad multi-label-friendly categories (Mode A) and surfaces label co-occurrence patterns (Mode B), gated by an on-demand "ripeness" badge.
+
+**Architecture:** Three pure modules — retrieval, generation, orchestration — backed by two SQLModel tables (extended `ConceptCandidate`, new `DiscoveryRun`). KMeans is removed from the discovery path entirely; granularity bias is fixed at retrieval via residual-set max-min diversity selection.
+
+**Tech Stack:** FastAPI + SQLModel + SQLite (backend), React 19 + Vite + TypeScript + Tailwind v4 (frontend), Google `gemini-2.0-flash` (function calling) + `gemini-embedding-001` (embeddings), `pytest` (backend tests), `vitest` + React Testing Library (frontend tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-01-concept-induction-rag-design.md`
+
+---
+
+## Phase 1 — Schema + DB scaffold
+
+### Task 1.1: Add `DiscoveryRun` model
+
+**Files:**
+- Modify: `server/python/models.py` (add new class at end)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_models.py` (create file if missing; if it exists, append):
+
+```python
+from datetime import datetime
+from sqlmodel import Session
+from models import DiscoveryRun
+
+
+def test_discovery_run_can_be_created(db_session: Session):
+    run = DiscoveryRun(
+        query_kind="broad_label",
+        trigger="manual",
+        pool_size_at_trigger=42,
+    )
+    db_session.add(run)
+    db_session.commit()
+    db_session.refresh(run)
+    assert run.id is not None
+    assert run.started_at is not None
+    assert run.completed_at is None
+    assert run.n_candidates == 0
+    assert run.error is None
+    assert run.drift_value_at_trigger is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd server/python && uv run pytest tests/test_models.py::test_discovery_run_can_be_created -v
+```
+Expected: `ImportError: cannot import name 'DiscoveryRun' from 'models'` or similar.
+
+- [ ] **Step 3: Add the model**
+
+Append to `server/python/models.py`:
+
+```python
+class DiscoveryRun(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    completed_at: Optional[datetime] = None
+    query_kind: str  # "broad_label" | "co_occurrence"
+    trigger: str     # "manual" | "badge"
+    drift_value_at_trigger: Optional[float] = None
+    pool_size_at_trigger: int
+    n_candidates: int = 0
+    error: Optional[str] = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd server/python && uv run pytest tests/test_models.py::test_discovery_run_can_be_created -v
+```
+Expected: `1 passed`.
+
+---
+
+### Task 1.2: Extend `ConceptCandidate` with new columns
+
+**Files:**
+- Modify: `server/python/models.py:74-83` (the `ConceptCandidate` class)
+- Modify: `server/python/tests/test_models.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_models.py`:
+
+```python
+from models import ConceptCandidate, DiscoveryRun, LabelDefinition
+
+
+def test_concept_candidate_has_new_fields(db_session: Session):
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=10
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    label = LabelDefinition(name="example")
+    db_session.add(label)
+    db_session.commit()
+
+    cc = ConceptCandidate(
+        name="curiosity",
+        description="student expressing curiosity",
+        example_messages="[]",
+        source_run_id="legacy",
+        kind="broad_label",
+        discovery_run_id=run.id,
+        evidence_message_ids='[{"chatlog_id": 1, "message_index": 0}]',
+        created_label_id=label.id,
+        decision="accept",
+    )
+    db_session.add(cc)
+    db_session.commit()
+    db_session.refresh(cc)
+    assert cc.kind == "broad_label"
+    assert cc.discovery_run_id == run.id
+    assert cc.created_label_id == label.id
+    assert cc.decision == "accept"
+    assert cc.co_occurrence_label_ids is None
+    assert cc.co_occurrence_count is None
+
+
+def test_concept_candidate_legacy_fields_still_work(db_session: Session):
+    cc = ConceptCandidate(
+        name="legacy",
+        description="legacy candidate without new fields",
+        example_messages="[]",
+        source_run_id="oldrun123",
+    )
+    db_session.add(cc)
+    db_session.commit()
+    db_session.refresh(cc)
+    assert cc.kind == "broad_label"  # default
+    assert cc.discovery_run_id is None
+    assert cc.status == "pending"  # legacy column intact
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_models.py::test_concept_candidate_has_new_fields -v
+```
+Expected: `AttributeError` or `TypeError` on `kind`/`discovery_run_id`.
+
+- [ ] **Step 3: Extend the model**
+
+Replace the `ConceptCandidate` class in `server/python/models.py` with:
+
+```python
+class ConceptCandidate(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    description: str
+    example_messages: str  # JSON string (legacy column, retained)
+
+    # Legacy fields — retained for backwards compat with old rows
+    status: str = "pending"  # pending | accepted | rejected (legacy)
+    source_run_id: str       # legacy string-keyed run id
+    similar_to: Optional[str] = Field(default=None)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    # New RAG-discovery fields
+    kind: str = "broad_label"  # "broad_label" | "co_occurrence"
+    discovery_run_id: Optional[int] = Field(
+        default=None, foreign_key="discoveryrun.id"
+    )
+    shown_at: Optional[datetime] = None
+    decided_at: Optional[datetime] = None
+    decision: Optional[str] = None  # accept | reject | dismiss | suggest_merge | note
+    created_label_id: Optional[int] = Field(
+        default=None, foreign_key="labeldefinition.id"
+    )
+    evidence_message_ids: Optional[str] = None  # JSON list of {chatlog_id, message_index}
+    co_occurrence_label_ids: Optional[str] = None  # JSON [int, int]
+    co_occurrence_count: Optional[int] = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_models.py -v
+```
+Expected: all tests pass.
+
+---
+
+### Task 1.3: Add migration for existing SQLite databases
+
+**Files:**
+- Modify: `server/python/main.py` (find the existing startup migration block; if there isn't one yet, add one in the FastAPI lifespan or `@app.on_event("startup")` handler)
+- Test: `server/python/tests/test_migration.py` (new)
+
+The existing `chatsight.db` files in dev environments do not have the new columns; `SQLModel.metadata.create_all` will only add new tables, not new columns to existing tables. Add `ALTER TABLE` statements that no-op when columns already exist.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/python/tests/test_migration.py`:
+
+```python
+import sqlite3
+import pytest
+from migrate import ensure_concept_candidate_columns
+
+
+def test_migration_adds_missing_columns(tmp_path):
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE conceptcandidate (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            description TEXT,
+            example_messages TEXT,
+            status TEXT,
+            source_run_id TEXT,
+            similar_to TEXT,
+            created_at TEXT
+        )
+    """)
+    conn.commit()
+
+    ensure_concept_candidate_columns(conn)
+
+    cols = [row[1] for row in conn.execute("PRAGMA table_info(conceptcandidate)")]
+    for required in [
+        "kind", "discovery_run_id", "shown_at", "decided_at",
+        "decision", "created_label_id", "evidence_message_ids",
+        "co_occurrence_label_ids", "co_occurrence_count",
+    ]:
+        assert required in cols, f"missing column: {required}"
+
+
+def test_migration_is_idempotent(tmp_path):
+    db_path = tmp_path / "fresh.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE conceptcandidate (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            kind TEXT
+        )
+    """)
+    conn.commit()
+    ensure_concept_candidate_columns(conn)
+    ensure_concept_candidate_columns(conn)  # second call must not error
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_migration.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'migrate'`.
+
+- [ ] **Step 3: Create the migration helper**
+
+Create `server/python/migrate.py`:
+
+```python
+"""Idempotent SQLite column-add migrations for schema evolution.
+
+SQLModel.metadata.create_all() creates new tables but never alters
+existing tables. This module adds new columns when they're missing.
+"""
+import sqlite3
+from typing import Iterable
+
+CONCEPT_CANDIDATE_NEW_COLUMNS: list[tuple[str, str]] = [
+    ("kind", "TEXT DEFAULT 'broad_label'"),
+    ("discovery_run_id", "INTEGER"),
+    ("shown_at", "DATETIME"),
+    ("decided_at", "DATETIME"),
+    ("decision", "TEXT"),
+    ("created_label_id", "INTEGER"),
+    ("evidence_message_ids", "TEXT"),
+    ("co_occurrence_label_ids", "TEXT"),
+    ("co_occurrence_count", "INTEGER"),
+]
+
+
+def _existing_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _add_columns_if_missing(
+    conn: sqlite3.Connection, table: str, new_cols: Iterable[tuple[str, str]]
+) -> None:
+    existing = _existing_columns(conn, table)
+    for name, ddl in new_cols:
+        if name not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}")
+    conn.commit()
+
+
+def ensure_concept_candidate_columns(conn: sqlite3.Connection) -> None:
+    _add_columns_if_missing(conn, "conceptcandidate", CONCEPT_CANDIDATE_NEW_COLUMNS)
+
+
+def run_all_migrations(conn: sqlite3.Connection) -> None:
+    """Entry point called at app startup."""
+    ensure_concept_candidate_columns(conn)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_migration.py -v
+```
+Expected: `2 passed`.
+
+- [ ] **Step 5: Wire migration into app startup**
+
+In `server/python/main.py`, find the startup section where `SQLModel.metadata.create_all(engine)` is called. Immediately after it, add:
+
+```python
+import sqlite3
+from migrate import run_all_migrations
+
+# Apply column-level migrations to existing tables
+with sqlite3.connect("chatsight.db") as conn:
+    run_all_migrations(conn)
+```
+
+(Use the same DB path the rest of the file uses; if it's referenced via a constant, use that constant.)
+
+- [ ] **Step 6: Run the full backend test suite**
+
+```bash
+cd server/python && uv run pytest -v
+```
+Expected: all tests pass; no regressions.
+
+---
+
+### STOP — Phase 1 review
+
+Pause for user review and commit. Suggested commit message:
+
+```
+feat: schema for RAG-style concept discovery
+
+Adds DiscoveryRun table and extends ConceptCandidate with
+kind, discovery_run_id, evidence_message_ids, decision,
+created_label_id, and co-occurrence fields. Includes
+idempotent SQLite column-add migration for existing dbs.
+```
+
+---
+
+## Phase 2 — Retrieval module
+
+### Task 2.1: `select_diverse` — max-min farthest-point sampling
+
+**Files:**
+- Create: `server/python/concept_retrieval.py`
+- Test: `server/python/tests/test_concept_retrieval.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/python/tests/test_concept_retrieval.py`:
+
+```python
+import numpy as np
+import pytest
+from concept_retrieval import select_diverse
+
+
+def test_select_diverse_returns_k_indices():
+    rng = np.random.default_rng(0)
+    vectors = rng.normal(size=(20, 8)).astype(np.float32)
+    chosen = select_diverse(vectors, k=5)
+    assert len(chosen) == 5
+    assert len(set(chosen)) == 5  # no duplicates
+    assert all(0 <= i < 20 for i in chosen)
+
+
+def test_select_diverse_picks_far_apart_points():
+    # Three tight clusters; k=3 should pick one from each.
+    centers = np.array([[10.0, 0], [-10.0, 0], [0, 10.0]], dtype=np.float32)
+    points = np.vstack([
+        centers + np.random.RandomState(i).normal(scale=0.01, size=(5, 2))
+        for i in range(3)
+    ]).astype(np.float32)
+    chosen = select_diverse(points, k=3)
+    chosen_pts = points[chosen]
+    # All three picked points should be far from each other (>5 apart)
+    for i in range(3):
+        for j in range(i + 1, 3):
+            d = np.linalg.norm(chosen_pts[i] - chosen_pts[j])
+            assert d > 5, f"chosen points {i} and {j} are too close: {d}"
+
+
+def test_select_diverse_handles_k_geq_n():
+    vectors = np.eye(3, dtype=np.float32)
+    chosen = select_diverse(vectors, k=5)
+    # Cannot select more than n; returns all unique indices.
+    assert sorted(chosen) == [0, 1, 2]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'concept_retrieval'`.
+
+- [ ] **Step 3: Implement `select_diverse`**
+
+Create `server/python/concept_retrieval.py`:
+
+```python
+"""Pure retrieval primitives for concept discovery.
+
+No Gemini calls here except deterministic embeddings.
+No DB writes; only DB reads.
+"""
+from __future__ import annotations
+from typing import Any, Optional, TypedDict
+import json
+import numpy as np
+from sqlmodel import Session, select, func
+
+from models import (
+    LabelApplication,
+    LabelDefinition,
+    MessageCache,
+    MessageEmbedding,
+)
+from concept_service import EMBED_MODEL  # reuse existing constant
+
+
+class Message(TypedDict):
+    chatlog_id: int
+    message_index: int
+    message_text: str
+
+
+class CoOccurrencePair(TypedDict):
+    label_a_id: int
+    label_b_id: int
+    label_a_name: str
+    label_b_name: str
+    count: int
+    example_message_ids: list[dict[str, int]]
+
+
+def select_diverse(vectors: np.ndarray, k: int) -> list[int]:
+    """Greedy max-min farthest-point sampling. No clustering.
+
+    Seed with index 0, then iteratively add the index whose minimum
+    distance to already-selected vectors is the largest. Returns
+    indices in selection order. If k >= len(vectors), returns all
+    indices in selection order.
+    """
+    n = len(vectors)
+    if n == 0:
+        return []
+    k = min(k, n)
+    chosen = [0]
+    # Precompute squared distances from each point to the current set
+    min_dists = np.linalg.norm(vectors - vectors[0], axis=1)
+    while len(chosen) < k:
+        next_idx = int(np.argmax(min_dists))
+        chosen.append(next_idx)
+        new_dists = np.linalg.norm(vectors - vectors[next_idx], axis=1)
+        min_dists = np.minimum(min_dists, new_dists)
+        # Prevent re-selecting same index
+        min_dists[next_idx] = -1.0
+    return chosen
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py -v
+```
+Expected: `3 passed`.
+
+---
+
+### Task 2.2: `thinly_labeled_pool`
+
+**Files:**
+- Modify: `server/python/concept_retrieval.py`
+- Modify: `server/python/tests/test_concept_retrieval.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_retrieval.py`:
+
+```python
+from datetime import datetime
+from sqlmodel import Session
+from models import (
+    MessageCache, LabelDefinition, LabelApplication,
+)
+from concept_retrieval import thinly_labeled_pool
+
+
+def test_thinly_labeled_pool_excludes_human_labeled(db_session: Session):
+    # Two messages: one human-labeled, one with only AI label, one unlabeled.
+    for i, text in enumerate(["a", "b", "c"]):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=text,
+            user_email="u@x", created_at=datetime.utcnow(),
+        ))
+    label = LabelDefinition(name="L1")
+    db_session.add(label)
+    db_session.commit()
+
+    # Message 0: human-applied (excluded)
+    db_session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label.id,
+        applied_by="human", confidence=None,
+    ))
+    # Message 1: AI-applied only (still in pool)
+    db_session.add(LabelApplication(
+        chatlog_id=1, message_index=1, label_id=label.id,
+        applied_by="ai", confidence=0.5,
+    ))
+    db_session.commit()
+
+    pool = thinly_labeled_pool(db_session)
+    keys = {(m["chatlog_id"], m["message_index"]) for m in pool}
+    assert (1, 0) not in keys      # human-labeled — excluded
+    assert (1, 1) in keys          # AI-only — included
+    assert (1, 2) in keys          # unlabeled — included
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py::test_thinly_labeled_pool_excludes_human_labeled -v
+```
+Expected: `ImportError: cannot import name 'thinly_labeled_pool'`.
+
+- [ ] **Step 3: Implement `thinly_labeled_pool`**
+
+Append to `server/python/concept_retrieval.py`:
+
+```python
+def thinly_labeled_pool(db: Session) -> list[Message]:
+    """Mode A corpus: messages with NO human LabelApplications.
+
+    AI-only applications do not count as labeled — discovery's purpose
+    is to find what instructor intent doesn't yet cover.
+    """
+    # Collect (chatlog_id, message_index) keys of messages with human labels
+    human_labeled = set(
+        (chatlog_id, message_index)
+        for chatlog_id, message_index in db.exec(
+            select(LabelApplication.chatlog_id, LabelApplication.message_index)
+            .where(LabelApplication.applied_by == "human")
+            .distinct()
+        ).all()
+    )
+
+    rows = db.exec(
+        select(
+            MessageCache.chatlog_id,
+            MessageCache.message_index,
+            MessageCache.message_text,
+        )
+    ).all()
+
+    return [
+        {
+            "chatlog_id": chatlog_id,
+            "message_index": message_index,
+            "message_text": message_text,
+        }
+        for chatlog_id, message_index, message_text in rows
+        if (chatlog_id, message_index) not in human_labeled
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py::test_thinly_labeled_pool_excludes_human_labeled -v
+```
+Expected: `1 passed`.
+
+---
+
+### Task 2.3: `retrieve_residual` — coverage-targeted retrieval
+
+**Files:**
+- Modify: `server/python/concept_retrieval.py`
+- Modify: `server/python/tests/test_concept_retrieval.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_retrieval.py`:
+
+```python
+from concept_retrieval import retrieve_residual
+
+
+def test_retrieve_residual_filters_high_similarity_messages(db_session, monkeypatch):
+    """Messages whose embedding is close to an existing label are filtered out.
+       Stub the embedding fetch path to return controlled vectors."""
+    # Build 5 cached messages
+    for i in range(5):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"msg{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+    label = LabelDefinition(name="LX", description="thing")
+    db_session.add(label)
+    db_session.commit()
+
+    # Stub: messages 0,1 are very close to label embedding;
+    #       messages 2,3,4 are far. With threshold 0.55,
+    #       residual = {2, 3, 4}.
+    msg_vecs = np.array([
+        [1, 0, 0, 0],   # cos = 1.0 vs label
+        [0.9, 0.1, 0, 0],
+        [0, 1, 0, 0],   # cos = 0 vs label
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+    ], dtype=np.float32)
+    label_vecs = np.array([[1, 0, 0, 0]], dtype=np.float32)
+
+    def fake_embed_messages(messages, db):
+        return msg_vecs[: len(messages)]
+
+    def fake_embed_labels(labels, db):
+        return label_vecs
+
+    monkeypatch.setattr("concept_retrieval._embed_messages", fake_embed_messages)
+    monkeypatch.setattr("concept_retrieval._embed_label_definitions", fake_embed_labels)
+
+    residual = retrieve_residual(db_session, threshold=0.55, target_size=10)
+    keys = sorted((m["chatlog_id"], m["message_index"]) for m in residual)
+    assert keys == [(1, 2), (1, 3), (1, 4)]
+
+
+def test_retrieve_residual_caps_at_target_size(db_session, monkeypatch):
+    for i in range(20):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"msg{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+    db_session.commit()
+
+    msg_vecs = np.eye(20, dtype=np.float32)
+    monkeypatch.setattr("concept_retrieval._embed_messages",
+                        lambda m, db: msg_vecs[: len(m)])
+    # No labels → no label_vecs → all messages pass residual filter
+    monkeypatch.setattr("concept_retrieval._embed_label_definitions",
+                        lambda l, db: np.zeros((0, 20), dtype=np.float32))
+
+    residual = retrieve_residual(db_session, threshold=0.55, target_size=5)
+    assert len(residual) == 5
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py -v -k retrieve_residual
+```
+Expected: import errors.
+
+- [ ] **Step 3: Implement `retrieve_residual`**
+
+Append to `server/python/concept_retrieval.py`:
+
+```python
+def _normalize(vectors: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9
+    return vectors / norms
+
+
+def _embed_messages(messages: list[Message], db: Session) -> np.ndarray:
+    """Wrapper around the existing embed_messages helper.
+
+    Imported lazily to avoid a circular import with concept_service.
+    """
+    from concept_service import embed_messages
+    return embed_messages(messages, db)
+
+
+def _embed_label_definitions(
+    labels: list[LabelDefinition], db: Session
+) -> np.ndarray:
+    """Embed `name: description` strings for each active label.
+
+    These are NOT cached in MessageEmbedding (different content type);
+    we just call the embedding API directly. Cheap because label
+    counts are small.
+    """
+    if not labels:
+        return np.zeros((0, 0), dtype=np.float32)
+    from concept_service import client
+    texts = [
+        f"{l.name}: {l.description or ''}".strip()
+        for l in labels
+    ]
+    result = client.models.embed_content(model=EMBED_MODEL, contents=texts)
+    return np.array([e.values for e in result.embeddings], dtype=np.float32)
+
+
+def retrieve_residual(
+    db: Session,
+    threshold: float = 0.55,
+    target_size: int = 80,
+) -> list[Message]:
+    """Mode A retrieval. Score each pool message by max cosine sim to
+    any active LabelDefinition embedding; keep messages whose max sim
+    is below `threshold`. Run max-min diversity selection on the
+    residual to pick `target_size` messages spanning it.
+    """
+    pool = thinly_labeled_pool(db)
+    if len(pool) == 0:
+        return []
+
+    msg_vecs = _embed_messages(pool, db)
+
+    active_labels = list(
+        db.exec(
+            select(LabelDefinition).where(LabelDefinition.archived_at == None)  # noqa: E711
+        ).all()
+    )
+    label_vecs = _embed_label_definitions(active_labels, db)
+
+    if label_vecs.size == 0:
+        residual_indices = list(range(len(pool)))
+    else:
+        msg_normed = _normalize(msg_vecs)
+        label_normed = _normalize(label_vecs)
+        sim = msg_normed @ label_normed.T  # shape (n_msgs, n_labels)
+        max_sim = sim.max(axis=1)
+        residual_indices = [i for i, s in enumerate(max_sim) if s < threshold]
+
+    if not residual_indices:
+        return []
+
+    residual_vecs = msg_vecs[residual_indices]
+    diverse_local = select_diverse(residual_vecs, k=target_size)
+    chosen = [residual_indices[i] for i in diverse_local]
+    return [pool[i] for i in chosen]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py -v
+```
+Expected: all retrieval tests pass.
+
+---
+
+### Task 2.4: `retrieve_co_occurrence`
+
+**Files:**
+- Modify: `server/python/concept_retrieval.py`
+- Modify: `server/python/tests/test_concept_retrieval.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_retrieval.py`:
+
+```python
+from concept_retrieval import retrieve_co_occurrence
+
+
+def test_retrieve_co_occurrence_finds_frequent_pairs(db_session):
+    # Two labels co-occur on 3 messages; min_count=2 → pair returned.
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    label_c = LabelDefinition(name="C")
+    db_session.add_all([label_a, label_b, label_c])
+    db_session.commit()
+
+    for i in range(3):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"m{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+        db_session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_a.id,
+            applied_by="human",
+        ))
+        db_session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_b.id,
+            applied_by="human",
+        ))
+    # Single C label, no co-occurrence partner above threshold
+    db_session.add(MessageCache(
+        chatlog_id=1, message_index=99, message_text="lonely",
+        user_email="u", created_at=datetime.utcnow(),
+    ))
+    db_session.add(LabelApplication(
+        chatlog_id=1, message_index=99, label_id=label_c.id,
+        applied_by="human",
+    ))
+    db_session.commit()
+
+    pairs = retrieve_co_occurrence(db_session, min_count=2)
+    pair_keys = {tuple(sorted([p["label_a_id"], p["label_b_id"]])): p
+                 for p in pairs}
+    expected_pair = tuple(sorted([label_a.id, label_b.id]))
+    assert expected_pair in pair_keys
+    assert pair_keys[expected_pair]["count"] == 3
+    assert len(pair_keys[expected_pair]["example_message_ids"]) >= 1
+
+
+def test_retrieve_co_occurrence_ignores_ai_labels(db_session):
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    db_session.add_all([label_a, label_b])
+    db_session.commit()
+    db_session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label_a.id,
+        applied_by="ai", confidence=0.7,
+    ))
+    db_session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label_b.id,
+        applied_by="human",
+    ))
+    db_session.commit()
+    pairs = retrieve_co_occurrence(db_session, min_count=1)
+    assert pairs == []  # mixed human+ai pair not counted
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py::test_retrieve_co_occurrence_finds_frequent_pairs tests/test_concept_retrieval.py::test_retrieve_co_occurrence_ignores_ai_labels -v
+```
+Expected: import error.
+
+- [ ] **Step 3: Implement `retrieve_co_occurrence`**
+
+Append to `server/python/concept_retrieval.py`:
+
+```python
+def retrieve_co_occurrence(
+    db: Session, min_count: int = 8,
+) -> list[CoOccurrencePair]:
+    """Mode B retrieval. Find pairs of (human-applied) labels that
+    co-occur on >= min_count messages. Returns pair rows with example
+    message keys.
+    """
+    # Build (chatlog_id, message_index) -> set of human label_ids
+    rows = db.exec(
+        select(
+            LabelApplication.chatlog_id,
+            LabelApplication.message_index,
+            LabelApplication.label_id,
+        ).where(LabelApplication.applied_by == "human")
+    ).all()
+
+    by_msg: dict[tuple[int, int], set[int]] = {}
+    for chatlog_id, message_index, label_id in rows:
+        key = (chatlog_id, message_index)
+        by_msg.setdefault(key, set()).add(label_id)
+
+    # Count unordered pairs
+    pair_counts: dict[tuple[int, int], int] = {}
+    pair_examples: dict[tuple[int, int], list[dict[str, int]]] = {}
+    for msg_key, label_ids in by_msg.items():
+        ids = sorted(label_ids)
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                pk = (ids[i], ids[j])
+                pair_counts[pk] = pair_counts.get(pk, 0) + 1
+                pair_examples.setdefault(pk, []).append(
+                    {"chatlog_id": msg_key[0], "message_index": msg_key[1]}
+                )
+
+    # Pull active label names
+    active = {
+        l.id: l.name
+        for l in db.exec(
+            select(LabelDefinition).where(LabelDefinition.archived_at == None)  # noqa: E711
+        ).all()
+    }
+
+    out: list[CoOccurrencePair] = []
+    for (a_id, b_id), count in pair_counts.items():
+        if count < min_count:
+            continue
+        if a_id not in active or b_id not in active:
+            continue
+        out.append({
+            "label_a_id": a_id,
+            "label_b_id": b_id,
+            "label_a_name": active[a_id],
+            "label_b_name": active[b_id],
+            "count": count,
+            "example_message_ids": pair_examples[(a_id, b_id)][:5],
+        })
+    out.sort(key=lambda p: p["count"], reverse=True)
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_retrieval.py -v
+```
+Expected: all retrieval tests pass.
+
+---
+
+### STOP — Phase 2 review
+
+Pause for user review and commit. Suggested commit message:
+
+```
+feat: retrieval primitives for concept discovery
+
+Adds concept_retrieval.py with select_diverse (max-min
+farthest-point sampling), thinly_labeled_pool,
+retrieve_residual (Mode A), and retrieve_co_occurrence
+(Mode B). Pure NumPy + SQL; no clustering on the
+discovery path.
+```
+
+---
+
+## Phase 3 — Generation module + orchestrator
+
+### Task 3.1: Mode A — `generate_broad_labels`
+
+**Files:**
+- Create: `server/python/concept_generation.py`
+- Test: `server/python/tests/test_concept_generation.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/python/tests/test_concept_generation.py`:
+
+```python
+from unittest.mock import MagicMock
+from concept_generation import (
+    generate_broad_labels, BROAD_LABEL_TOOL,
+)
+
+
+def test_generate_broad_labels_calls_gemini_with_breadth_constraints(monkeypatch):
+    """Verify the prompt explicitly instructs the model to produce broad,
+       multi-label-friendly proposals."""
+    captured = {}
+
+    fake_response = MagicMock()
+    fake_part = MagicMock()
+    fake_part.function_call.name = "suggest_broad_labels"
+    fake_part.function_call.args = {
+        "concepts": [
+            {
+                "name": "metacognition",
+                "description": "students reflecting on their own learning",
+                "evidence_message_indices": [0, 3],
+            }
+        ]
+    }
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+
+    fake_client = MagicMock()
+    fake_client.models.generate_content = MagicMock(return_value=fake_response)
+
+    def capture(*args, **kwargs):
+        captured["prompt"] = kwargs.get("contents") or args[1]
+        return fake_response
+
+    fake_client.models.generate_content.side_effect = capture
+    monkeypatch.setattr("concept_generation.client", fake_client)
+
+    retrieved = [
+        {"chatlog_id": 1, "message_index": 0, "message_text": "I'm not sure if I get this"},
+        {"chatlog_id": 1, "message_index": 1, "message_text": "code didn't run"},
+        {"chatlog_id": 1, "message_index": 2, "message_text": "what does .loc do"},
+        {"chatlog_id": 1, "message_index": 3, "message_text": "am I doing this right"},
+    ]
+    drafts = generate_broad_labels(retrieved, existing_labels=[], rejected_names=[])
+
+    assert len(drafts) == 1
+    assert drafts[0]["name"] == "metacognition"
+    # evidence resolved back to chatlog_id/message_index
+    assert {"chatlog_id": 1, "message_index": 0} in drafts[0]["evidence_message_ids"]
+    assert {"chatlog_id": 1, "message_index": 3} in drafts[0]["evidence_message_ids"]
+
+    # Prompt must include the breadth constraint
+    prompt = captured["prompt"]
+    assert "co-apply" in prompt.lower() or "combine" in prompt.lower()
+    assert "broad" in prompt.lower()
+
+
+def test_broad_label_tool_schema_shape():
+    decl = BROAD_LABEL_TOOL.function_declarations[0]
+    assert decl.name == "suggest_broad_labels"
+    props = decl.parameters["properties"]["concepts"]["items"]["properties"]
+    assert "name" in props
+    assert "description" in props
+    assert "evidence_message_indices" in props
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_generation.py -v
+```
+Expected: import error.
+
+- [ ] **Step 3: Implement `generate_broad_labels`**
+
+Create `server/python/concept_generation.py`:
+
+```python
+"""Gemini prompt + tool schemas for RAG-style concept discovery."""
+from __future__ import annotations
+import os
+from typing import Any, TypedDict
+from google import genai
+from google.genai import types
+
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+class ConceptDraft(TypedDict, total=False):
+    kind: str  # "broad_label" | "co_occurrence"
+    name: str
+    description: str
+    evidence_message_ids: list[dict[str, int]]
+    co_occurrence_label_ids: list[int]
+    co_occurrence_count: int
+    suggested_resolution: str  # for co_occurrence: "make_label" | "merge" | "independent"
+
+
+# ── Mode A: broad-label discovery ──────────────────────────────────
+
+BROAD_LABEL_TOOL = types.Tool(function_declarations=[
+    types.FunctionDeclaration(
+        name="suggest_broad_labels",
+        description="Propose broad, multi-label-friendly categories.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "concepts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "description": {"type": "string"},
+                            "evidence_message_indices": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "description": "0-indexed positions in the input list",
+                            },
+                        },
+                        "required": ["name", "description", "evidence_message_indices"],
+                    },
+                },
+            },
+            "required": ["concepts"],
+        },
+    )
+])
+
+BROAD_LABEL_CONFIG = types.GenerateContentConfig(
+    system_instruction=(
+        "You are an education researcher analyzing student-AI tutoring "
+        "conversations. The instructor labels messages with multiple BROAD "
+        "labels per message — labels are designed to combine, not to be "
+        "mutually exclusive. Your job is to find broad themes the schema "
+        "doesn't yet cover."
+    ),
+    temperature=0,
+    tools=[BROAD_LABEL_TOOL],
+    tool_config=types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["suggest_broad_labels"],
+        )
+    ),
+)
+
+
+def _build_broad_label_prompt(
+    retrieved: list[dict[str, Any]],
+    existing_labels: list[dict[str, str]],
+    rejected_names: list[str],
+) -> str:
+    parts: list[str] = []
+    parts.append("## Existing Labels (already in use — do NOT re-suggest)")
+    parts.append("These labels reflect the instructor's style and granularity.")
+    for l in existing_labels:
+        desc = f" — {l.get('description','')}" if l.get("description") else ""
+        parts.append(f"- **{l['name']}**{desc}")
+
+    if rejected_names:
+        parts.append("\n## Previously Rejected (do NOT suggest)")
+        for name in rejected_names:
+            parts.append(f"- {name}")
+
+    parts.append("\n## Candidate Messages")
+    parts.append(
+        "These messages were retrieved as the SCHEMA'S BLIND SPOT — they "
+        "are deliberately diverse, NOT a tight cluster. Any single narrow "
+        "label cannot span this set."
+    )
+    parts.append("")
+    for i, m in enumerate(retrieved):
+        text = m["message_text"][:400]
+        parts.append(f"{i}. \"{text}\"")
+
+    parts.append("")
+    parts.append("## Task")
+    parts.append(
+        "Propose BROAD label categories. A useful proposal here:\n"
+        "- covers AT LEAST ~15% of the candidate messages above\n"
+        "- is meant to CO-APPLY with existing labels, not replace them\n"
+        "- is distinct from existing labels (different concept, not just a rename)\n"
+        "- is named in the SAME style as existing labels (look at their format)\n\n"
+        "Do NOT propose narrow sub-categories. If a concept would only fit "
+        "one or two messages, skip it. Quality over quantity. It is fine to "
+        "return zero proposals if the retrieved set has no broad theme.\n\n"
+        "Reference each proposal's evidence by the 0-indexed message numbers "
+        "above. Call `suggest_broad_labels` with your proposals."
+    )
+    return "\n".join(parts)
+
+
+def generate_broad_labels(
+    retrieved: list[dict[str, Any]],
+    existing_labels: list[dict[str, str]],
+    rejected_names: list[str],
+) -> list[ConceptDraft]:
+    """Single Gemini call. Returns drafts with evidence resolved back to
+    {chatlog_id, message_index} pairs (not the prompt-local indices)."""
+    if not retrieved:
+        return []
+    prompt = _build_broad_label_prompt(retrieved, existing_labels, rejected_names)
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=prompt,
+        config=BROAD_LABEL_CONFIG,
+    )
+
+    raw_concepts: list[dict[str, Any]] = []
+    for part in response.candidates[0].content.parts:
+        if getattr(part, "function_call", None) and \
+                part.function_call.name == "suggest_broad_labels":
+            args = dict(part.function_call.args)
+            raw_concepts = list(args.get("concepts", []))
+            break
+
+    drafts: list[ConceptDraft] = []
+    for c in raw_concepts:
+        evidence_ids: list[dict[str, int]] = []
+        for idx in c.get("evidence_message_indices", []) or []:
+            try:
+                idx_int = int(idx)
+            except (TypeError, ValueError):
+                continue
+            if 0 <= idx_int < len(retrieved):
+                m = retrieved[idx_int]
+                evidence_ids.append({
+                    "chatlog_id": m["chatlog_id"],
+                    "message_index": m["message_index"],
+                })
+        drafts.append({
+            "kind": "broad_label",
+            "name": c["name"],
+            "description": c["description"],
+            "evidence_message_ids": evidence_ids,
+        })
+    return drafts
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_generation.py -v
+```
+Expected: `2 passed`.
+
+---
+
+### Task 3.2: Mode B — `generate_co_occurrence_concepts`
+
+**Files:**
+- Modify: `server/python/concept_generation.py`
+- Modify: `server/python/tests/test_concept_generation.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_generation.py`:
+
+```python
+from concept_generation import (
+    generate_co_occurrence_concepts, CO_OCCURRENCE_TOOL,
+)
+
+
+def test_generate_co_occurrence_returns_drafts(monkeypatch):
+    fake_response = MagicMock()
+    fake_part = MagicMock()
+    fake_part.function_call.name = "evaluate_co_occurrence"
+    fake_part.function_call.args = {
+        "evaluations": [
+            {
+                "label_a_id": 1, "label_b_id": 2,
+                "name": "stuck on code",
+                "description": "students who cannot run their code and feel stuck",
+                "suggested_resolution": "make_label",
+            }
+        ]
+    }
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+
+    fake_client = MagicMock()
+    fake_client.models.generate_content = MagicMock(return_value=fake_response)
+    monkeypatch.setattr("concept_generation.client", fake_client)
+
+    pairs = [{
+        "label_a_id": 1, "label_b_id": 2,
+        "label_a_name": "code help", "label_b_name": "confused",
+        "count": 12,
+        "example_message_ids": [{"chatlog_id": 1, "message_index": 0}],
+    }]
+    drafts = generate_co_occurrence_concepts(pairs, existing_labels=[])
+
+    assert len(drafts) == 1
+    assert drafts[0]["kind"] == "co_occurrence"
+    assert drafts[0]["co_occurrence_label_ids"] == [1, 2]
+    assert drafts[0]["co_occurrence_count"] == 12
+    assert drafts[0]["suggested_resolution"] == "make_label"
+
+
+def test_co_occurrence_tool_schema_shape():
+    decl = CO_OCCURRENCE_TOOL.function_declarations[0]
+    assert decl.name == "evaluate_co_occurrence"
+    props = decl.parameters["properties"]["evaluations"]["items"]["properties"]
+    assert {"label_a_id", "label_b_id", "suggested_resolution"} <= set(props)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_generation.py -v -k co_occurrence
+```
+Expected: import error.
+
+- [ ] **Step 3: Implement `generate_co_occurrence_concepts`**
+
+Append to `server/python/concept_generation.py`:
+
+```python
+# ── Mode B: co-occurrence evaluation ───────────────────────────────
+
+CO_OCCURRENCE_TOOL = types.Tool(function_declarations=[
+    types.FunctionDeclaration(
+        name="evaluate_co_occurrence",
+        description="Evaluate whether co-occurring label pairs deserve a combined label, a merge, or are independent.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "evaluations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label_a_id": {"type": "integer"},
+                            "label_b_id": {"type": "integer"},
+                            "name": {"type": "string", "description": "If suggested_resolution=='make_label', the proposed combo name; else empty."},
+                            "description": {"type": "string"},
+                            "suggested_resolution": {
+                                "type": "string",
+                                "enum": ["make_label", "merge", "independent"],
+                            },
+                        },
+                        "required": ["label_a_id", "label_b_id", "suggested_resolution"],
+                    },
+                },
+            },
+            "required": ["evaluations"],
+        },
+    )
+])
+
+CO_OCCURRENCE_CONFIG = types.GenerateContentConfig(
+    system_instruction=(
+        "You are evaluating whether pairs of labels that frequently "
+        "co-occur represent (a) a coherent THIRD concept worth its own "
+        "label, (b) essentially the same thing under two names "
+        "(merge candidates), or (c) two genuinely independent things "
+        "that just happen to overlap. Be conservative — most pairs are "
+        "independent."
+    ),
+    temperature=0,
+    tools=[CO_OCCURRENCE_TOOL],
+    tool_config=types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["evaluate_co_occurrence"],
+        )
+    ),
+)
+
+
+def _build_co_occurrence_prompt(
+    pairs: list[dict[str, Any]],
+    existing_labels: list[dict[str, str]],
+) -> str:
+    parts: list[str] = []
+    parts.append("## Existing Labels in the Schema")
+    for l in existing_labels:
+        desc = f" — {l.get('description','')}" if l.get("description") else ""
+        parts.append(f"- (id={l.get('id','?')}) **{l['name']}**{desc}")
+
+    parts.append("\n## Frequently Co-occurring Label Pairs")
+    for p in pairs:
+        parts.append(
+            f"- **{p['label_a_name']}** + **{p['label_b_name']}** "
+            f"co-occur on {p['count']} messages "
+            f"(label_a_id={p['label_a_id']}, label_b_id={p['label_b_id']})"
+        )
+
+    parts.append("\n## Task")
+    parts.append(
+        "For each pair, decide one of:\n"
+        "- `make_label`: the combination is a coherent third concept "
+        "worth its own broad label (rare; only when the combination "
+        "captures something neither label captures alone)\n"
+        "- `merge`: the two labels are nearly synonymous; keeping both "
+        "fragments the schema\n"
+        "- `independent`: the pair is just two real things that often "
+        "appear in the same message — no schema action needed\n\n"
+        "Default to `independent`. Only suggest `make_label` if you can "
+        "name the combined concept in the same style as existing labels. "
+        "Call `evaluate_co_occurrence` with one entry per pair."
+    )
+    return "\n".join(parts)
+
+
+def generate_co_occurrence_concepts(
+    pairs: list[dict[str, Any]],
+    existing_labels: list[dict[str, Any]],
+) -> list[ConceptDraft]:
+    """Single Gemini call across all pairs."""
+    if not pairs:
+        return []
+    prompt = _build_co_occurrence_prompt(pairs, existing_labels)
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=prompt,
+        config=CO_OCCURRENCE_CONFIG,
+    )
+
+    raw: list[dict[str, Any]] = []
+    for part in response.candidates[0].content.parts:
+        if getattr(part, "function_call", None) and \
+                part.function_call.name == "evaluate_co_occurrence":
+            args = dict(part.function_call.args)
+            raw = list(args.get("evaluations", []))
+            break
+
+    pair_lookup = {
+        tuple(sorted([p["label_a_id"], p["label_b_id"]])): p for p in pairs
+    }
+
+    drafts: list[ConceptDraft] = []
+    for ev in raw:
+        try:
+            a, b = int(ev["label_a_id"]), int(ev["label_b_id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        key = tuple(sorted([a, b]))
+        src = pair_lookup.get(key)
+        if not src:
+            continue
+        name = ev.get("name") or f"{src['label_a_name']}+{src['label_b_name']}"
+        drafts.append({
+            "kind": "co_occurrence",
+            "name": name,
+            "description": ev.get("description") or "",
+            "co_occurrence_label_ids": [a, b],
+            "co_occurrence_count": src["count"],
+            "suggested_resolution": ev.get("suggested_resolution", "independent"),
+            "evidence_message_ids": src.get("example_message_ids", []),
+        })
+    return drafts
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_generation.py -v
+```
+Expected: all generation tests pass.
+
+---
+
+### Task 3.3: Rewrite `concept_service.discover()` as the orchestrator
+
+**Files:**
+- Modify: `server/python/concept_service.py:209-326` (replace `discover_concepts`)
+- Test: `server/python/tests/test_concept_service.py` (new or modify)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/python/tests/test_concept_service.py`:
+
+```python
+from unittest.mock import patch
+from datetime import datetime
+from sqlmodel import Session, select
+from models import (
+    DiscoveryRun, ConceptCandidate, MessageCache,
+    LabelDefinition, LabelApplication,
+)
+from concept_service import discover
+
+
+def test_discover_broad_label_creates_run_and_candidates(db_session: Session):
+    for i in range(10):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"msg{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+    db_session.commit()
+
+    fake_retrieved = [
+        {"chatlog_id": 1, "message_index": i, "message_text": f"msg{i}"}
+        for i in range(5)
+    ]
+    fake_drafts = [{
+        "kind": "broad_label",
+        "name": "curious",
+        "description": "students expressing curiosity",
+        "evidence_message_ids": [{"chatlog_id": 1, "message_index": 0}],
+    }]
+
+    with patch("concept_service.retrieve_residual", return_value=fake_retrieved), \
+         patch("concept_service.generate_broad_labels", return_value=fake_drafts):
+        run = discover(db_session, query_kind="broad_label", trigger="manual")
+
+    assert run.id is not None
+    assert run.completed_at is not None
+    assert run.error is None
+    assert run.n_candidates == 1
+    assert run.pool_size_at_trigger == 10  # all messages are unlabeled
+
+    candidates = db_session.exec(
+        select(ConceptCandidate).where(
+            ConceptCandidate.discovery_run_id == run.id
+        )
+    ).all()
+    assert len(candidates) == 1
+    assert candidates[0].kind == "broad_label"
+    assert candidates[0].name == "curious"
+
+
+def test_discover_records_error_on_failure(db_session: Session):
+    with patch(
+        "concept_service.retrieve_residual",
+        side_effect=RuntimeError("boom"),
+    ):
+        run = discover(db_session, query_kind="broad_label", trigger="manual")
+    assert run.error == "boom"
+    assert run.completed_at is not None
+    assert run.n_candidates == 0
+
+
+def test_discover_co_occurrence_path(db_session: Session):
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    db_session.add_all([label_a, label_b])
+    db_session.commit()
+    for i in range(2):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"m{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+        db_session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_a.id,
+            applied_by="human",
+        ))
+        db_session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_b.id,
+            applied_by="human",
+        ))
+    db_session.commit()
+
+    fake_drafts = [{
+        "kind": "co_occurrence", "name": "combo",
+        "description": "A+B together",
+        "co_occurrence_label_ids": [label_a.id, label_b.id],
+        "co_occurrence_count": 2,
+        "suggested_resolution": "independent",
+        "evidence_message_ids": [],
+    }]
+
+    with patch("concept_service.generate_co_occurrence_concepts",
+               return_value=fake_drafts):
+        run = discover(db_session, query_kind="co_occurrence",
+                       trigger="manual", min_count=1)
+
+    assert run.query_kind == "co_occurrence"
+    assert run.n_candidates == 1
+    cc = db_session.exec(
+        select(ConceptCandidate).where(
+            ConceptCandidate.discovery_run_id == run.id
+        )
+    ).one()
+    assert cc.kind == "co_occurrence"
+    assert cc.co_occurrence_count == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_service.py -v
+```
+Expected: import errors / function-signature mismatches.
+
+- [ ] **Step 3: Rewrite `concept_service.py`**
+
+Open `server/python/concept_service.py`. **Delete** the existing `SUGGEST_TOOL`, `SUGGEST_CONFIG`, `_build_discovery_prompt`, `_deduplicate_concepts`, and `discover_concepts` functions (lines ~74-326). Keep `embed_messages`, the `client`, and the `EMBED_MODEL`/`EMBED_DIM`/`EMBED_BATCH_SIZE` constants.
+
+Append the new orchestrator at the end of the file:
+
+```python
+import json
+from datetime import datetime
+from typing import Optional
+from concept_retrieval import (
+    retrieve_residual, retrieve_co_occurrence,
+)
+from concept_generation import (
+    generate_broad_labels, generate_co_occurrence_concepts,
+)
+from models import (
+    DiscoveryRun, ConceptCandidate, LabelDefinition,
+    LabelApplication,
+)
+
+
+def _read_recalibration_due(db: Session) -> bool:
+    """Returns True if the PR #36 recalibration system says drift is up.
+    Implemented as: a non-null `RecalibrationEvent`-driven signal
+    indicates `GET /api/session/recalibration` would currently surface
+    a recalibration message. Cheap to compute directly here without
+    going through the route layer."""
+    # Use the existing helper to avoid duplication.
+    from main import _compute_recalibration_interval
+    from models import RecalibrationEvent, LabelingSession
+    session_row = db.exec(
+        select(LabelingSession).order_by(LabelingSession.id.desc())
+    ).first()
+    if not session_row:
+        return False
+    events = list(db.exec(
+        select(RecalibrationEvent).order_by(RecalibrationEvent.id.asc())
+    ).all())
+    interval = _compute_recalibration_interval(events)
+    cutoff = events[-1].created_at if events else session_row.started_at
+    labeled_since = db.exec(
+        select(func.count()).select_from(
+            select(LabelApplication.chatlog_id, LabelApplication.message_index)
+            .where(LabelApplication.applied_by == "human")
+            .where(LabelApplication.created_at > cutoff)
+            .distinct()
+            .subquery()
+        )
+    ).one()
+    return labeled_since >= interval
+
+
+def _persist_drafts(
+    drafts: list[dict], run: DiscoveryRun, db: Session,
+) -> list[ConceptCandidate]:
+    out: list[ConceptCandidate] = []
+    for d in drafts:
+        cc = ConceptCandidate(
+            name=d["name"],
+            description=d.get("description", ""),
+            example_messages=json.dumps(
+                [{"excerpt": ""}]  # legacy column kept populated
+            ),
+            source_run_id=str(run.id),  # legacy column populated for compat
+            kind=d["kind"],
+            discovery_run_id=run.id,
+            evidence_message_ids=(
+                json.dumps(d["evidence_message_ids"])
+                if d.get("evidence_message_ids") is not None else None
+            ),
+            co_occurrence_label_ids=(
+                json.dumps(d["co_occurrence_label_ids"])
+                if d.get("co_occurrence_label_ids") is not None else None
+            ),
+            co_occurrence_count=d.get("co_occurrence_count"),
+        )
+        db.add(cc)
+        out.append(cc)
+    db.commit()
+    for cc in out:
+        db.refresh(cc)
+    return out
+
+
+def discover(
+    db: Session,
+    query_kind: str,
+    trigger: str,
+    *,
+    threshold: float = 0.55,
+    target_size: int = 80,
+    min_count: int = 8,
+) -> DiscoveryRun:
+    """Orchestrates one discovery run end-to-end.
+    Always finalizes the run (sets completed_at and either n_candidates
+    or error)."""
+    run = DiscoveryRun(
+        query_kind=query_kind,
+        trigger=trigger,
+        pool_size_at_trigger=0,  # filled in below
+        drift_value_at_trigger=None,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    try:
+        # Compute drift signal once (Mode B doesn't really care, but keep it consistent)
+        try:
+            run.drift_value_at_trigger = (
+                1.0 if _read_recalibration_due(db) else 0.0
+            )
+        except Exception:
+            run.drift_value_at_trigger = None
+
+        if query_kind == "broad_label":
+            retrieved = retrieve_residual(
+                db, threshold=threshold, target_size=target_size,
+            )
+            run.pool_size_at_trigger = len(retrieved)
+            existing = [
+                {"name": l.name, "description": l.description or "", "id": l.id}
+                for l in db.exec(
+                    select(LabelDefinition).where(
+                        LabelDefinition.archived_at == None  # noqa: E711
+                    )
+                ).all()
+            ]
+            rejected = [
+                cc.name for cc in db.exec(
+                    select(ConceptCandidate).where(
+                        ConceptCandidate.decision == "reject"
+                    )
+                ).all()
+            ]
+            drafts = generate_broad_labels(retrieved, existing, rejected)
+        elif query_kind == "co_occurrence":
+            pairs = retrieve_co_occurrence(db, min_count=min_count)
+            run.pool_size_at_trigger = len(pairs)
+            existing = [
+                {"name": l.name, "description": l.description or "", "id": l.id}
+                for l in db.exec(
+                    select(LabelDefinition).where(
+                        LabelDefinition.archived_at == None  # noqa: E711
+                    )
+                ).all()
+            ]
+            drafts = generate_co_occurrence_concepts(pairs, existing)
+        else:
+            raise ValueError(f"unknown query_kind: {query_kind}")
+
+        candidates = _persist_drafts(drafts, run, db)
+        run.n_candidates = len(candidates)
+    except Exception as e:
+        run.error = str(e)
+    finally:
+        run.completed_at = datetime.utcnow()
+        db.add(run)
+        db.commit()
+        db.refresh(run)
+    return run
+```
+
+- [ ] **Step 4: Run all backend tests**
+
+```bash
+cd server/python && uv run pytest -v
+```
+Expected: all tests pass; no regressions in unrelated suites.
+
+---
+
+### Task 3.4: `accept_broad_label` — auto-create label and AI-apply
+
+**Files:**
+- Modify: `server/python/concept_service.py`
+- Modify: `server/python/tests/test_concept_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_service.py`:
+
+```python
+from concept_service import accept_broad_label
+
+
+def test_accept_broad_label_creates_label_and_ai_applies(db_session):
+    # Set up: cached messages and a candidate referencing them.
+    for i in range(3):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"m{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=3,
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    cc = ConceptCandidate(
+        name="metacognition",
+        description="reflection on own learning",
+        example_messages="[]",
+        source_run_id=str(run.id),
+        kind="broad_label",
+        discovery_run_id=run.id,
+        evidence_message_ids='[{"chatlog_id":1,"message_index":0},{"chatlog_id":1,"message_index":2}]',
+    )
+    db_session.add(cc)
+    db_session.commit()
+
+    result = accept_broad_label(cc.id, db_session)
+
+    assert result.created_label_id is not None
+    assert result.applied_count == 2
+
+    db_session.refresh(cc)
+    assert cc.decision == "accept"
+    assert cc.decided_at is not None
+    assert cc.created_label_id == result.created_label_id
+
+    # The two evidence messages now carry an AI label.
+    apps = db_session.exec(
+        select(LabelApplication).where(
+            LabelApplication.label_id == result.created_label_id
+        )
+    ).all()
+    assert len(apps) == 2
+    assert all(a.applied_by == "ai" for a in apps)
+    assert all(a.confidence == 0.6 for a in apps)
+
+
+def test_accept_broad_label_rejects_co_occurrence_kind(db_session):
+    run = DiscoveryRun(
+        query_kind="co_occurrence", trigger="manual", pool_size_at_trigger=0,
+    )
+    db_session.add(run); db_session.commit()
+    cc = ConceptCandidate(
+        name="x+y", description="", example_messages="[]",
+        source_run_id=str(run.id),
+        kind="co_occurrence", discovery_run_id=run.id,
+    )
+    db_session.add(cc); db_session.commit()
+    with pytest.raises(ValueError, match="kind"):
+        accept_broad_label(cc.id, db_session)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_service.py -v -k accept_broad_label
+```
+Expected: import error.
+
+- [ ] **Step 3: Implement `accept_broad_label`**
+
+Append to `server/python/concept_service.py`:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass
+class AcceptResult:
+    candidate_id: int
+    created_label_id: int
+    applied_count: int
+
+
+def accept_broad_label(candidate_id: int, db: Session) -> AcceptResult:
+    """Mode A acceptance:
+    1. Create a LabelDefinition from the candidate.
+    2. Auto-apply it to evidence messages with applied_by='ai',
+       confidence=0.6.
+    3. Set candidate.decision='accept', decided_at, created_label_id.
+    """
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise ValueError(f"candidate {candidate_id} not found")
+    if cc.kind != "broad_label":
+        raise ValueError(
+            f"accept_broad_label requires kind='broad_label', got '{cc.kind}'"
+        )
+    if cc.decision in ("accept", "dismiss", "reject"):
+        raise ValueError(f"candidate {candidate_id} already decided: {cc.decision}")
+
+    new_label = LabelDefinition(name=cc.name, description=cc.description or None)
+    db.add(new_label)
+    db.commit()
+    db.refresh(new_label)
+
+    evidence: list[dict] = []
+    if cc.evidence_message_ids:
+        try:
+            evidence = json.loads(cc.evidence_message_ids)
+        except (TypeError, ValueError):
+            evidence = []
+
+    applied = 0
+    for ev in evidence:
+        try:
+            chatlog_id = int(ev["chatlog_id"])
+            message_index = int(ev["message_index"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        db.add(LabelApplication(
+            chatlog_id=chatlog_id,
+            message_index=message_index,
+            label_id=new_label.id,
+            applied_by="ai",
+            confidence=0.6,
+        ))
+        applied += 1
+
+    cc.decision = "accept"
+    cc.decided_at = datetime.utcnow()
+    cc.created_label_id = new_label.id
+    cc.status = "accepted"  # legacy column for backwards compat
+    db.add(cc)
+    db.commit()
+
+    return AcceptResult(
+        candidate_id=cc.id,
+        created_label_id=new_label.id,
+        applied_count=applied,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_service.py -v
+```
+Expected: all `concept_service` tests pass.
+
+---
+
+### Task 3.5: `is_discovery_ripe`
+
+**Files:**
+- Modify: `server/python/concept_service.py`
+- Modify: `server/python/tests/test_concept_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_service.py`:
+
+```python
+from concept_service import is_discovery_ripe
+
+
+def test_is_discovery_ripe_returns_signal_dict(db_session):
+    # Empty DB → not ripe (pool too small, no recalibration).
+    sig = is_discovery_ripe(db_session, min_pool=5)
+    assert sig["ripe"] is False
+    assert "pool_size" in sig
+    assert "drift_value" in sig
+    assert "reasons" in sig
+    assert "pool_below_threshold" in sig["reasons"]
+
+
+def test_is_discovery_ripe_when_pool_large_and_recal_due(db_session, monkeypatch):
+    # Stub recalibration check to True; ensure pool >= min_pool.
+    for i in range(10):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"m{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+    db_session.commit()
+    monkeypatch.setattr(
+        "concept_service._read_recalibration_due", lambda db: True
+    )
+    sig = is_discovery_ripe(db_session, min_pool=5)
+    assert sig["ripe"] is True
+    assert sig["drift_value"] == 1.0
+    assert sig["pool_size"] >= 5
+    assert sig["reasons"] == ["ok"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_service.py -v -k discovery_ripe
+```
+Expected: import error.
+
+- [ ] **Step 3: Implement `is_discovery_ripe`**
+
+Append to `server/python/concept_service.py`:
+
+```python
+def is_discovery_ripe(db: Session, min_pool: int = 30) -> dict:
+    """Returns a JSON-friendly ripeness signal. Cheap; safe to poll."""
+    from concept_retrieval import thinly_labeled_pool
+    pool = thinly_labeled_pool(db)
+    pool_size = len(pool)
+
+    drift_due = False
+    drift_value: Optional[float] = None
+    try:
+        drift_due = _read_recalibration_due(db)
+        drift_value = 1.0 if drift_due else 0.0
+    except Exception:
+        drift_value = None
+
+    reasons: list[str] = []
+    if pool_size < min_pool:
+        reasons.append("pool_below_threshold")
+    if not drift_due:
+        reasons.append("drift_low")
+    ripe = pool_size >= min_pool and drift_due
+
+    if ripe:
+        reasons = ["ok"]
+    return {
+        "ripe": ripe,
+        "pool_size": pool_size,
+        "drift_value": drift_value,
+        "reasons": reasons,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_service.py -v
+```
+Expected: all pass.
+
+---
+
+### STOP — Phase 3 review
+
+Pause for user review and commit. Suggested commit message:
+
+```
+feat: RAG-style discovery orchestrator
+
+Adds concept_generation.py (broad-label + co-occurrence
+prompts), rewrites concept_service.discover() as a thin
+orchestrator over retrieve→generate, adds
+accept_broad_label and is_discovery_ripe. Removes the
+KMeans-based discover_concepts path.
+```
+
+---
+
+## Phase 4 — API endpoints
+
+### Task 4.1: Modify `POST /api/concepts/discover` to accept query_kind/trigger
+
+**Files:**
+- Modify: `server/python/main.py:1659-1707` (the `_run_discover`/`start_discover` block)
+- Modify: `server/python/schemas.py` (extend `DiscoverConceptsResponse` and add request schema if not present)
+- Test: `server/python/tests/test_concept_api.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/python/tests/test_concept_api.py`:
+
+```python
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+from datetime import datetime
+from models import (
+    DiscoveryRun, ConceptCandidate, MessageCache,
+    LabelDefinition, LabelApplication,
+)
+
+
+def test_post_discover_accepts_query_kind_and_trigger(client: TestClient):
+    resp = client.post("/api/concepts/discover", json={
+        "query_kind": "broad_label", "trigger": "manual",
+    })
+    # Either accepts (returns run_id) or rejects with 409 if a run is
+    # already in progress; both are valid here. Reject 422 (schema fail).
+    assert resp.status_code in (200, 409)
+    if resp.status_code == 200:
+        body = resp.json()
+        assert "run_id" in body
+        assert body.get("status") == "running"
+
+
+def test_post_discover_rejects_unknown_query_kind(client: TestClient):
+    resp = client.post("/api/concepts/discover", json={
+        "query_kind": "made_up", "trigger": "manual",
+    })
+    assert resp.status_code == 422
+
+
+def test_post_discover_rejects_unknown_trigger(client: TestClient):
+    resp = client.post("/api/concepts/discover", json={
+        "query_kind": "broad_label", "trigger": "cosmic_ray",
+    })
+    assert resp.status_code == 422
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v -k post_discover
+```
+Expected: failures because the route still takes the old shape (no body, query param `limit`).
+
+- [ ] **Step 3: Update schemas**
+
+Open `server/python/schemas.py`. Add (or replace) these definitions:
+
+```python
+from typing import Literal
+from pydantic import BaseModel
+
+
+class StartDiscoverRequest(BaseModel):
+    query_kind: Literal["broad_label", "co_occurrence"]
+    trigger: Literal["manual", "badge"] = "manual"
+
+
+class DiscoverConceptsResponse(BaseModel):
+    run_id: int | str
+    status: str  # "running"
+```
+
+- [ ] **Step 4: Update the route**
+
+In `server/python/main.py`, replace the `_discover_status`/`_run_discover`/`start_discover` block (around `main.py:1659-1707`) with:
+
+```python
+_discover_status: dict = {
+    "running": False, "run_id": None, "error": None, "query_kind": None,
+}
+
+
+def _run_discover(query_kind: str, trigger: str):
+    """Background task: dispatches to concept_service.discover()."""
+    from concept_service import discover
+    global _discover_status
+    try:
+        with Session(engine) as db:
+            run = discover(db, query_kind=query_kind, trigger=trigger)
+            _discover_status = {
+                "running": False,
+                "run_id": run.id,
+                "error": run.error,
+                "query_kind": query_kind,
+            }
+    except Exception as e:
+        _discover_status = {
+            "running": False,
+            "run_id": _discover_status.get("run_id"),
+            "error": str(e),
+            "query_kind": query_kind,
+        }
+
+
+@app.post("/api/concepts/discover", response_model=DiscoverConceptsResponse)
+def start_discover(req: StartDiscoverRequest):
+    global _discover_status
+    if _discover_status["running"]:
+        raise HTTPException(status_code=409,
+                            detail="Concept discovery already in progress")
+    _discover_status = {
+        "running": True, "run_id": None, "error": None,
+        "query_kind": req.query_kind,
+    }
+    thread = threading.Thread(
+        target=_run_discover, args=(req.query_kind, req.trigger), daemon=True,
+    )
+    thread.start()
+    return DiscoverConceptsResponse(run_id="starting", status="running")
+```
+
+(Add `from schemas import StartDiscoverRequest, DiscoverConceptsResponse` if not already imported.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v -k post_discover
+```
+Expected: all three tests pass.
+
+---
+
+### Task 4.2: `GET /api/concepts/ripe`
+
+**Files:**
+- Modify: `server/python/main.py`
+- Modify: `server/python/schemas.py`
+- Modify: `server/python/tests/test_concept_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_api.py`:
+
+```python
+def test_get_ripe_returns_signal(client):
+    resp = client.get("/api/concepts/ripe")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "ripe" in body
+    assert "pool_size" in body
+    assert "drift_value" in body
+    assert "reasons" in body
+    assert isinstance(body["reasons"], list)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py::test_get_ripe_returns_signal -v
+```
+Expected: 404.
+
+- [ ] **Step 3: Add the schema**
+
+Append to `server/python/schemas.py`:
+
+```python
+class RipeSignalResponse(BaseModel):
+    ripe: bool
+    pool_size: int
+    drift_value: float | None
+    reasons: list[str]
+```
+
+- [ ] **Step 4: Add the route**
+
+In `server/python/main.py`, near the other `/api/concepts/*` routes:
+
+```python
+from concept_service import is_discovery_ripe
+
+
+@app.get("/api/concepts/ripe", response_model=RipeSignalResponse)
+def get_concept_ripe(db: Session = Depends(get_session)):
+    return is_discovery_ripe(db)
+```
+
+(Add `RipeSignalResponse` to the schemas import if not already.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py::test_get_ripe_returns_signal -v
+```
+Expected: pass.
+
+---
+
+### Task 4.3: `POST /api/concepts/candidates/{id}/accept`
+
+**Files:**
+- Modify: `server/python/main.py`
+- Modify: `server/python/schemas.py`
+- Modify: `server/python/tests/test_concept_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/python/tests/test_concept_api.py`:
+
+```python
+def test_post_accept_creates_label_and_applies(client, db_session):
+    # Seed cached messages and a candidate.
+    for i in range(2):
+        db_session.add(MessageCache(
+            chatlog_id=1, message_index=i, message_text=f"m{i}",
+            user_email="u", created_at=datetime.utcnow(),
+        ))
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=2,
+    )
+    db_session.add(run); db_session.commit()
+    cc = ConceptCandidate(
+        name="curious", description="curious students",
+        example_messages="[]", source_run_id=str(run.id),
+        kind="broad_label", discovery_run_id=run.id,
+        evidence_message_ids='[{"chatlog_id":1,"message_index":0}]',
+    )
+    db_session.add(cc); db_session.commit()
+
+    resp = client.post(f"/api/concepts/candidates/{cc.id}/accept", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["candidate_id"] == cc.id
+    assert body["created_label_id"] is not None
+    assert body["applied_count"] == 1
+
+
+def test_post_accept_404_for_unknown_candidate(client):
+    resp = client.post("/api/concepts/candidates/99999/accept", json={})
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v -k post_accept
+```
+Expected: 404 / not implemented.
+
+- [ ] **Step 3: Add the schema**
+
+Append to `server/python/schemas.py`:
+
+```python
+class AcceptCandidateResponse(BaseModel):
+    candidate_id: int
+    created_label_id: int
+    applied_count: int
+```
+
+- [ ] **Step 4: Add the route**
+
+In `server/python/main.py`:
+
+```python
+from concept_service import accept_broad_label
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/accept",
+    response_model=AcceptCandidateResponse,
+)
+def post_accept_candidate(candidate_id: int,
+                          db: Session = Depends(get_session)):
+    try:
+        result = accept_broad_label(candidate_id, db)
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+    return AcceptCandidateResponse(
+        candidate_id=result.candidate_id,
+        created_label_id=result.created_label_id,
+        applied_count=result.applied_count,
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v -k post_accept
+```
+Expected: pass.
+
+---
+
+### Task 4.4: `POST /api/concepts/candidates/{id}/dismiss`, `/note`, `/make-label`, `/suggest-merge`
+
+These four routes share a similar shape. Implement them together.
+
+**Files:**
+- Modify: `server/python/main.py`
+- Modify: `server/python/schemas.py`
+- Modify: `server/python/tests/test_concept_api.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `server/python/tests/test_concept_api.py`:
+
+```python
+def test_post_dismiss_sets_decision(client, db_session):
+    cc = ConceptCandidate(
+        name="x", description="", example_messages="[]",
+        source_run_id="r", kind="broad_label",
+    )
+    db_session.add(cc); db_session.commit()
+    resp = client.post(f"/api/concepts/candidates/{cc.id}/dismiss",
+                       json={"reason": "too narrow"})
+    assert resp.status_code == 200
+    db_session.refresh(cc)
+    assert cc.decision == "dismiss"
+    assert cc.decided_at is not None
+
+
+def test_post_note_only_for_co_occurrence(client, db_session):
+    cc_co = ConceptCandidate(
+        name="A+B", description="", example_messages="[]",
+        source_run_id="r", kind="co_occurrence",
+        co_occurrence_label_ids="[1,2]", co_occurrence_count=5,
+    )
+    cc_broad = ConceptCandidate(
+        name="x", description="", example_messages="[]",
+        source_run_id="r", kind="broad_label",
+    )
+    db_session.add_all([cc_co, cc_broad]); db_session.commit()
+
+    resp_ok = client.post(f"/api/concepts/candidates/{cc_co.id}/note", json={})
+    assert resp_ok.status_code == 200
+
+    resp_bad = client.post(f"/api/concepts/candidates/{cc_broad.id}/note", json={})
+    assert resp_bad.status_code == 400
+
+
+def test_post_make_label_creates_label(client, db_session):
+    cc = ConceptCandidate(
+        name="A+B", description="combo", example_messages="[]",
+        source_run_id="r", kind="co_occurrence",
+        co_occurrence_label_ids="[1,2]", co_occurrence_count=5,
+    )
+    db_session.add(cc); db_session.commit()
+
+    resp = client.post(f"/api/concepts/candidates/{cc.id}/make-label", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created_label_id"] is not None
+
+    label = db_session.exec(
+        select(LabelDefinition).where(LabelDefinition.id == body["created_label_id"])
+    ).one()
+    assert label.name == "A+B"
+    # No auto-apply: no LabelApplications for this label.
+    apps = db_session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == label.id)
+    ).all()
+    assert apps == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v -k "dismiss or note or make_label"
+```
+
+- [ ] **Step 3: Add helper functions in `concept_service.py`**
+
+Append to `server/python/concept_service.py`:
+
+```python
+def dismiss_candidate(
+    candidate_id: int, db: Session, reason: Optional[str] = None,
+) -> ConceptCandidate:
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise ValueError(f"candidate {candidate_id} not found")
+    cc.decision = "dismiss"
+    cc.decided_at = datetime.utcnow()
+    cc.status = "rejected"  # legacy
+    db.add(cc); db.commit(); db.refresh(cc)
+    return cc
+
+
+def note_candidate(candidate_id: int, db: Session) -> ConceptCandidate:
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise ValueError(f"candidate {candidate_id} not found")
+    if cc.kind != "co_occurrence":
+        raise ValueError("note_candidate requires kind='co_occurrence'")
+    cc.decision = "note"
+    cc.decided_at = datetime.utcnow()
+    db.add(cc); db.commit(); db.refresh(cc)
+    return cc
+
+
+def make_label_from_co_occurrence(
+    candidate_id: int, db: Session,
+) -> AcceptResult:
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise ValueError(f"candidate {candidate_id} not found")
+    if cc.kind != "co_occurrence":
+        raise ValueError("make_label_from_co_occurrence requires kind='co_occurrence'")
+    new_label = LabelDefinition(name=cc.name, description=cc.description or None)
+    db.add(new_label); db.commit(); db.refresh(new_label)
+    cc.decision = "accept"
+    cc.decided_at = datetime.utcnow()
+    cc.created_label_id = new_label.id
+    cc.status = "accepted"
+    db.add(cc); db.commit()
+    return AcceptResult(
+        candidate_id=cc.id,
+        created_label_id=new_label.id,
+        applied_count=0,  # no auto-apply for Mode B
+    )
+```
+
+(`suggest-merge` reuses the existing label-archive flow on the backend; it's wired in the route, not a new service function.)
+
+- [ ] **Step 4: Add schemas**
+
+Append to `server/python/schemas.py`:
+
+```python
+class DismissRequest(BaseModel):
+    reason: str | None = None
+
+
+class GenericOk(BaseModel):
+    ok: bool = True
+
+
+class MakeLabelResponse(BaseModel):
+    candidate_id: int
+    created_label_id: int
+
+
+class SuggestMergeRequest(BaseModel):
+    archive_label_id: int
+    keep_label_id: int
+
+
+class SuggestMergeResponse(BaseModel):
+    archived_label_id: int
+    kept_label_id: int
+    retagged_count: int
+```
+
+- [ ] **Step 5: Add the routes**
+
+In `server/python/main.py`, near the accept route. **For `/suggest-merge`, reuse whatever the existing label-archive endpoint internally does.** Search `main.py` for `archived_at = ` or `archive` to find the existing helper; if it lives in a function, call it directly. If it is only a route, factor a small helper (call it `_archive_and_retag_label`) in `main.py` — this is the only refactor permitted in this phase.
+
+```python
+from concept_service import (
+    dismiss_candidate, note_candidate, make_label_from_co_occurrence,
+)
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/dismiss",
+    response_model=GenericOk,
+)
+def post_dismiss(
+    candidate_id: int, req: DismissRequest,
+    db: Session = Depends(get_session),
+):
+    try:
+        dismiss_candidate(candidate_id, db, reason=req.reason)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return GenericOk()
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/note",
+    response_model=GenericOk,
+)
+def post_note(candidate_id: int, db: Session = Depends(get_session)):
+    try:
+        note_candidate(candidate_id, db)
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+    return GenericOk()
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/make-label",
+    response_model=MakeLabelResponse,
+)
+def post_make_label(candidate_id: int, db: Session = Depends(get_session)):
+    try:
+        result = make_label_from_co_occurrence(candidate_id, db)
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+    return MakeLabelResponse(
+        candidate_id=result.candidate_id,
+        created_label_id=result.created_label_id,
+    )
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/suggest-merge",
+    response_model=SuggestMergeResponse,
+)
+def post_suggest_merge(
+    candidate_id: int,
+    req: SuggestMergeRequest,
+    db: Session = Depends(get_session),
+):
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise HTTPException(status_code=404, detail="candidate not found")
+    if cc.kind != "co_occurrence":
+        raise HTTPException(
+            status_code=400,
+            detail="suggest-merge requires kind='co_occurrence'",
+        )
+    # Reuse existing archive-and-retag logic. Replace this stub with a
+    # direct call to the existing helper found via the search above.
+    retagged_count = _archive_and_retag_label(
+        archive_label_id=req.archive_label_id,
+        keep_label_id=req.keep_label_id,
+        db=db,
+    )
+    cc.decision = "suggest_merge"
+    cc.decided_at = datetime.utcnow()
+    db.add(cc); db.commit()
+    return SuggestMergeResponse(
+        archived_label_id=req.archive_label_id,
+        kept_label_id=req.keep_label_id,
+        retagged_count=retagged_count,
+    )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v
+```
+Expected: all dismiss/note/make-label tests pass.
+
+---
+
+### Task 4.5: `GET /api/concepts/runs` and extend `GET /api/concepts/candidates`
+
+**Files:**
+- Modify: `server/python/main.py:1710-1729` (existing `/candidates` route)
+- Modify: `server/python/schemas.py`
+- Modify: `server/python/tests/test_concept_api.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `server/python/tests/test_concept_api.py`:
+
+```python
+def test_get_candidates_includes_new_fields(client, db_session):
+    cc = ConceptCandidate(
+        name="x", description="", example_messages="[]",
+        source_run_id="r", kind="broad_label",
+        evidence_message_ids='[{"chatlog_id":1,"message_index":0}]',
+    )
+    db_session.add(cc); db_session.commit()
+    resp = client.get("/api/concepts/candidates")
+    assert resp.status_code == 200
+    rows = resp.json()
+    target = next(r for r in rows if r["id"] == cc.id)
+    assert target["kind"] == "broad_label"
+    assert target["evidence_message_ids"] == [
+        {"chatlog_id": 1, "message_index": 0}
+    ]
+    assert target.get("co_occurrence_label_ids") in (None, [])
+    assert "decision" in target
+
+
+def test_get_candidates_filters_by_kind_and_run_id(client, db_session):
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=0,
+    )
+    db_session.add(run); db_session.commit()
+    cc1 = ConceptCandidate(name="a", description="", example_messages="[]",
+                            source_run_id=str(run.id), kind="broad_label",
+                            discovery_run_id=run.id)
+    cc2 = ConceptCandidate(name="b", description="", example_messages="[]",
+                            source_run_id=str(run.id), kind="co_occurrence",
+                            discovery_run_id=run.id)
+    db_session.add_all([cc1, cc2]); db_session.commit()
+
+    resp = client.get(f"/api/concepts/candidates?run_id={run.id}&kind=broad_label")
+    rows = resp.json()
+    ids = {r["id"] for r in rows}
+    assert cc1.id in ids and cc2.id not in ids
+
+
+def test_get_runs_returns_recent(client, db_session):
+    for k in ("broad_label", "co_occurrence"):
+        db_session.add(DiscoveryRun(
+            query_kind=k, trigger="manual", pool_size_at_trigger=0,
+        ))
+    db_session.commit()
+    resp = client.get("/api/concepts/runs?limit=5")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) >= 2
+    assert all("query_kind" in r and "trigger" in r for r in rows)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v -k "candidates_includes_new or filters_by_kind or get_runs"
+```
+
+- [ ] **Step 3: Update schemas**
+
+In `server/python/schemas.py`, replace the existing `ConceptCandidateResponse` (search for the class) with:
+
+```python
+class ConceptCandidateResponse(BaseModel):
+    id: int
+    name: str
+    description: str
+    example_messages: list[dict]
+    status: str
+    source_run_id: str
+    similar_to: str | None = None
+    created_at: str
+    # New
+    kind: str = "broad_label"
+    discovery_run_id: int | None = None
+    decision: str | None = None
+    created_label_id: int | None = None
+    evidence_message_ids: list[dict] | None = None
+    co_occurrence_label_ids: list[int] | None = None
+    co_occurrence_count: int | None = None
+
+
+class DiscoveryRunResponse(BaseModel):
+    id: int
+    started_at: str
+    completed_at: str | None = None
+    query_kind: str
+    trigger: str
+    drift_value_at_trigger: float | None = None
+    pool_size_at_trigger: int
+    n_candidates: int
+    error: str | None = None
+```
+
+- [ ] **Step 4: Update the `/candidates` route and add `/runs`**
+
+Replace the existing `/api/concepts/candidates` GET route in `main.py:1710-1729` with:
+
+```python
+@app.get("/api/concepts/candidates", response_model=List[ConceptCandidateResponse])
+def get_candidates(
+    run_id: int | None = None,
+    kind: str | None = None,
+    decision: str | None = None,
+    db: Session = Depends(get_session),
+):
+    q = select(ConceptCandidate)
+    if run_id is not None:
+        q = q.where(ConceptCandidate.discovery_run_id == run_id)
+    if kind is not None:
+        q = q.where(ConceptCandidate.kind == kind)
+    if decision is not None:
+        q = q.where(ConceptCandidate.decision == decision)
+    rows = db.exec(q.order_by(ConceptCandidate.id.desc())).all()
+
+    out: list[ConceptCandidateResponse] = []
+    for cc in rows:
+        out.append(ConceptCandidateResponse(
+            id=cc.id,
+            name=cc.name,
+            description=cc.description or "",
+            example_messages=(
+                json.loads(cc.example_messages) if cc.example_messages else []
+            ),
+            status=cc.status,
+            source_run_id=cc.source_run_id,
+            similar_to=cc.similar_to,
+            created_at=cc.created_at.isoformat(),
+            kind=cc.kind,
+            discovery_run_id=cc.discovery_run_id,
+            decision=cc.decision,
+            created_label_id=cc.created_label_id,
+            evidence_message_ids=(
+                json.loads(cc.evidence_message_ids)
+                if cc.evidence_message_ids else None
+            ),
+            co_occurrence_label_ids=(
+                json.loads(cc.co_occurrence_label_ids)
+                if cc.co_occurrence_label_ids else None
+            ),
+            co_occurrence_count=cc.co_occurrence_count,
+        ))
+    return out
+
+
+@app.get("/api/concepts/runs", response_model=List[DiscoveryRunResponse])
+def get_runs(limit: int = 20, db: Session = Depends(get_session)):
+    rows = db.exec(
+        select(DiscoveryRun).order_by(DiscoveryRun.id.desc()).limit(limit)
+    ).all()
+    return [
+        DiscoveryRunResponse(
+            id=r.id,
+            started_at=r.started_at.isoformat(),
+            completed_at=r.completed_at.isoformat() if r.completed_at else None,
+            query_kind=r.query_kind,
+            trigger=r.trigger,
+            drift_value_at_trigger=r.drift_value_at_trigger,
+            pool_size_at_trigger=r.pool_size_at_trigger,
+            n_candidates=r.n_candidates,
+            error=r.error,
+        )
+        for r in rows
+    ]
+```
+
+(Add `import json` at the top of the file if it isn't there. Add the new schemas to the imports.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_concept_api.py -v
+```
+Expected: all `/candidates` and `/runs` tests pass.
+
+- [ ] **Step 6: Run the full backend suite**
+
+```bash
+cd server/python && uv run pytest -v
+```
+Expected: no regressions across all backend tests.
+
+---
+
+### STOP — Phase 4 review
+
+Pause for user review and commit. Suggested commit message:
+
+```
+feat: concept discovery API endpoints
+
+Adds POST /discover (mode-aware), GET /ripe, POST
+/accept, /dismiss, /note, /make-label, /suggest-merge,
+GET /runs. Extends GET /candidates with kind/run_id/
+decision filters and new field projection.
+```
+
+---
+
+## Phase 5 — Frontend mode picker + candidate cards
+
+### Task 5.1: Update TypeScript types
+
+**Files:**
+- Modify: `src/types/index.ts:163-172`
+
+- [ ] **Step 1: Replace the `ConceptCandidate` interface**
+
+Open `src/types/index.ts`. Replace the existing `ConceptCandidate` interface with:
+
+```ts
+export type ConceptCandidateKind = 'broad_label' | 'co_occurrence'
+
+export type ConceptDecision =
+  | 'accept' | 'reject' | 'dismiss' | 'suggest_merge' | 'note'
+
+export interface ConceptCandidate {
+  id: number
+  name: string
+  description: string
+  example_messages: { excerpt: string; chatlog_id?: number; message_index?: number }[]
+  status: 'pending' | 'accepted' | 'rejected'
+  source_run_id: string
+  similar_to: string | null
+  created_at: string
+  // New RAG-discovery fields
+  kind: ConceptCandidateKind
+  discovery_run_id?: number | null
+  decision?: ConceptDecision | null
+  created_label_id?: number | null
+  evidence_message_ids?: { chatlog_id: number; message_index: number }[] | null
+  co_occurrence_label_ids?: [number, number] | null
+  co_occurrence_count?: number | null
+}
+
+export interface RipeSignal {
+  ripe: boolean
+  pool_size: number
+  drift_value: number | null
+  reasons: string[]
+}
+
+export interface DiscoveryRun {
+  id: number
+  started_at: string
+  completed_at: string | null
+  query_kind: ConceptCandidateKind
+  trigger: 'manual' | 'badge'
+  drift_value_at_trigger: number | null
+  pool_size_at_trigger: number
+  n_candidates: number
+  error: string | null
+}
+```
+
+- [ ] **Step 2: Run type-check**
+
+```bash
+npx tsc --noEmit
+```
+Expected: pass (existing usages of `ConceptCandidate` still satisfied because new fields are optional).
+
+---
+
+### Task 5.2: Update `src/services/api.ts` with new endpoints
+
+**Files:**
+- Modify: `src/services/api.ts:115-130`
+
+- [ ] **Step 1: Add type imports at the top of the file**
+
+Open `src/services/api.ts`. Add (or extend) the type imports at the top of the file:
+
+```ts
+import type {
+  ConceptCandidate, RipeSignal, DiscoveryRun, ConceptCandidateKind,
+} from '../types'
+```
+
+- [ ] **Step 2: Replace existing concept-related methods on the `api` object**
+
+Replace the existing `discoverConcepts`, `getCandidates`, `updateCandidate`, and `getEmbedStatus` methods (around lines 115-130) with the methods below. Keep the surrounding `api` object scaffolding intact:
+
+```ts
+discoverConcepts: (
+  query_kind: ConceptCandidateKind,
+  trigger: 'manual' | 'badge' = 'manual',
+): Promise<{ run_id: number | string; status: string }> =>
+  USE_MOCK
+    ? mocks.discoverConcepts(query_kind, trigger)
+    : req('/api/concepts/discover', {
+        method: 'POST',
+        ...json({ query_kind, trigger }),
+      }),
+
+getConceptCandidates: (
+  filters: { run_id?: number; kind?: ConceptCandidateKind; decision?: string } = {},
+): Promise<ConceptCandidate[]> => {
+  const params = new URLSearchParams()
+  if (filters.run_id != null) params.set('run_id', String(filters.run_id))
+  if (filters.kind) params.set('kind', filters.kind)
+  if (filters.decision) params.set('decision', filters.decision)
+  const qs = params.toString() ? `?${params.toString()}` : ''
+  return USE_MOCK
+    ? mocks.getConceptCandidates(filters)
+    : req(`/api/concepts/candidates${qs}`)
+},
+
+getConceptRipe: (): Promise<RipeSignal> =>
+  USE_MOCK ? mocks.getConceptRipe() : req('/api/concepts/ripe'),
+
+acceptConceptCandidate: (
+  id: number,
+): Promise<{ candidate_id: number; created_label_id: number; applied_count: number }> =>
+  USE_MOCK
+    ? mocks.acceptConceptCandidate(id)
+    : req(`/api/concepts/candidates/${id}/accept`, {
+        method: 'POST',
+        ...json({}),
+      }),
+
+dismissConceptCandidate: (
+  id: number, reason?: string,
+): Promise<{ ok: true }> =>
+  USE_MOCK
+    ? mocks.dismissConceptCandidate(id, reason)
+    : req(`/api/concepts/candidates/${id}/dismiss`, {
+        method: 'POST',
+        ...json({ reason }),
+      }),
+
+noteConceptCandidate: (id: number): Promise<{ ok: true }> =>
+  USE_MOCK
+    ? mocks.noteConceptCandidate(id)
+    : req(`/api/concepts/candidates/${id}/note`, {
+        method: 'POST', ...json({}),
+      }),
+
+makeLabelFromCandidate: (
+  id: number,
+): Promise<{ candidate_id: number; created_label_id: number }> =>
+  USE_MOCK
+    ? mocks.makeLabelFromCandidate(id)
+    : req(`/api/concepts/candidates/${id}/make-label`, {
+        method: 'POST', ...json({}),
+      }),
+
+suggestMergeFromCandidate: (
+  id: number, archive_label_id: number, keep_label_id: number,
+): Promise<{ archived_label_id: number; kept_label_id: number; retagged_count: number }> =>
+  USE_MOCK
+    ? mocks.suggestMergeFromCandidate(id, archive_label_id, keep_label_id)
+    : req(`/api/concepts/candidates/${id}/suggest-merge`, {
+        method: 'POST',
+        ...json({ archive_label_id, keep_label_id }),
+      }),
+
+getDiscoveryRuns: (limit = 20): Promise<DiscoveryRun[]> =>
+  USE_MOCK ? mocks.getDiscoveryRuns(limit) : req(`/api/concepts/runs?limit=${limit}`),
+```
+
+(Remove the legacy `discoverConcepts(limit)` overload and the legacy `getCandidates`/`updateCandidate`/`getEmbedStatus` references that no longer compile. Where existing callers use them, port the call sites to the new method names.)
+
+- [ ] **Step 3: Find and update call sites**
+
+```bash
+grep -rn "discoverConcepts\|getCandidates\|updateCandidate\|getEmbedStatus" src/ --include="*.ts" --include="*.tsx"
+```
+
+Update each call site to use the new method names and signatures. The expected callers are inside `src/components/queue/DiscoverSection.tsx` and `src/components/queue/DiscoverModal.tsx` (handled in Task 5.4 and Task 5.5).
+
+- [ ] **Step 4: Run type-check**
+
+```bash
+npx tsc --noEmit
+```
+Expected: pass after call-site updates in 5.4/5.5; if errors remain in DiscoverSection/DiscoverModal, defer those fixes to those tasks.
+
+---
+
+### Task 5.3: Update mocks
+
+**Files:**
+- Modify: `src/mocks/index.ts`
+
+- [ ] **Step 1: Add mock implementations**
+
+Open `src/mocks/index.ts`. Add (or replace) functions:
+
+```ts
+import type {
+  ConceptCandidate, RipeSignal, DiscoveryRun, ConceptCandidateKind,
+} from '../types'
+
+const mockBroadCandidate: ConceptCandidate = {
+  id: 1001,
+  name: 'metacognition',
+  description: 'students reflecting on their own learning process',
+  example_messages: [
+    { excerpt: "I'm not sure I get this", chatlog_id: 1, message_index: 0 },
+    { excerpt: "am I doing this right?",  chatlog_id: 1, message_index: 3 },
+  ],
+  status: 'pending',
+  source_run_id: '42',
+  similar_to: null,
+  created_at: new Date().toISOString(),
+  kind: 'broad_label',
+  discovery_run_id: 42,
+  decision: null,
+  evidence_message_ids: [
+    { chatlog_id: 1, message_index: 0 },
+    { chatlog_id: 1, message_index: 3 },
+  ],
+  co_occurrence_label_ids: null,
+  co_occurrence_count: null,
+}
+
+const mockCoOccurCandidate: ConceptCandidate = {
+  id: 1002,
+  name: 'code help + confused',
+  description: 'students asking about code while signaling confusion',
+  example_messages: [],
+  status: 'pending',
+  source_run_id: '43',
+  similar_to: null,
+  created_at: new Date().toISOString(),
+  kind: 'co_occurrence',
+  discovery_run_id: 43,
+  decision: null,
+  evidence_message_ids: null,
+  co_occurrence_label_ids: [10, 12],
+  co_occurrence_count: 14,
+}
+
+export const discoverConcepts = async (
+  _kind: ConceptCandidateKind, _trigger: 'manual' | 'badge',
+) => ({ run_id: 42, status: 'running' })
+
+export const getConceptCandidates = async (
+  filters: { kind?: ConceptCandidateKind } = {},
+): Promise<ConceptCandidate[]> => {
+  const all = [mockBroadCandidate, mockCoOccurCandidate]
+  return filters.kind ? all.filter(c => c.kind === filters.kind) : all
+}
+
+export const getConceptRipe = async (): Promise<RipeSignal> => ({
+  ripe: true, pool_size: 87, drift_value: 1.0, reasons: ['ok'],
+})
+
+export const acceptConceptCandidate = async (id: number) =>
+  ({ candidate_id: id, created_label_id: 999, applied_count: 2 })
+
+export const dismissConceptCandidate = async (_id: number, _reason?: string) =>
+  ({ ok: true as const })
+
+export const noteConceptCandidate = async (_id: number) =>
+  ({ ok: true as const })
+
+export const makeLabelFromCandidate = async (id: number) =>
+  ({ candidate_id: id, created_label_id: 998 })
+
+export const suggestMergeFromCandidate = async (
+  _id: number, archive: number, keep: number,
+) => ({ archived_label_id: archive, kept_label_id: keep, retagged_count: 14 })
+
+export const getDiscoveryRuns = async (_limit: number): Promise<DiscoveryRun[]> => ([
+  {
+    id: 42, started_at: new Date().toISOString(),
+    completed_at: new Date().toISOString(),
+    query_kind: 'broad_label', trigger: 'manual',
+    drift_value_at_trigger: 1.0, pool_size_at_trigger: 87,
+    n_candidates: 3, error: null,
+  },
+])
+```
+
+- [ ] **Step 2: Run type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+---
+
+### Task 5.4: Update `DiscoverSection` with mode picker + ripeness pills
+
+**Files:**
+- Modify: `src/components/queue/DiscoverSection.tsx`
+- Test: `src/components/queue/DiscoverSection.test.tsx` (new or modify)
+
+- [ ] **Step 1: Read the current component**
+
+```bash
+cat src/components/queue/DiscoverSection.tsx
+```
+Note the existing structure: which props it takes, what state it owns, where it's rendered from.
+
+- [ ] **Step 2: Write a failing test**
+
+Create or extend `src/components/queue/DiscoverSection.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { DiscoverSection } from './DiscoverSection'
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getConceptRipe: vi.fn().mockResolvedValue({
+      ripe: true, pool_size: 87, drift_value: 1.0, reasons: ['ok'],
+    }),
+    discoverConcepts: vi.fn().mockResolvedValue({ run_id: 1, status: 'running' }),
+  },
+}))
+
+describe('DiscoverSection', () => {
+  it('renders both mode buttons when corpus has multi-labeled messages', () => {
+    render(<DiscoverSection multiLabeledCount={5} />)
+    expect(screen.getByRole('button', { name: /find missing labels/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /find label patterns/i })).toBeInTheDocument()
+  })
+
+  it('hides Mode B button when no multi-labeled messages exist', () => {
+    render(<DiscoverSection multiLabeledCount={0} />)
+    expect(screen.queryByRole('button', { name: /find label patterns/i }))
+      .not.toBeInTheDocument()
+  })
+
+  it('calls discoverConcepts with broad_label when Mode A clicked', async () => {
+    const { api } = await import('../../services/api')
+    render(<DiscoverSection multiLabeledCount={5} />)
+    await userEvent.click(screen.getByRole('button', { name: /find missing labels/i }))
+    expect(api.discoverConcepts).toHaveBeenCalledWith('broad_label', 'manual')
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify failure**
+
+```bash
+npm test -- DiscoverSection
+```
+
+- [ ] **Step 4: Implement the component**
+
+Replace the body of `DiscoverSection.tsx` with:
+
+```tsx
+import { useEffect, useState } from 'react'
+import { api } from '../../services/api'
+import type { RipeSignal, ConceptCandidateKind } from '../../types'
+
+type Props = {
+  multiLabeledCount: number
+  onRunStarted?: (kind: ConceptCandidateKind) => void
+}
+
+export function DiscoverSection({ multiLabeledCount, onRunStarted }: Props) {
+  const [ripe, setRipe] = useState<RipeSignal | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const sig = await api.getConceptRipe()
+        if (!cancelled) setRipe(sig)
+      } catch {/* ignore polling errors */}
+    }
+    tick()
+    const id = setInterval(tick, 30_000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [])
+
+  const fire = async (kind: ConceptCandidateKind) => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await api.discoverConcepts(kind, 'manual')
+      onRunStarted?.(kind)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const ripeForAny = ripe?.ripe === true
+
+  return (
+    <section aria-label="discover" className="flex flex-col gap-2 p-3">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => fire('broad_label')}
+          className="rounded bg-neutral-800 px-3 py-2 text-sm text-neutral-100 hover:bg-neutral-700"
+        >
+          Find missing labels
+          {ripeForAny && (
+            <span
+              aria-label="discovery is ripe"
+              title={
+                ripe ? `${ripe.pool_size} unlabeled messages • drift ${ripe.drift_value ?? '–'}` : ''
+              }
+              className="ml-2 inline-block h-2 w-2 rounded-full bg-emerald-400"
+            />
+          )}
+        </button>
+
+        {multiLabeledCount > 0 && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => fire('co_occurrence')}
+            className="rounded bg-neutral-800 px-3 py-2 text-sm text-neutral-100 hover:bg-neutral-700"
+          >
+            Find label patterns
+          </button>
+        )}
+      </div>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```bash
+npm test -- DiscoverSection
+```
+
+- [ ] **Step 6: Update existing usages**
+
+```bash
+grep -rn "DiscoverSection" src/ --include="*.tsx" --include="*.ts"
+```
+
+If callers pass props that no longer exist, update them to pass `multiLabeledCount` (which can be derived from existing label-count data on the queue page; pass `0` as a temporary value if the count isn't readily available — refining is part of Task 6.1).
+
+- [ ] **Step 7: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+---
+
+### Task 5.5: Update `DiscoverModal` with kind-discriminated cards
+
+**Files:**
+- Modify: `src/components/queue/DiscoverModal.tsx`
+- Test: `src/components/queue/DiscoverModal.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create or extend `src/components/queue/DiscoverModal.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { DiscoverModal } from './DiscoverModal'
+import type { ConceptCandidate } from '../../types'
+
+const broad: ConceptCandidate = {
+  id: 1, name: 'metacognition',
+  description: 'students reflecting on learning',
+  example_messages: [{ excerpt: 'am I doing this right?' }],
+  status: 'pending', source_run_id: '1', similar_to: null,
+  created_at: '', kind: 'broad_label',
+  evidence_message_ids: [{ chatlog_id: 1, message_index: 0 }],
+}
+
+const coOccur: ConceptCandidate = {
+  id: 2, name: 'code+confused',
+  description: 'overlap pattern',
+  example_messages: [], status: 'pending',
+  source_run_id: '1', similar_to: null,
+  created_at: '', kind: 'co_occurrence',
+  co_occurrence_label_ids: [10, 12], co_occurrence_count: 14,
+}
+
+vi.mock('../../services/api', () => ({
+  api: {
+    acceptConceptCandidate: vi.fn().mockResolvedValue({
+      candidate_id: 1, created_label_id: 999, applied_count: 1,
+    }),
+    dismissConceptCandidate: vi.fn().mockResolvedValue({ ok: true }),
+    noteConceptCandidate: vi.fn().mockResolvedValue({ ok: true }),
+    makeLabelFromCandidate: vi.fn().mockResolvedValue({
+      candidate_id: 2, created_label_id: 998,
+    }),
+  },
+}))
+
+describe('DiscoverModal', () => {
+  it('renders Accept & apply button on broad_label cards', () => {
+    render(<DiscoverModal candidates={[broad]} onClose={() => {}} />)
+    expect(screen.getByRole('button', { name: /accept & apply/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /make a combo label/i }))
+      .not.toBeInTheDocument()
+  })
+
+  it('renders combo-label / merge / note buttons on co_occurrence cards', () => {
+    render(<DiscoverModal candidates={[coOccur]} onClose={() => {}} />)
+    expect(screen.getByRole('button', { name: /make a combo label/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /suggest merge/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /note only/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /accept & apply/i })).not.toBeInTheDocument()
+  })
+
+  it('calls acceptConceptCandidate when Accept & apply is clicked', async () => {
+    const { api } = await import('../../services/api')
+    render(<DiscoverModal candidates={[broad]} onClose={() => {}} />)
+    await userEvent.click(screen.getByRole('button', { name: /accept & apply/i }))
+    expect(api.acceptConceptCandidate).toHaveBeenCalledWith(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- DiscoverModal
+```
+
+- [ ] **Step 3: Implement the modal**
+
+Replace the body of `DiscoverModal.tsx` with:
+
+```tsx
+import { useState } from 'react'
+import { api } from '../../services/api'
+import type { ConceptCandidate } from '../../types'
+
+type Props = {
+  candidates: ConceptCandidate[]
+  onClose: () => void
+  onCandidateChanged?: () => void
+}
+
+export function DiscoverModal({ candidates, onClose, onCandidateChanged }: Props) {
+  return (
+    <div role="dialog" aria-modal="true"
+         className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="max-h-[80vh] w-[680px] overflow-y-auto rounded-lg bg-neutral-900 p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-neutral-100">Discovery results</h2>
+          <button type="button" onClick={onClose}
+                  className="text-neutral-400 hover:text-neutral-200">×</button>
+        </div>
+        <div className="flex flex-col gap-3">
+          {candidates.map(c =>
+            c.kind === 'broad_label' ? (
+              <BroadLabelCard key={c.id} c={c} onChanged={onCandidateChanged} />
+            ) : (
+              <CoOccurrenceCard key={c.id} c={c} onChanged={onCandidateChanged} />
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function BroadLabelCard({
+  c, onChanged,
+}: { c: ConceptCandidate; onChanged?: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+
+  const accept = async () => {
+    setBusy(true)
+    try {
+      const r = await api.acceptConceptCandidate(c.id)
+      setToast(`Created '${c.name}' and applied to ${r.applied_count} messages as AI labels.`)
+      onChanged?.()
+    } finally { setBusy(false) }
+  }
+  const dismiss = async () => {
+    setBusy(true)
+    try { await api.dismissConceptCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+
+  return (
+    <article className="rounded border border-neutral-800 bg-neutral-950 p-3">
+      <header className="mb-1">
+        <h3 className="text-base font-medium text-neutral-100">{c.name}</h3>
+        <p className="text-sm text-neutral-400">{c.description}</p>
+      </header>
+      {c.example_messages.length > 0 && (
+        <ul className="mb-2 list-disc pl-5 text-sm text-neutral-300">
+          {c.example_messages.slice(0, 5).map((ex, i) =>
+            <li key={i}>"{ex.excerpt || ''}"</li>
+          )}
+        </ul>
+      )}
+      <div className="flex gap-2">
+        <button type="button" disabled={busy} onClick={accept}
+                className="rounded bg-emerald-700 px-3 py-1 text-sm text-white hover:bg-emerald-600">
+          Accept & apply
+        </button>
+        <button type="button" disabled={busy} onClick={dismiss}
+                className="rounded bg-neutral-800 px-3 py-1 text-sm text-neutral-200 hover:bg-neutral-700">
+          Dismiss
+        </button>
+      </div>
+      {toast && <p className="mt-2 text-xs text-emerald-400">{toast}</p>}
+      <footer className="mt-2 text-xs text-neutral-500">
+        run #{c.discovery_run_id ?? '?'} • {c.kind}
+      </footer>
+    </article>
+  )
+}
+
+function CoOccurrenceCard({
+  c, onChanged,
+}: { c: ConceptCandidate; onChanged?: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const ids = c.co_occurrence_label_ids ?? [0, 0]
+  const count = c.co_occurrence_count ?? 0
+
+  const note = async () => {
+    setBusy(true)
+    try { await api.noteConceptCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+  const makeLabel = async () => {
+    setBusy(true)
+    try { await api.makeLabelFromCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+  const dismiss = async () => {
+    setBusy(true)
+    try { await api.dismissConceptCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+  const suggestMerge = async () => {
+    // Minimal v1 UX: archive the lower id, keep the higher.
+    const [a, b] = ids
+    if (!a || !b) return
+    const archive = Math.min(a, b)
+    const keep = Math.max(a, b)
+    setBusy(true)
+    try {
+      await api.suggestMergeFromCandidate(c.id, archive, keep)
+      onChanged?.()
+    } finally { setBusy(false) }
+  }
+
+  return (
+    <article className="rounded border border-neutral-800 bg-neutral-950 p-3">
+      <header className="mb-1">
+        <h3 className="text-base font-medium text-neutral-100">
+          Pattern: <span className="font-normal">{c.name}</span>
+        </h3>
+        <p className="text-sm text-neutral-400">
+          Labels {ids[0]} + {ids[1]} co-occur on {count} messages
+        </p>
+        {c.description && <p className="mt-1 text-sm text-neutral-400">{c.description}</p>}
+      </header>
+      <div className="flex flex-wrap gap-2">
+        <button type="button" disabled={busy} onClick={makeLabel}
+                className="rounded bg-neutral-800 px-3 py-1 text-sm text-neutral-100 hover:bg-neutral-700">
+          Make a combo label
+        </button>
+        <button type="button" disabled={busy} onClick={suggestMerge}
+                className="rounded bg-neutral-800 px-3 py-1 text-sm text-neutral-100 hover:bg-neutral-700">
+          Suggest merge
+        </button>
+        <button type="button" disabled={busy} onClick={note}
+                className="rounded bg-neutral-800 px-3 py-1 text-sm text-neutral-100 hover:bg-neutral-700">
+          Note only
+        </button>
+        <button type="button" disabled={busy} onClick={dismiss}
+                className="rounded bg-neutral-800 px-3 py-1 text-sm text-neutral-200 hover:bg-neutral-700">
+          Dismiss
+        </button>
+      </div>
+      <footer className="mt-2 text-xs text-neutral-500">
+        run #{c.discovery_run_id ?? '?'} • {c.kind}
+      </footer>
+    </article>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- DiscoverModal
+```
+Expected: all card-kind tests pass.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+---
+
+### STOP — Phase 5 review
+
+Pause for user review and commit. Suggested commit message:
+
+```
+feat: mode-aware discover UI with ripeness signal
+
+Adds two-mode picker (broad labels / label patterns) on
+DiscoverSection, kind-discriminated cards on DiscoverModal,
+ripeness polling, and updated TypeScript types and mocks.
+```
+
+---
+
+## Phase 6 — Polling badge + cleanup
+
+### Task 6.1: Wire ripeness polling into the queue page
+
+**Files:**
+- Modify: `src/pages/QueuePage.tsx` (where `DiscoverSection` is rendered)
+
+- [ ] **Step 1: Compute `multiLabeledCount` on the queue page**
+
+Search QueuePage for where label-count data is loaded:
+
+```bash
+grep -n "labels\|labelDefinitions\|labelApplications" src/pages/QueuePage.tsx | head -20
+```
+
+If a count of "messages with ≥2 human labels" isn't already computed, derive it from the queue's existing label-application data, or expose it from the existing API helper. If not easily derivable, add a small `multi_labeled_count` field to the relevant existing endpoint (preferred), or fall back to passing `0` and adding a TODO note in the spec's Open Risks section.
+
+- [ ] **Step 2: Pass `multiLabeledCount` to DiscoverSection**
+
+```tsx
+<DiscoverSection
+  multiLabeledCount={multiLabeledCount}
+  onRunStarted={() => setShowDiscoverModal(true)}
+/>
+```
+
+- [ ] **Step 3: Confirm cleanup-on-unmount**
+
+The `useEffect` polling interval inside `DiscoverSection` (Task 5.4) already returns a cleanup that clears the interval. Verify by mounting and unmounting:
+
+```bash
+npm test -- DiscoverSection
+```
+
+- [ ] **Step 4: Type-check + build**
+
+```bash
+npx tsc --noEmit && npm run build
+```
+
+---
+
+### Task 6.2: Remove dead code from the old KMeans path
+
+**Files:**
+- Modify: `server/python/concept_service.py` (verify deletions from Phase 3 are complete)
+- Modify: `server/python/main.py` (remove the legacy `/api/concepts/embed-status` if it's truly unused; otherwise leave it)
+- Modify: `src/services/api.ts` (remove the legacy `getEmbedStatus` if no callers remain)
+
+- [ ] **Step 1: Confirm no callers of removed names**
+
+```bash
+grep -rn "_run_discover\b\|discover_concepts\b\|SUGGEST_TOOL\b\|_build_discovery_prompt\b\|_deduplicate_concepts\b" server/python/
+```
+Expected: no hits in non-test, non-deleted code. (Tests for the new path use different names.)
+
+- [ ] **Step 2: Remove unused frontend helpers**
+
+```bash
+grep -rn "getEmbedStatus\|getCandidates\b" src/ --include="*.ts" --include="*.tsx"
+```
+Remove any remaining references to the legacy names. Keep `embed_messages` in `concept_service.py` — it's still used by retrieval.
+
+- [ ] **Step 3: Verify all tests pass**
+
+```bash
+cd server/python && uv run pytest -v
+```
+
+```bash
+npm test
+```
+
+```bash
+npm run build
+```
+
+---
+
+### Task 6.3: End-to-end manual test
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Start the backend**
+
+```bash
+cd server/python && uv run uvicorn main:app --reload
+```
+
+- [ ] **Step 2: Start the frontend**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 3: Mode A walkthrough**
+
+1. Apply ~30 human labels to messages so the residual pool is meaningful.
+2. Open the Discover section. Confirm the **"Find missing labels"** button is visible. If recalibration is due (PR #36), confirm the green dot lights up.
+3. Click **Find missing labels**. Wait for the run to complete.
+4. Open the modal. Confirm at least one broad-label card appears with `Accept & apply` / `Dismiss` buttons (NOT the co-occurrence buttons).
+5. Click `Accept & apply`. Confirm the toast: *"Created 'X' and applied to N messages as AI labels."*
+6. Return to the queue. Confirm the new label is in the legend.
+7. Walk to one of the AI-applied messages. Confirm the label is shown with the AI provenance, and that toggling it off works (revertibility).
+
+- [ ] **Step 4: Mode B walkthrough**
+
+1. Confirm there are messages with ≥2 human labels in the corpus. If not, label a few accordingly.
+2. Open the Discover section. Confirm the **"Find label patterns"** button is visible.
+3. Click it. After the run, open the modal.
+4. Confirm a co-occurrence card appears with `Make a combo label` / `Suggest merge` / `Note only` / `Dismiss` (NOT the `Accept & apply` button).
+5. Click `Make a combo label`. Confirm a new label appears in the legend (no auto-apply expected).
+6. Click `Note only` on a different card. Confirm it disappears from the modal but no schema change occurs.
+
+- [ ] **Step 5: Verify instrumentation**
+
+```bash
+sqlite3 server/python/chatsight.db "SELECT id, query_kind, trigger, n_candidates, drift_value_at_trigger, pool_size_at_trigger FROM discoveryrun ORDER BY id DESC LIMIT 5;"
+```
+
+```bash
+sqlite3 server/python/chatsight.db "SELECT id, kind, decision, created_label_id, name FROM conceptcandidate ORDER BY id DESC LIMIT 10;"
+```
+
+Expected: rows for both runs, decisions populated for the candidates you acted on, `created_label_id` set on accepted candidates.
+
+---
+
+### STOP — Phase 6 review
+
+Pause for user review and commit. Suggested commit message:
+
+```
+feat: discovery ripeness badge + cleanup
+
+Wires ripeness polling on QueuePage with cleanup-on-unmount,
+removes dead KMeans-related code and unused legacy helpers,
+end-to-end verifies both Mode A and Mode B flows.
+```
+
+---
+
+## Out of scope reminder
+
+The following are explicitly deferred per the spec; do NOT implement in this rollout:
+
+- Replacing the legacy `status` and `source_run_id` columns on `ConceptCandidate`
+- Promoting the badge to an auto-trigger
+- Mode C (missing-axes query)
+- The "confirm-each" Variant C acceptance UX
+- A discovery-health UI panel

--- a/docs/superpowers/specs/2026-05-01-concept-induction-rag-design.md
+++ b/docs/superpowers/specs/2026-05-01-concept-induction-rag-design.md
@@ -1,0 +1,404 @@
+# Concept Induction Rework — RAG-Style Discovery Design
+
+**Date:** 2026-05-01
+**Branch:** `fix-induction`
+**Status:** Design approved; pending written-spec review before implementation plan
+**Source brief:** `docs/suggestions/D-concept-induction-rework.md`
+
+## Problem
+
+The current concept-induction feature (PR #32) embeds messages, runs KMeans, and asks Gemini to name each cluster. In practice the proposals come back **more specific than the label they were run against** — sub-categories, micro-labels, single-message specializations. That is the opposite of the workflow's intent: instructors want **broad labels applied in combination**, not narrow specializations. The feature exists but fights the grain of the labeling work.
+
+Concept induction is also the oldest AI-discovery piece in the schema and the only one not yet rethought against how instructors actually label.
+
+This document is the design contract for the rework. It resolves every tension in the source brief and is the input to the implementation plan that follows.
+
+## Decisions
+
+| Tension from brief | Decision |
+|---|---|
+| What to discover | **Mode A — Missing broad labels** (default) and **Mode B — Co-occurrence patterns** |
+| Where to look | A: messages with no human labels (AI-only applications still count as in-pool). B: messages with ≥2 human labels |
+| Granularity bias | Coverage-targeted retrieval over the residual set with max-min diversity selection. **No KMeans on the discovery path.** |
+| When to fire | On-demand only, with a "discovery is ripe" badge gated by drift signal (PR #36) + pool size. **Never auto-fires.** |
+| What instructor does | Mode A: accept auto-creates a `LabelDefinition` and auto-applies as `applied_by="ai"`, low confidence. Mode B: note-only ("make a combo label" / "suggest merge" / "dismiss") |
+| Measuring useful | Per-candidate decision fields + new `DiscoveryRun` table. No UI dashboard in v1. |
+
+## Framing — RAG-style discovery
+
+Three roles compose into one pipeline, parameterized by mode:
+
+```
+                        ┌─────────────────┐
+   Trigger              │   query_kind    │
+   (manual / badge)     └────────┬────────┘
+                                 │
+              ┌──────────────────┴───────────────────┐
+              │                                      │
+       Mode A — broad labels                Mode B — co-occurrence
+              │                                      │
+      ┌───────▼────────┐                    ┌────────▼─────────┐
+      │   RETRIEVE     │                    │     RETRIEVE     │
+      │  residual_set  │                    │  co_occur_pairs  │
+      │ (max-min div.) │                    │   (≥ min_count)  │
+      └───────┬────────┘                    └────────┬─────────┘
+              │                                      │
+      ┌───────▼────────┐                    ┌────────▼─────────┐
+      │   AUGMENT      │                    │     AUGMENT      │
+      │  + schema      │                    │  + label defs    │
+      │  + style hints │                    │  + co-occur      │
+      │  + rejected    │                    │    counts        │
+      └───────┬────────┘                    └────────┬─────────┘
+              │                                      │
+      ┌───────▼────────┐                    ┌────────▼─────────┐
+      │   GENERATE     │                    │     GENERATE     │
+      │ broad labels   │                    │ combo proposals  │
+      │ (function-call)│                    │  (function-call) │
+      └───────┬────────┘                    └────────┬─────────┘
+              │                                      │
+      ┌───────▼────────┐                    ┌────────▼─────────┐
+      │ ConceptCandid. │                    │  ConceptCandid.  │
+      │ kind="broad_   │                    │  kind="co_       │
+      │   label"       │                    │    occurrence"   │
+      └────────────────┘                    └──────────────────┘
+```
+
+Retrieval and generation are pure functions in separate modules. `discover()` is the only orchestrator. KMeans is removed entirely from the discovery path.
+
+## Architecture
+
+### Module layout
+
+- `server/python/concept_retrieval.py` — **new**. Pure NumPy + SQL. No Gemini calls (except the deterministic embedding model). No DB writes.
+- `server/python/concept_generation.py` — **new**. Owns Gemini prompts and tool schemas for both modes.
+- `server/python/concept_service.py` — **rewritten**. Becomes a thin orchestrator. Old KMeans path deleted.
+
+### `concept_retrieval.py`
+
+```python
+def thinly_labeled_pool(db) -> list[Message]:
+    """Mode A corpus: messages with zero human LabelApplications.
+       AI-only applications do not count as labeled, since the
+       point of discovery is to find what the schema (instructor
+       intent) doesn't yet cover. Excludes messages with at least
+       one applied_by='human' LabelApplication."""
+
+def retrieve_residual(
+    db, threshold: float = 0.55, target_size: int = 80
+) -> list[Message]:
+    """Mode A retrieval. Score each pool message by max cosine similarity
+       to any active LabelDefinition embedding. Keep messages whose max
+       similarity is below `threshold` (the residual: schema's blind spot).
+       Run max-min diversity selection over residual embeddings to pick
+       `target_size` messages that span the residual."""
+
+def retrieve_co_occurrence(
+    db, min_count: int = 8
+) -> list[CoOccurrencePair]:
+    """Mode B retrieval. Aggregate human LabelApplications by
+       (chatlog_id, message_index). For each unordered pair of
+       LabelDefinitions, count co-occurrences. Return pairs with
+       count >= min_count, with example message excerpts."""
+
+def select_diverse(vectors: np.ndarray, k: int) -> list[int]:
+    """Greedy max-min farthest-point sampling. No clustering.
+       Seed with random vector, iteratively add the vector whose
+       minimum distance to already-selected vectors is largest."""
+```
+
+Granularity-bias fix lives here: messages reach the LLM as a **diverse spread**, not a centroid-tight neighborhood. Narrow labels cannot span the spread, so the prompt naturally elicits broader proposals.
+
+### `concept_generation.py`
+
+```python
+def generate_broad_labels(
+    retrieved: list[Message],
+    existing_labels: list[LabelDefinition],
+    rejected_names: list[str],
+) -> list[ConceptDraft]:
+    """Mode A. Single Gemini function call. Prompt emphasizes BREADTH:
+       - retrieved messages span semantic space (not a tight neighborhood)
+       - explicit instruction: "a useful label here covers ≥15% of these
+         messages and is meant to co-apply with existing labels"
+       - constraint: must be distinct from existing, not in rejected list
+       - tool returns: name, description, evidence_message_ids"""
+
+def generate_co_occurrence_concepts(
+    pairs: list[CoOccurrencePair],
+    existing_labels: list[LabelDefinition],
+) -> list[ConceptDraft]:
+    """Mode B. For each frequent pair, ask Gemini whether the
+       combination represents a coherent third concept worth its own
+       label, OR is essentially a redundancy worth merging, OR is just
+       two independent things that happen to co-occur. Returns drafts
+       with one of three suggested resolutions."""
+```
+
+### `concept_service.py`
+
+```python
+def discover(db, query_kind: str, trigger: str) -> DiscoveryRun:
+    """Orchestrator. Creates a DiscoveryRun row, dispatches to the
+       right retrieval+generation path, persists ConceptCandidate rows
+       referencing the run, sets run.completed_at and run.n_candidates.
+       Errors are caught and stored in run.error; the run is always
+       finalized."""
+
+def is_discovery_ripe(db) -> RipeSignal:
+    """Computes pool size and reads the PR #36 drift signal.
+       Returns ripe=True only when both pass thresholds.
+       Cheap; safe to poll on a 30s cadence."""
+
+def accept_broad_label(candidate_id: int, db) -> AcceptResult:
+    """Mode A acceptance: creates a LabelDefinition from the candidate,
+       auto-applies it to evidence_message_ids with applied_by='ai',
+       confidence=0.6. Sets candidate.decision='accept',
+       candidate.created_label_id, candidate.decided_at."""
+```
+
+## Schema changes
+
+Three changes to `server/python/models.py`. SQLite + `SQLModel.metadata.create_all` handles the new table; the existing startup migration block in `main.py` adds new columns to `ConceptCandidate` if missing. No destructive migration; existing rows remain valid.
+
+### New: `DiscoveryRun`
+
+```python
+class DiscoveryRun(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    completed_at: Optional[datetime] = None
+    query_kind: str                          # "broad_label" | "co_occurrence"
+    trigger: str                             # "manual" | "badge"
+    drift_value_at_trigger: Optional[float]  # null on Mode B or pre-#36 history
+    pool_size_at_trigger: int                # |corpus| at trigger time
+    n_candidates: int = 0                    # populated on completion
+    error: Optional[str] = None
+```
+
+### Extended: `ConceptCandidate`
+
+New nullable columns appended; legacy columns kept for backwards compat.
+
+```python
+kind: str = "broad_label"                                    # "broad_label" | "co_occurrence"
+discovery_run_id: Optional[int] = Field(default=None,
+                                          foreign_key="discoveryrun.id")
+shown_at: Optional[datetime] = None
+decided_at: Optional[datetime] = None
+decision: Optional[str] = None                               # accept | reject | dismiss | suggest_merge | note
+created_label_id: Optional[int] = Field(default=None,
+                                          foreign_key="labeldefinition.id")
+evidence_message_ids: Optional[str] = None                   # JSON: [{"chatlog_id": int, "message_index": int}]
+co_occurrence_label_ids: Optional[str] = None                # JSON: [int, int] (Mode B only)
+co_occurrence_count: Optional[int] = None                    # Mode B only
+```
+
+Legacy `status` and `source_run_id` columns remain for older rows; new code reads/writes `decision` and `discovery_run_id` only.
+
+### Unchanged
+
+`LabelApplication`, `LabelDefinition`, `MessageEmbedding`, `LabelingSession`, `SkippedMessage`, `MessageCache`. The existing `applied_by="ai"` + `confidence` fields on `LabelApplication` are exactly what Mode A's auto-apply needs.
+
+## API endpoints
+
+Routes added/modified in `server/python/main.py`. Existing background-thread pattern (`_discover_status` global) is preserved and extended to include `query_kind` so concurrent runs of different modes still 409.
+
+### Modified
+
+```
+POST /api/concepts/discover
+  body: { query_kind: "broad_label" | "co_occurrence",
+          trigger: "manual" | "badge" }
+  → { run_id: int, status: "running" }
+
+GET  /api/concepts/candidates?run_id=&kind=&decision=
+  → list of ConceptCandidate including new fields
+```
+
+### New
+
+```
+GET  /api/concepts/ripe
+  → { ripe: bool, pool_size: int, drift_value: float | null,
+      reasons: ["pool_below_threshold" | "drift_low" | "ok"] }
+
+POST /api/concepts/candidates/{id}/accept           # Mode A
+  body: {}
+  → { candidate_id, created_label_id, applied_count }
+
+POST /api/concepts/candidates/{id}/dismiss
+  body: { reason?: string }
+  → { ok: true }
+
+POST /api/concepts/candidates/{id}/note             # Mode B
+  → { ok: true }
+
+POST /api/concepts/candidates/{id}/make-label       # Mode B
+  → { candidate_id, created_label_id }              # no auto-apply
+
+POST /api/concepts/candidates/{id}/suggest-merge    # Mode B
+  body: { archive_label_id: int, keep_label_id: int }
+  → { archived_label_id, kept_label_id, retagged_count }
+  Reuses the existing label-archive flow; no new merge logic.
+
+GET  /api/concepts/runs?limit=20
+  → list of DiscoveryRun rows
+```
+
+### Deprecated but kept
+
+```
+PUT  /api/concepts/candidates/{id}    # legacy generic status update
+GET  /api/concepts/embed-status
+```
+
+## Frontend
+
+Three surfaces. All in `src/`. The existing `DiscoverSection` and `DiscoverModal` are extended, not replaced.
+
+### Mode picker — `src/components/queue/DiscoverSection.tsx`
+
+- Two buttons: **"Find missing labels"** (Mode A) and **"Find label patterns"** (Mode B).
+- A small ripeness pill next to each button. Lit when `/api/concepts/ripe` returns `ripe: true` for that mode. Tooltip: *"Drift detected on 3 labels • 87 unlabeled messages ready"*.
+- Mode B button hidden until ≥2 messages have ≥2 human labels (otherwise the button has nothing to do).
+
+### Candidate cards — `src/components/queue/DiscoverModal.tsx`
+
+One modal, two card layouts driven by `candidate.kind`.
+
+**Broad-label card:**
+- Header: name, description.
+- Body: 3–5 evidence excerpts.
+- Actions: `Accept & apply` (primary) → calls `/accept` → toast: *"Created 'X' and applied to N messages as AI labels — visible in queue."* `Edit then accept` → opens inline rename/redescribe form, then `/accept`. `Dismiss` → `/dismiss`.
+
+**Co-occurrence card:**
+- Header: "**X** + **Y** appear together on **N** messages."
+- No primary action — co-occurrence is informational by design.
+- Actions: `Make a combo label` (opens inline form pre-seeded with `X+Y` as suggested name; calls `/make-label`). `Suggest merge` (opens chooser: which label to archive; calls `/suggest-merge`). `Note only` (calls `/note`). `Dismiss`.
+
+Both card types show the source `DiscoveryRun.id` and `query_kind` in a subtle footer for traceability.
+
+### Ripeness badge
+
+Pulsing dot on the Discover entry point in `ProgressSidebar` when `/api/concepts/ripe` returns `ripe: true` for *either* mode. Polled every 30s while the queue page is mounted; cleanup on unmount. Per-mode dots inside the modal say which mode is ripe.
+
+### Types — `src/types/index.ts`
+
+```ts
+type ConceptCandidate = {
+  // ...existing fields
+  kind: "broad_label" | "co_occurrence";
+  evidence_message_ids?: { chatlog_id: number; message_index: number }[];
+  co_occurrence_label_ids?: [number, number];
+  co_occurrence_count?: number;
+  created_label_id?: number;
+  decision?: "accept" | "reject" | "dismiss" | "suggest_merge" | "note";
+};
+
+type RipeSignal = {
+  ripe: boolean;
+  pool_size: number;
+  drift_value: number | null;
+  reasons: string[];
+};
+```
+
+### Mocks — `src/mocks/index.ts`
+
+Add fixtures for both `kind` values and a stub `/ripe` response so the frontend stays mock-runnable (`VITE_USE_MOCK=true`).
+
+### Unchanged
+
+Routing, the queue's main labeling flow, label management, history page. The discover surface is the only frontend touch point.
+
+## Rollout — six iterative phases
+
+Implementation runs sequentially in the main session. **No subagents, no parallel agents.** Each phase ends with an explicit stop where the user reviews and commits. No commits are created by Claude.
+
+### Phase 1 — Schema + DB scaffold
+
+- Add `DiscoveryRun` model. Extend `ConceptCandidate` with new nullable columns.
+- Update startup migration code in `main.py` to add columns to existing SQLite if missing.
+- Backend tests: model creation, columns nullable on old rows, FK integrity.
+
+**STOP — user reviews & commits** (suggested message: `feat: schema for RAG-style concept discovery`).
+
+### Phase 2 — Retrieval module
+
+- Build `concept_retrieval.py` with `thinly_labeled_pool`, `retrieve_residual`, `retrieve_co_occurrence`, `select_diverse`.
+- Tests with synthetic embeddings + fixture `LabelApplication` rows. No Gemini key needed.
+
+**STOP — user reviews & commits** (suggested message: `feat: retrieval primitives for concept discovery`).
+
+### Phase 3 — Generation module + orchestrator
+
+- Build `concept_generation.py` with both prompts and tool schemas.
+- Rewrite `concept_service.discover()` as the orchestrator. Delete the KMeans path.
+- Tests: stub Gemini client, verify prompt construction and persistence, verify error handling writes to `DiscoveryRun.error`.
+
+**STOP — user reviews & commits** (suggested message: `feat: RAG-style discovery orchestrator`).
+
+### Phase 4 — API endpoints
+
+- Add `/discover` (mode-aware), `/ripe`, `/accept`, `/dismiss`, `/note`, `/make-label`, `/suggest-merge`, `/runs`. Extend `/candidates`.
+- Implement `is_discovery_ripe` reading the PR #36 drift signal.
+- Tests: endpoint contracts, accept-applies-AI-labels behavior, suggest-merge reuses existing archive flow.
+
+**STOP — user reviews & commits** (suggested message: `feat: concept discovery API endpoints`).
+
+### Phase 5 — Frontend mode picker + candidate cards
+
+- Extend `DiscoverSection` with two-button mode picker + ripeness pills.
+- Extend `DiscoverModal` with kind-discriminated cards and per-kind action handlers.
+- Add `RipeSignal` and extended `ConceptCandidate` types.
+- Update `src/services/api.ts` with new endpoints. Update mocks.
+- Vitest tests for both card types.
+
+**STOP — user reviews & commits** (suggested message: `feat: mode-aware discover UI with ripeness signal`).
+
+### Phase 6 — Polling badge + cleanup
+
+- Wire ripeness polling on `QueuePage` with cleanup-on-unmount.
+- Remove dead code from old KMeans path.
+- End-to-end manual test: run a Mode A discovery, accept a candidate, verify AI labels appear in queue with revertibility. Run Mode B, make a combo label, verify it appears in legend.
+
+**STOP — user reviews & commits** (suggested message: `feat: discovery ripeness badge + cleanup`).
+
+## Success metrics
+
+All four signals from the brief's signalbox are derivable from data captured in Phase 1. No additional instrumentation is needed.
+
+| Signal | Computed as | Threshold |
+|---|---|---|
+| ≥1 accepted label applied to >10 messages | `count(LabelApplication)` grouped by `LabelDefinition.id` where `id IN (created_label_id from ConceptCandidate where decision='accept')`, max ≥ 10 | At least one accepted label crosses 10 within 2 weeks of acceptance |
+| Fewer near-duplicates on labels page | Pairwise cosine sim of `name + description` embeddings; count pairs above 0.85 | Trending down across runs vs. pre-rework baseline |
+| Schema trends broader, not narrower | Avg `LabelApplication` count per labeled message over time | Increases or holds steady; never declining |
+| Voluntary re-invocation | `DiscoveryRun` count grouped by session, `trigger='manual'` | ≥2 manual runs in a session for ≥1 instructor |
+
+### Drift-as-trigger experiment
+
+The brief asks whether drift is the right premise. The answer must be a *finding*, not a built-in assumption.
+
+- Compute acceptance rate per `DiscoveryRun.trigger`: `accepted / n_candidates` for `trigger='badge'` vs `trigger='manual'`.
+- Decision rule (after ≥10 runs):
+  - Badge runs have meaningfully higher acceptance → drift was useful → promote to auto-trigger in v2.
+  - Equal or lower → drift was noise → keep on-demand-only and remove the badge.
+
+### Read surface
+
+Direct SQL queries against `chatsight.db` during research check-ins. No dashboard in v1. (Adding visualization is unjustified until we know which numbers matter.)
+
+## Out of scope
+
+- Replacing the legacy `status` and `source_run_id` columns (deprecated but kept).
+- Promoting the badge to an auto-trigger (v2; gated by the experiment above).
+- Mode C — missing-axes query (the brief's "axes the schema isn't using" tension). v2 candidate; needs a different prompt and a different evaluation story.
+- The "confirm-each" Variant C acceptance UX — open inline mini-queue of evidence per acceptance.
+- A discovery-health UI panel.
+
+## Open risks
+
+- **Threshold choice for `retrieve_residual`.** The default `threshold=0.55` for max-cosine-similarity-to-any-label is a reasonable starting point but unvalidated against this corpus. Phase 6's manual end-to-end test should sanity-check that the residual set is non-empty at meaningful schema sizes; tune from there.
+- **`min_count=8` for co-occurrence may be too high in early sessions.** With <40 multi-labeled messages, almost no pairs cross 8. Acceptable; Mode B button is hidden until the pool is sufficient anyway.
+- **Drift signal coupling.** `is_discovery_ripe` reads PR #36's drift signal; if that signal's API changes, the ripeness badge needs updating. Mitigation: a single read-site, easy to follow.
+- **Auto-applied AI labels can pollute the corpus** if the model picks a low-quality candidate and the instructor isn't paying attention. Mitigation: low confidence (0.6) + visibility in the queue with revert affordance + the existing `applied_by="ai"` distinction in any analysis.

--- a/server/python/concept_generation.py
+++ b/server/python/concept_generation.py
@@ -1,0 +1,309 @@
+"""Gemini prompts and tool schemas for RAG-style concept discovery."""
+from __future__ import annotations
+import os
+from typing import Any, TypedDict
+
+from google import genai
+from google.genai import types
+
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+class ConceptDraft(TypedDict, total=False):
+    kind: str  # "broad_label" | "co_occurrence"
+    name: str
+    description: str
+    evidence_message_ids: list[dict[str, int]]
+    co_occurrence_label_ids: list[int]
+    co_occurrence_count: int
+    suggested_resolution: str  # for co_occurrence: "make_label" | "merge" | "independent"
+
+
+# ── Mode A: broad-label discovery ──────────────────────────────────
+
+BROAD_LABEL_TOOL = types.Tool(function_declarations=[
+    types.FunctionDeclaration(
+        name="suggest_broad_labels",
+        description="Propose broad, multi-label-friendly categories.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "concepts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "description": {"type": "string"},
+                            "evidence_message_indices": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "description": "0-indexed positions in the input list",
+                            },
+                        },
+                        "required": ["name", "description", "evidence_message_indices"],
+                    },
+                },
+            },
+            "required": ["concepts"],
+        },
+    )
+])
+
+BROAD_LABEL_CONFIG = types.GenerateContentConfig(
+    system_instruction=(
+        "You are an education researcher analyzing student-AI tutoring "
+        "conversations. The instructor labels messages with multiple BROAD "
+        "labels per message — labels are designed to combine, not to be "
+        "mutually exclusive. Your job is to find broad themes the schema "
+        "doesn't yet cover."
+    ),
+    temperature=0,
+    tools=[BROAD_LABEL_TOOL],
+    tool_config=types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["suggest_broad_labels"],
+        )
+    ),
+)
+
+
+def _build_broad_label_prompt(
+    retrieved: list[dict[str, Any]],
+    existing_labels: list[dict[str, str]],
+    rejected_names: list[str],
+) -> str:
+    parts: list[str] = []
+    parts.append("## Existing Labels (already in use — do NOT re-suggest)")
+    parts.append("These labels reflect the instructor's style and granularity.")
+    for l in existing_labels:
+        desc = f" — {l.get('description', '')}" if l.get("description") else ""
+        parts.append(f"- **{l['name']}**{desc}")
+
+    if rejected_names:
+        parts.append("\n## Previously Rejected (do NOT suggest)")
+        for name in rejected_names:
+            parts.append(f"- {name}")
+
+    parts.append("\n## Candidate Messages")
+    parts.append(
+        "These messages were retrieved as the SCHEMA'S BLIND SPOT — they "
+        "are deliberately diverse, NOT a tight cluster. Any single narrow "
+        "label cannot span this set."
+    )
+    parts.append("")
+    for i, m in enumerate(retrieved):
+        text = m["message_text"][:400]
+        parts.append(f"{i}. \"{text}\"")
+
+    parts.append("")
+    parts.append("## Task")
+    parts.append(
+        "Propose BROAD label categories. A useful proposal here:\n"
+        "- covers AT LEAST ~15% of the candidate messages above\n"
+        "- is meant to CO-APPLY with existing labels, not replace them\n"
+        "- is distinct from existing labels (different concept, not a rename)\n"
+        "- is named in the SAME style as existing labels (look at their format)\n\n"
+        "Do NOT propose narrow sub-categories. If a concept would only fit "
+        "one or two messages, skip it. Quality over quantity. It is fine to "
+        "return zero proposals if the retrieved set has no broad theme.\n\n"
+        "Reference each proposal's evidence by the 0-indexed message numbers "
+        "above. Call `suggest_broad_labels` with your proposals."
+    )
+    return "\n".join(parts)
+
+
+def generate_broad_labels(
+    retrieved: list[dict[str, Any]],
+    existing_labels: list[dict[str, Any]],
+    rejected_names: list[str],
+) -> list[ConceptDraft]:
+    """Single Gemini call. Returns drafts with evidence resolved back to
+    {chatlog_id, message_index} pairs (not the prompt-local indices)."""
+    if not retrieved:
+        return []
+    prompt = _build_broad_label_prompt(retrieved, existing_labels, rejected_names)
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=prompt,
+        config=BROAD_LABEL_CONFIG,
+    )
+
+    raw_concepts: list[dict[str, Any]] = []
+    for part in response.candidates[0].content.parts:
+        fc = getattr(part, "function_call", None)
+        if fc and fc.name == "suggest_broad_labels":
+            args = dict(fc.args)
+            raw_concepts = list(args.get("concepts", []))
+            break
+
+    drafts: list[ConceptDraft] = []
+    for c in raw_concepts:
+        evidence_ids: list[dict[str, int]] = []
+        for idx in c.get("evidence_message_indices", []) or []:
+            try:
+                idx_int = int(idx)
+            except (TypeError, ValueError):
+                continue
+            if 0 <= idx_int < len(retrieved):
+                m = retrieved[idx_int]
+                evidence_ids.append({
+                    "chatlog_id": m["chatlog_id"],
+                    "message_index": m["message_index"],
+                })
+        drafts.append({
+            "kind": "broad_label",
+            "name": c["name"],
+            "description": c.get("description", ""),
+            "evidence_message_ids": evidence_ids,
+        })
+    return drafts
+
+
+# ── Mode B: co-occurrence evaluation ───────────────────────────────
+
+CO_OCCURRENCE_TOOL = types.Tool(function_declarations=[
+    types.FunctionDeclaration(
+        name="evaluate_co_occurrence",
+        description=(
+            "Evaluate whether co-occurring label pairs deserve a combined "
+            "label, a merge, or are independent."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "evaluations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label_a_id": {"type": "integer"},
+                            "label_b_id": {"type": "integer"},
+                            "name": {
+                                "type": "string",
+                                "description": (
+                                    "If suggested_resolution=='make_label', "
+                                    "the proposed combo name; else empty."
+                                ),
+                            },
+                            "description": {"type": "string"},
+                            "suggested_resolution": {
+                                "type": "string",
+                                "enum": ["make_label", "merge", "independent"],
+                            },
+                        },
+                        "required": [
+                            "label_a_id", "label_b_id", "suggested_resolution",
+                        ],
+                    },
+                },
+            },
+            "required": ["evaluations"],
+        },
+    )
+])
+
+CO_OCCURRENCE_CONFIG = types.GenerateContentConfig(
+    system_instruction=(
+        "You are evaluating whether pairs of labels that frequently "
+        "co-occur represent (a) a coherent THIRD concept worth its own "
+        "label, (b) essentially the same thing under two names "
+        "(merge candidates), or (c) two genuinely independent things "
+        "that just happen to overlap. Be conservative — most pairs are "
+        "independent."
+    ),
+    temperature=0,
+    tools=[CO_OCCURRENCE_TOOL],
+    tool_config=types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["evaluate_co_occurrence"],
+        )
+    ),
+)
+
+
+def _build_co_occurrence_prompt(
+    pairs: list[dict[str, Any]],
+    existing_labels: list[dict[str, Any]],
+) -> str:
+    parts: list[str] = []
+    parts.append("## Existing Labels in the Schema")
+    for l in existing_labels:
+        desc = f" — {l.get('description', '')}" if l.get("description") else ""
+        parts.append(f"- (id={l.get('id', '?')}) **{l['name']}**{desc}")
+
+    parts.append("\n## Frequently Co-occurring Label Pairs")
+    for p in pairs:
+        parts.append(
+            f"- **{p['label_a_name']}** + **{p['label_b_name']}** "
+            f"co-occur on {p['count']} messages "
+            f"(label_a_id={p['label_a_id']}, label_b_id={p['label_b_id']})"
+        )
+
+    parts.append("\n## Task")
+    parts.append(
+        "For each pair, decide one of:\n"
+        "- `make_label`: the combination is a coherent third concept "
+        "worth its own broad label (rare; only when the combination "
+        "captures something neither label captures alone)\n"
+        "- `merge`: the two labels are nearly synonymous; keeping both "
+        "fragments the schema\n"
+        "- `independent`: the pair is just two real things that often "
+        "appear in the same message — no schema action needed\n\n"
+        "Default to `independent`. Only suggest `make_label` if you can "
+        "name the combined concept in the same style as existing labels. "
+        "Call `evaluate_co_occurrence` with one entry per pair."
+    )
+    return "\n".join(parts)
+
+
+def generate_co_occurrence_concepts(
+    pairs: list[dict[str, Any]],
+    existing_labels: list[dict[str, Any]],
+) -> list[ConceptDraft]:
+    """Single Gemini call across all pairs."""
+    if not pairs:
+        return []
+    prompt = _build_co_occurrence_prompt(pairs, existing_labels)
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=prompt,
+        config=CO_OCCURRENCE_CONFIG,
+    )
+
+    raw: list[dict[str, Any]] = []
+    for part in response.candidates[0].content.parts:
+        fc = getattr(part, "function_call", None)
+        if fc and fc.name == "evaluate_co_occurrence":
+            args = dict(fc.args)
+            raw = list(args.get("evaluations", []))
+            break
+
+    pair_lookup = {
+        tuple(sorted([p["label_a_id"], p["label_b_id"]])): p for p in pairs
+    }
+
+    drafts: list[ConceptDraft] = []
+    for ev in raw:
+        try:
+            a, b = int(ev["label_a_id"]), int(ev["label_b_id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        key = tuple(sorted([a, b]))
+        src = pair_lookup.get(key)
+        if not src:
+            continue
+        name = ev.get("name") or f"{src['label_a_name']}+{src['label_b_name']}"
+        drafts.append({
+            "kind": "co_occurrence",
+            "name": name,
+            "description": ev.get("description") or "",
+            "co_occurrence_label_ids": [a, b],
+            "co_occurrence_count": src["count"],
+            "suggested_resolution": ev.get("suggested_resolution", "independent"),
+            "evidence_message_ids": src.get("example_message_ids", []),
+        })
+    return drafts

--- a/server/python/concept_retrieval.py
+++ b/server/python/concept_retrieval.py
@@ -1,0 +1,220 @@
+"""Pure retrieval primitives for RAG-style concept discovery.
+
+No Gemini calls here except deterministic embeddings.
+No DB writes; only DB reads.
+"""
+from __future__ import annotations
+from typing import Any, TypedDict
+
+import numpy as np
+from sqlmodel import Session, select
+
+from models import (
+    LabelApplication,
+    LabelDefinition,
+    MessageCache,
+)
+
+
+class Message(TypedDict):
+    chatlog_id: int
+    message_index: int
+    message_text: str
+
+
+class CoOccurrencePair(TypedDict):
+    label_a_id: int
+    label_b_id: int
+    label_a_name: str
+    label_b_name: str
+    count: int
+    example_message_ids: list[dict[str, int]]
+
+
+def thinly_labeled_pool(db: Session) -> list[Message]:
+    """Mode A corpus: messages with NO human LabelApplications.
+
+    AI-only applications do not count as labeled — discovery's purpose
+    is to find what instructor intent doesn't yet cover.
+    """
+    human_labeled = {
+        (chatlog_id, message_index)
+        for chatlog_id, message_index in db.exec(
+            select(LabelApplication.chatlog_id, LabelApplication.message_index)
+            .where(LabelApplication.applied_by == "human")
+            .distinct()
+        ).all()
+    }
+
+    rows = db.exec(
+        select(
+            MessageCache.chatlog_id,
+            MessageCache.message_index,
+            MessageCache.message_text,
+        )
+    ).all()
+
+    return [
+        {
+            "chatlog_id": chatlog_id,
+            "message_index": message_index,
+            "message_text": message_text,
+        }
+        for chatlog_id, message_index, message_text in rows
+        if (chatlog_id, message_index) not in human_labeled
+    ]
+
+
+def select_diverse(vectors: np.ndarray, k: int) -> list[int]:
+    """Greedy max-min farthest-point sampling. No clustering.
+
+    Seed with index 0, then iteratively add the index whose minimum
+    distance to already-selected vectors is largest. Returns indices
+    in selection order. If k >= len(vectors), returns all indices in
+    selection order.
+    """
+    n = len(vectors)
+    if n == 0:
+        return []
+    k = min(k, n)
+    chosen = [0]
+    min_dists = np.linalg.norm(vectors - vectors[0], axis=1)
+    while len(chosen) < k:
+        # Mask already-chosen indices so they cannot be re-picked.
+        masked = min_dists.copy()
+        masked[chosen] = -1.0
+        next_idx = int(np.argmax(masked))
+        chosen.append(next_idx)
+        new_dists = np.linalg.norm(vectors - vectors[next_idx], axis=1)
+        min_dists = np.minimum(min_dists, new_dists)
+    return chosen
+
+
+def _normalize(vectors: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9
+    return vectors / norms
+
+
+def _embed_messages(messages: list[Message], db: Session) -> np.ndarray:
+    """Wrapper around the existing concept_service.embed_messages helper.
+
+    Imported lazily to avoid a circular import.
+    """
+    from concept_service import embed_messages
+    return embed_messages(messages, db)
+
+
+def _embed_label_definitions(
+    labels: list[LabelDefinition], db: Session,
+) -> np.ndarray:
+    """Embed `name: description` strings for each active label.
+
+    Not cached in MessageEmbedding (different content type); cheap
+    because label counts are small.
+    """
+    if not labels:
+        return np.zeros((0, 0), dtype=np.float32)
+    from concept_service import client, EMBED_MODEL
+    texts = [
+        f"{l.name}: {l.description or ''}".strip()
+        for l in labels
+    ]
+    result = client.models.embed_content(model=EMBED_MODEL, contents=texts)
+    return np.array([e.values for e in result.embeddings], dtype=np.float32)
+
+
+def retrieve_residual(
+    db: Session,
+    threshold: float = 0.55,
+    target_size: int = 80,
+) -> list[Message]:
+    """Mode A retrieval. Score each pool message by max cosine sim to any
+    active LabelDefinition embedding; keep messages whose max sim is
+    below `threshold`. Run max-min diversity selection on the residual
+    to pick `target_size` messages spanning it.
+    """
+    pool = thinly_labeled_pool(db)
+    if not pool:
+        return []
+
+    msg_vecs = _embed_messages(pool, db)
+
+    active_labels = list(
+        db.exec(
+            select(LabelDefinition).where(LabelDefinition.archived_at == None)  # noqa: E711
+        ).all()
+    )
+    label_vecs = _embed_label_definitions(active_labels, db)
+
+    if label_vecs.size == 0:
+        residual_indices = list(range(len(pool)))
+    else:
+        msg_normed = _normalize(msg_vecs)
+        label_normed = _normalize(label_vecs)
+        sim = msg_normed @ label_normed.T  # (n_msgs, n_labels)
+        max_sim = sim.max(axis=1)
+        residual_indices = [i for i, s in enumerate(max_sim) if s < threshold]
+
+    if not residual_indices:
+        return []
+
+    residual_vecs = msg_vecs[residual_indices]
+    diverse_local = select_diverse(residual_vecs, k=target_size)
+    chosen = [residual_indices[i] for i in diverse_local]
+    return [pool[i] for i in chosen]
+
+
+def retrieve_co_occurrence(
+    db: Session, min_count: int = 8,
+) -> list[CoOccurrencePair]:
+    """Mode B retrieval. Find pairs of human-applied labels that
+    co-occur on >= min_count messages. Returns pair rows with example
+    message keys.
+    """
+    rows = db.exec(
+        select(
+            LabelApplication.chatlog_id,
+            LabelApplication.message_index,
+            LabelApplication.label_id,
+        ).where(LabelApplication.applied_by == "human")
+    ).all()
+
+    by_msg: dict[tuple[int, int], set[int]] = {}
+    for chatlog_id, message_index, label_id in rows:
+        by_msg.setdefault((chatlog_id, message_index), set()).add(label_id)
+
+    pair_counts: dict[tuple[int, int], int] = {}
+    pair_examples: dict[tuple[int, int], list[dict[str, int]]] = {}
+    for msg_key, label_ids in by_msg.items():
+        ids = sorted(label_ids)
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                pk = (ids[i], ids[j])
+                pair_counts[pk] = pair_counts.get(pk, 0) + 1
+                pair_examples.setdefault(pk, []).append(
+                    {"chatlog_id": msg_key[0], "message_index": msg_key[1]}
+                )
+
+    active = {
+        l.id: l.name
+        for l in db.exec(
+            select(LabelDefinition).where(LabelDefinition.archived_at == None)  # noqa: E711
+        ).all()
+    }
+
+    out: list[CoOccurrencePair] = []
+    for (a_id, b_id), count in pair_counts.items():
+        if count < min_count:
+            continue
+        if a_id not in active or b_id not in active:
+            continue
+        out.append({
+            "label_a_id": a_id,
+            "label_b_id": b_id,
+            "label_a_name": active[a_id],
+            "label_b_name": active[b_id],
+            "count": count,
+            "example_message_ids": pair_examples[(a_id, b_id)][:5],
+        })
+    out.sort(key=lambda p: p["count"], reverse=True)
+    return out

--- a/server/python/concept_service.py
+++ b/server/python/concept_service.py
@@ -1,14 +1,24 @@
-import os
-import uuid
-import json
-import numpy as np
-from typing import List, Dict, Any
-from google import genai
-from google.genai import types
-from sqlmodel import Session, select
-from sklearn.cluster import KMeans
+"""Concept discovery orchestrator.
 
-from models import MessageEmbedding, ConceptCandidate, LabelDefinition
+embed_messages() is preserved for use by concept_retrieval. The
+old KMeans-based discover_concepts() pipeline has been removed in
+favor of the RAG-style discover() orchestrator below.
+"""
+import os
+import json
+from datetime import datetime
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from google import genai
+from sqlmodel import Session, func, select
+
+from models import (
+    ConceptCandidate, DiscoveryRun, LabelApplication, LabelDefinition,
+    MessageEmbedding,
+)
+
 
 client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
 
@@ -18,17 +28,16 @@ EMBED_BATCH_SIZE = 100  # Gemini API limit per call
 
 
 def embed_messages(
-    messages: List[Dict[str, Any]], db: Session
+    messages: List[Dict[str, Any]], db: Session,
 ) -> np.ndarray:
     """Embed messages, using cached embeddings where available.
 
     Each message dict must have: chatlog_id, message_index, message_text.
-    Returns numpy array of shape (len(messages), 768).
+    Returns a (len(messages), EMBED_DIM) float32 array.
     """
     vectors = np.zeros((len(messages), EMBED_DIM), dtype=np.float32)
     uncached_indices: List[int] = []
 
-    # Check cache
     for i, msg in enumerate(messages):
         cached = db.exec(
             select(MessageEmbedding).where(
@@ -45,7 +54,6 @@ def embed_messages(
     if not uncached_indices:
         return vectors
 
-    # Embed uncached in batches
     for batch_start in range(0, len(uncached_indices), EMBED_BATCH_SIZE):
         batch_idx = uncached_indices[batch_start : batch_start + EMBED_BATCH_SIZE]
         texts = [messages[i]["message_text"] for i in batch_idx]
@@ -58,7 +66,6 @@ def embed_messages(
         for j, idx in enumerate(batch_idx):
             vec = np.array(result.embeddings[j].values, dtype=np.float32)
             vectors[idx] = vec
-            # Cache
             row = MessageEmbedding(
                 chatlog_id=messages[idx]["chatlog_id"],
                 message_index=messages[idx]["message_index"],
@@ -71,255 +78,246 @@ def embed_messages(
     return vectors
 
 
-# ── Gemini concept suggestion tool ────────────────────────────────
+# ── RAG-style discovery orchestrator ───────────────────────────────
 
-SUGGEST_TOOL = types.Tool(function_declarations=[
-    types.FunctionDeclaration(
-        name="suggest_concepts",
-        description="Suggest new label categories for unlabeled student messages",
-        parameters={
-            "type": "object",
-            "properties": {
-                "concepts": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string", "description": "Short label name"},
-                            "description": {"type": "string", "description": "1-2 sentence definition"},
-                            "evidence": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                                "description": "2-3 representative message excerpts",
-                            },
-                            "cluster_ids": {
-                                "type": "array",
-                                "items": {"type": "integer"},
-                                "description": "Which cluster indices this concept spans",
-                            },
-                        },
-                        "required": ["name", "description", "evidence", "cluster_ids"],
-                    },
-                },
-            },
-            "required": ["concepts"],
-        },
-    )
-])
-
-SUGGEST_CONFIG = types.GenerateContentConfig(
-    system_instruction=(
-        "You are an education researcher analyzing student-AI tutoring conversations. "
-        "You are given groups of similar student messages that have NOT been labeled yet. "
-        "Your job is to propose new label categories that capture pedagogically meaningful patterns. "
-        "Only propose categories that are genuinely distinct from the existing labels provided. "
-        "Be precise and evidence-based."
-    ),
-    temperature=0,
-    tools=[SUGGEST_TOOL],
-    tool_config=types.ToolConfig(
-        function_calling_config=types.FunctionCallingConfig(
-            mode="ANY",
-            allowed_function_names=["suggest_concepts"],
-        )
-    ),
+from concept_retrieval import retrieve_residual, retrieve_co_occurrence
+from concept_generation import (
+    generate_broad_labels, generate_co_occurrence_concepts,
 )
 
 
-def _build_discovery_prompt(
-    samples_by_cluster: Dict[int, List[Dict[str, Any]]],
-    existing_labels: List[Dict[str, str]],
-    rejected_names: List[str],
-) -> str:
-    """Build the prompt for Gemini concept discovery."""
-    parts = []
-
-    parts.append("## Existing Labels (already in use — do NOT re-suggest these)")
-    parts.append("These labels reflect the instructor's labeling style. Study their naming conventions,")
-    parts.append("granularity, and thematic focus. Your suggestions MUST match this style.\n")
-    for label in existing_labels:
-        desc = f" — {label['description']}" if label.get("description") else ""
-        parts.append(f"- **{label['name']}**{desc}")
-
-    if rejected_names:
-        parts.append("\n## Previously Rejected (do NOT suggest these again)")
-        for name in rejected_names:
-            parts.append(f"- {name}")
-
-    parts.append("\n## Unlabeled Message Clusters")
-    parts.append("Each cluster contains similar messages that don't fit existing labels.\n")
-
-    for cluster_id, samples in samples_by_cluster.items():
-        parts.append(f"### Cluster {cluster_id}")
-        for s in samples:
-            text = s["message_text"][:300]
-            parts.append(f'- "{text}"')
-        parts.append("")
-
-    parts.append(
-        "## Task\n"
-        "Analyze these clusters and propose new label categories.\n\n"
-        "**Naming style:** Match the instructor's naming convention. Look at the existing labels —\n"
-        "if they use short lowercase phrases (e.g. 'code help', 'confused how to start'),\n"
-        "your names should follow the same format. Don't use title case or formal academic phrasing\n"
-        "unless the existing labels do.\n\n"
-        "**Thematic scope:** You are NOT limited to the same themes as existing labels.\n"
-        "If the existing labels focus on actions (e.g. 'code help', 'validation') but you notice\n"
-        "emotional, social, or metacognitive patterns in the clusters, propose those too.\n"
-        "New dimensions of student behavior are valuable — just use consistent naming style.\n\n"
-        "Each category should:\n"
-        "- Use the same naming style as existing labels\n"
-        "- Be pedagogically meaningful\n"
-        "- Be distinct from existing labels\n"
-        "- Reference specific message excerpts as evidence\n\n"
-        "Call the `suggest_concepts` tool with your proposed categories."
-    )
-
-    return "\n".join(parts)
+@dataclass
+class AcceptResult:
+    candidate_id: int
+    created_label_id: int
+    applied_count: int
 
 
-def _deduplicate_concepts(
-    concepts: List[Dict[str, Any]], threshold: float = 0.85
-) -> List[Dict[str, Any]]:
-    """Remove near-duplicate concepts using embedding cosine similarity.
+def _read_recalibration_due(db: Session) -> bool:
+    """Returns True if the PR #36 recalibration system says drift is up.
+    Lazily imports from main to avoid a top-level circular dependency."""
+    from main import _compute_recalibration_interval
+    from models import RecalibrationEvent, LabelingSession
 
-    Greedy: iterate in order, keep a concept only if its max similarity
-    to all previously kept concepts is below threshold.
-    """
-    if len(concepts) <= 1:
-        return concepts
+    session_row = db.exec(
+        select(LabelingSession).order_by(LabelingSession.id.desc())
+    ).first()
+    if not session_row:
+        return False
 
-    texts = [f"{c['name']}: {c['description']}" for c in concepts]
-    result = client.models.embed_content(model=EMBED_MODEL, contents=texts)
-    vectors = np.array([e.values for e in result.embeddings], dtype=np.float32)
+    events = list(db.exec(
+        select(RecalibrationEvent).order_by(RecalibrationEvent.id.asc())
+    ).all())
+    interval = _compute_recalibration_interval(events)
+    cutoff = events[-1].created_at if events else session_row.started_at
 
-    norms = np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9
-    normed = vectors / norms
-
-    kept_indices: List[int] = [0]
-    for i in range(1, len(concepts)):
-        kept_vecs = normed[kept_indices]
-        sims = kept_vecs @ normed[i]
-        if float(np.max(sims)) < threshold:
-            kept_indices.append(i)
-
-    return [concepts[i] for i in kept_indices]
-
-
-def discover_concepts(
-    messages: List[Dict[str, Any]],
-    db: Session,
-    n_clusters: int = 8,
-    sample_per_cluster: int = 5,
-) -> List[ConceptCandidate]:
-    """Embed, cluster, sample, and ask Gemini to propose new label categories.
-
-    Each message dict must have: chatlog_id, message_index, message_text.
-    Returns list of ConceptCandidate rows (already saved to DB).
-    """
-    if len(messages) < 5:
-        return []
-
-    # 1. Embed
-    vectors = embed_messages(messages, db)
-
-    # 2. Cluster
-    k = min(n_clusters, len(messages) // 5)
-    k = max(k, 2)
-    kmeans = KMeans(n_clusters=k, random_state=42, n_init=10)
-    labels = kmeans.fit_predict(vectors)
-
-    # 3. Sample nearest-to-centroid from each cluster
-    samples_by_cluster: Dict[int, List[Dict[str, Any]]] = {}
-    for cluster_id in range(k):
-        mask = labels == cluster_id
-        if not mask.any():
-            continue
-        cluster_vectors = vectors[mask]
-        cluster_messages = [messages[i] for i in range(len(messages)) if labels[i] == cluster_id]
-        centroid = kmeans.cluster_centers_[cluster_id]
-        distances = np.linalg.norm(cluster_vectors - centroid, axis=1)
-        nearest_idx = np.argsort(distances)[:sample_per_cluster]
-        samples_by_cluster[cluster_id] = [cluster_messages[i] for i in nearest_idx]
-
-    # 4. Gather existing + rejected labels
-    existing = [
-        {"name": ld.name, "description": ld.description or ""}
-        for ld in db.exec(
-            select(LabelDefinition).where(LabelDefinition.archived_at == None)
-        ).all()
-    ]
-    rejected = [
-        cc.name for cc in db.exec(
-            select(ConceptCandidate).where(ConceptCandidate.status == "rejected")
-        ).all()
-    ]
-
-    # 5. Call Gemini
-    prompt = _build_discovery_prompt(samples_by_cluster, existing, rejected)
-    response = client.models.generate_content(
-        model="gemini-2.0-flash",
-        contents=prompt,
-        config=SUGGEST_CONFIG,
-    )
-
-    # 6. Parse response
-    concepts_raw: List[Dict[str, Any]] = []
-    for part in response.candidates[0].content.parts:
-        if part.function_call and part.function_call.name == "suggest_concepts":
-            args = dict(part.function_call.args)
-            concepts_raw = list(args.get("concepts", []))
-            break
-
-    # 6b. Deduplicate similar concepts
-    concepts_raw = _deduplicate_concepts(concepts_raw)
-
-    # 7. Compute similarity to existing labels
-    label_vectors = None
-    if existing:
-        label_texts = [f"{ld['name']}: {ld['description']}" for ld in existing]
-        label_embed_result = client.models.embed_content(
-            model=EMBED_MODEL,
-            contents=label_texts,
+    labeled_since = db.exec(
+        select(func.count()).select_from(
+            select(LabelApplication.chatlog_id, LabelApplication.message_index)
+            .where(LabelApplication.applied_by == "human")
+            .where(LabelApplication.created_at > cutoff)
+            .distinct()
+            .subquery()
         )
-        label_vectors = np.array(
-            [e.values for e in label_embed_result.embeddings], dtype=np.float32
+    ).one()
+    return labeled_since >= interval
+
+
+def _persist_drafts(
+    drafts: list[dict], run: DiscoveryRun, db: Session,
+) -> list[ConceptCandidate]:
+    out: list[ConceptCandidate] = []
+    for d in drafts:
+        cc = ConceptCandidate(
+            name=d["name"],
+            description=d.get("description", ""),
+            example_messages=json.dumps([{"excerpt": ""}]),  # legacy column
+            source_run_id=str(run.id),  # legacy column
+            kind=d["kind"],
+            discovery_run_id=run.id,
+            evidence_message_ids=(
+                json.dumps(d["evidence_message_ids"])
+                if d.get("evidence_message_ids") is not None else None
+            ),
+            co_occurrence_label_ids=(
+                json.dumps(d["co_occurrence_label_ids"])
+                if d.get("co_occurrence_label_ids") is not None else None
+            ),
+            co_occurrence_count=d.get("co_occurrence_count"),
         )
-
-    # 8. Save candidates with similarity
-    run_id = str(uuid.uuid4())[:8]
-    candidates: List[ConceptCandidate] = []
-    for c in concepts_raw:
-        nearest_label: str | None = None
-        if label_vectors is not None and c.get("cluster_ids"):
-            cids = [int(ci) for ci in c["cluster_ids"] if int(ci) < k]
-            if cids:
-                concept_vec = np.mean(
-                    [kmeans.cluster_centers_[ci] for ci in cids], axis=0
-                )
-                concept_norm = concept_vec / (np.linalg.norm(concept_vec) + 1e-9)
-                label_norms = label_vectors / (
-                    np.linalg.norm(label_vectors, axis=1, keepdims=True) + 1e-9
-                )
-                similarities = label_norms @ concept_norm
-                best_idx = int(np.argmax(similarities))
-                if similarities[best_idx] > 0.75:
-                    nearest_label = existing[best_idx]["name"]
-
-        example_data = [{"excerpt": e} for e in c.get("evidence", [])]
-        candidate = ConceptCandidate(
-            name=c["name"],
-            description=c["description"],
-            example_messages=json.dumps(example_data),
-            status="pending",
-            source_run_id=run_id,
-            similar_to=nearest_label,
-        )
-        db.add(candidate)
-        candidates.append(candidate)
-
+        db.add(cc)
+        out.append(cc)
     db.commit()
-    for candidate in candidates:
-        db.refresh(candidate)
+    for cc in out:
+        db.refresh(cc)
+    return out
 
-    return candidates
+
+def discover(
+    db: Session,
+    query_kind: str,
+    trigger: str,
+    *,
+    threshold: float = 0.55,
+    target_size: int = 80,
+    min_count: int = 8,
+) -> DiscoveryRun:
+    """Orchestrates one discovery run end-to-end. Always finalizes the
+    run (sets completed_at and either n_candidates or error)."""
+    run = DiscoveryRun(
+        query_kind=query_kind,
+        trigger=trigger,
+        pool_size_at_trigger=0,  # filled in below
+        drift_value_at_trigger=None,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    try:
+        try:
+            run.drift_value_at_trigger = (
+                1.0 if _read_recalibration_due(db) else 0.0
+            )
+        except Exception:
+            run.drift_value_at_trigger = None
+
+        if query_kind == "broad_label":
+            retrieved = retrieve_residual(
+                db, threshold=threshold, target_size=target_size,
+            )
+            run.pool_size_at_trigger = len(retrieved)
+            existing = [
+                {"name": l.name, "description": l.description or "", "id": l.id}
+                for l in db.exec(
+                    select(LabelDefinition).where(
+                        LabelDefinition.archived_at == None  # noqa: E711
+                    )
+                ).all()
+            ]
+            rejected = [
+                cc.name for cc in db.exec(
+                    select(ConceptCandidate).where(
+                        ConceptCandidate.decision == "reject"
+                    )
+                ).all()
+            ]
+            drafts = generate_broad_labels(retrieved, existing, rejected)
+        elif query_kind == "co_occurrence":
+            pairs = retrieve_co_occurrence(db, min_count=min_count)
+            run.pool_size_at_trigger = len(pairs)
+            existing = [
+                {"name": l.name, "description": l.description or "", "id": l.id}
+                for l in db.exec(
+                    select(LabelDefinition).where(
+                        LabelDefinition.archived_at == None  # noqa: E711
+                    )
+                ).all()
+            ]
+            drafts = generate_co_occurrence_concepts(pairs, existing)
+        else:
+            raise ValueError(f"unknown query_kind: {query_kind}")
+
+        candidates = _persist_drafts(drafts, run, db)
+        run.n_candidates = len(candidates)
+    except Exception as e:
+        run.error = str(e)
+    finally:
+        run.completed_at = datetime.utcnow()
+        db.add(run)
+        db.commit()
+        db.refresh(run)
+    return run
+
+
+def accept_broad_label(candidate_id: int, db: Session) -> AcceptResult:
+    """Mode A acceptance:
+    1. Create a LabelDefinition from the candidate.
+    2. Auto-apply it to evidence messages with applied_by='ai',
+       confidence=0.6.
+    3. Set candidate.decision='accept', decided_at, created_label_id.
+    """
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise ValueError(f"candidate {candidate_id} not found")
+    if cc.kind != "broad_label":
+        raise ValueError(
+            f"accept_broad_label requires kind='broad_label', got '{cc.kind}'"
+        )
+    if cc.decision in ("accept", "dismiss", "reject"):
+        raise ValueError(
+            f"candidate {candidate_id} already decided: {cc.decision}"
+        )
+
+    new_label = LabelDefinition(
+        name=cc.name, description=cc.description or None,
+    )
+    db.add(new_label)
+    db.commit()
+    db.refresh(new_label)
+
+    evidence: list[dict] = []
+    if cc.evidence_message_ids:
+        try:
+            evidence = json.loads(cc.evidence_message_ids)
+        except (TypeError, ValueError):
+            evidence = []
+
+    applied = 0
+    for ev in evidence:
+        try:
+            chatlog_id = int(ev["chatlog_id"])
+            message_index = int(ev["message_index"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        db.add(LabelApplication(
+            chatlog_id=chatlog_id,
+            message_index=message_index,
+            label_id=new_label.id,
+            applied_by="ai",
+            confidence=0.6,
+        ))
+        applied += 1
+
+    cc.decision = "accept"
+    cc.decided_at = datetime.utcnow()
+    cc.created_label_id = new_label.id
+    cc.status = "accepted"  # legacy column for backwards compat
+    db.add(cc)
+    db.commit()
+
+    return AcceptResult(
+        candidate_id=cc.id,
+        created_label_id=new_label.id,
+        applied_count=applied,
+    )
+
+
+def is_discovery_ripe(db: Session, min_pool: int = 30) -> dict:
+    """Returns a JSON-friendly ripeness signal. Cheap; safe to poll."""
+    from concept_retrieval import thinly_labeled_pool
+    pool = thinly_labeled_pool(db)
+    pool_size = len(pool)
+
+    drift_due = False
+    drift_value: Optional[float] = None
+    try:
+        drift_due = _read_recalibration_due(db)
+        drift_value = 1.0 if drift_due else 0.0
+    except Exception:
+        drift_value = None
+
+    reasons: list[str] = []
+    if pool_size < min_pool:
+        reasons.append("pool_below_threshold")
+    if not drift_due:
+        reasons.append("drift_low")
+    ripe = pool_size >= min_pool and drift_due
+    if ripe:
+        reasons = ["ok"]
+    return {
+        "ripe": ripe,
+        "pool_size": pool_size,
+        "drift_value": drift_value,
+        "reasons": reasons,
+    }

--- a/server/python/database.py
+++ b/server/python/database.py
@@ -8,6 +8,30 @@ load_dotenv()
 DATABASE_URL = "sqlite:///./chatsight.db"
 engine = create_engine(DATABASE_URL, echo=False)
 
+CONCEPT_CANDIDATE_NEW_COLUMNS: list[tuple[str, str]] = [
+    ("kind", "TEXT DEFAULT 'broad_label'"),
+    ("discovery_run_id", "INTEGER"),
+    ("shown_at", "DATETIME"),
+    ("decided_at", "DATETIME"),
+    ("decision", "TEXT"),
+    ("created_label_id", "INTEGER"),
+    ("evidence_message_ids", "TEXT"),
+    ("co_occurrence_label_ids", "TEXT"),
+    ("co_occurrence_count", "INTEGER"),
+]
+
+
+def migrate_concept_candidate_columns(conn) -> None:
+    """Add new RAG-discovery columns to conceptcandidate if missing.
+    Idempotent: safe to call repeatedly."""
+    from sqlalchemy import text, inspect
+    existing = {c["name"] for c in inspect(conn).get_columns("conceptcandidate")}
+    for name, ddl in CONCEPT_CANDIDATE_NEW_COLUMNS:
+        if name not in existing:
+            conn.execute(text(f"ALTER TABLE conceptcandidate ADD COLUMN {name} {ddl}"))
+    conn.commit()
+
+
 def create_db_and_tables():
     SQLModel.metadata.create_all(engine)
     # Migrate: add sort_order column if missing (added in task4 branch)
@@ -26,6 +50,8 @@ def create_db_and_tables():
         if "confidence" not in cols_la:
             conn.execute(text("ALTER TABLE labelapplication ADD COLUMN confidence FLOAT DEFAULT NULL"))
             conn.commit()
+        # Migrate: add RAG-discovery columns to conceptcandidate
+        migrate_concept_candidate_columns(conn)
         # Add indexes for fast lookups on (chatlog_id, message_index)
         conn.execute(text(
             "CREATE INDEX IF NOT EXISTS idx_labelapp_chatlog_msg "

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -830,10 +830,29 @@ def get_queue_stats(db: Session = Depends(get_session)):
     ).one()
     skipped_count = db.exec(select(func.count(SkippedMessage.id))).one()
     total = db.exec(select(func.count(MessageCache.id))).one() or 0
+
+    # Count messages with >= 2 active human labels (gates Mode B in UI).
+    multi_labeled_subq = (
+        select(
+            LabelApplication.chatlog_id,
+            LabelApplication.message_index,
+            func.count(LabelApplication.id).label("n"),
+        )
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelApplication.applied_by == "human")
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .group_by(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .subquery()
+    )
+    multi_labeled_count = db.exec(
+        select(func.count()).select_from(multi_labeled_subq)
+        .where(multi_labeled_subq.c.n >= 2)
+    ).one()
     return {
         "total_messages": total,
         "labeled_count": labeled_count,
         "skipped_count": skipped_count,
+        "multi_labeled_count": multi_labeled_count,
     }
 
 

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -18,7 +18,7 @@ from sqlalchemy.engine import Connection
 
 from database import create_db_and_tables, get_session, ext_engine, engine
 import json as json_mod
-from models import LabelDefinition, LabelApplication, LabelingSession, SkippedMessage, MessageCache, ConceptCandidate, SuggestionCache, RecalibrationEvent
+from models import LabelDefinition, LabelApplication, LabelingSession, SkippedMessage, MessageCache, ConceptCandidate, SuggestionCache, RecalibrationEvent, DiscoveryRun
 from schemas import (
     CreateLabelRequest, DeleteLabelResponse, UpdateLabelRequest, ApplyLabelRequest,
     ApplyBatchRequest, SkipMessageRequest, SuggestRequest, ConciseRequest, ConciseResponse,
@@ -29,6 +29,9 @@ from schemas import (
     DiscoverConceptsResponse, ConceptCandidateResponse, ResolveCandidateRequest, EmbedStatusResponse,
     LabelReviewResponse,
     RecalibrationItemResponse, SaveRecalibrationRequest, SaveRecalibrationResponse, RecalibrationStatsResponse,
+    StartDiscoverRequest, RipeSignalResponse, AcceptCandidateResponse, DismissRequest,
+    GenericOk, MakeLabelResponse, SuggestMergeRequest, SuggestMergeResponse,
+    DiscoveryRunResponse,
 )
 from sqlmodel import Session, select
 
@@ -1656,72 +1659,265 @@ def delete_label(
 
 # ── Concept Induction ──────────────────────────────────────────────
 
-_discover_status: dict = {"running": False, "run_id": None, "error": None}
+_discover_status: dict = {
+    "running": False, "run_id": None, "error": None, "query_kind": None,
+}
 
 
-def _run_discover():
-    """Background task: embed, cluster, and discover concepts."""
-    import uuid
-    from concept_service import discover_concepts
+def _run_discover(query_kind: str, trigger: str):
+    """Background task: dispatches to concept_service.discover()."""
+    from concept_service import discover
     from database import engine as local_engine
     global _discover_status
 
-    run_id = str(uuid.uuid4())[:8]
-    _discover_status = {"running": True, "run_id": run_id, "error": None}
-
     try:
         with Session(local_engine) as db:
-            # Get labeled (chatlog_id, message_index) pairs
-            labeled_keys = set()
-            for la in db.exec(select(LabelApplication)).all():
-                labeled_keys.add((la.chatlog_id, la.message_index))
-
-            # Get all messages from cache that are unlabeled
-            all_messages = []
-            for mc in db.exec(select(MessageCache)).all():
-                key = (mc.chatlog_id, mc.message_index)
-                if key not in labeled_keys:
-                    all_messages.append({
-                        "chatlog_id": mc.chatlog_id,
-                        "message_index": mc.message_index,
-                        "message_text": mc.message_text,
-                    })
-
-            if not all_messages:
-                _discover_status = {"running": False, "run_id": run_id, "error": "No unlabeled messages found"}
-                return
-
-            discover_concepts(all_messages, db)
-            _discover_status = {"running": False, "run_id": run_id, "error": None}
-
+            run = discover(db, query_kind=query_kind, trigger=trigger)
+            _discover_status = {
+                "running": False,
+                "run_id": str(run.id) if run.id is not None else None,
+                "error": run.error,
+                "query_kind": query_kind,
+            }
     except Exception as e:
-        _discover_status = {"running": False, "run_id": _discover_status.get("run_id"), "error": str(e)}
+        _discover_status = {
+            "running": False,
+            "run_id": _discover_status.get("run_id"),
+            "error": str(e),
+            "query_kind": query_kind,
+        }
 
 
 @app.post("/api/concepts/discover", response_model=DiscoverConceptsResponse)
-def start_discover():
+def start_discover(req: StartDiscoverRequest):
+    global _discover_status
     if _discover_status["running"]:
-        raise HTTPException(status_code=409, detail="Concept discovery already in progress")
-    thread = threading.Thread(target=_run_discover, daemon=True)
+        raise HTTPException(
+            status_code=409, detail="Concept discovery already in progress",
+        )
+    _discover_status = {
+        "running": True, "run_id": None, "error": None,
+        "query_kind": req.query_kind,
+    }
+    thread = threading.Thread(
+        target=_run_discover, args=(req.query_kind, req.trigger), daemon=True,
+    )
     thread.start()
-    return DiscoverConceptsResponse(run_id=_discover_status.get("run_id") or "starting", status="running")
+    return DiscoverConceptsResponse(run_id="starting", status="running")
+
+
+@app.get("/api/concepts/ripe", response_model=RipeSignalResponse)
+def get_concept_ripe(db: Session = Depends(get_session)):
+    from concept_service import is_discovery_ripe
+    return is_discovery_ripe(db)
+
+
+def _candidate_to_response(cc: ConceptCandidate) -> ConceptCandidateResponse:
+    return ConceptCandidateResponse(
+        id=cc.id,
+        name=cc.name,
+        description=cc.description or "",
+        example_messages=(
+            json_mod.loads(cc.example_messages) if cc.example_messages else []
+        ),
+        status=cc.status,
+        source_run_id=cc.source_run_id,
+        similar_to=cc.similar_to,
+        created_at=cc.created_at,
+        kind=cc.kind,
+        discovery_run_id=cc.discovery_run_id,
+        decision=cc.decision,
+        created_label_id=cc.created_label_id,
+        evidence_message_ids=(
+            json_mod.loads(cc.evidence_message_ids)
+            if cc.evidence_message_ids else None
+        ),
+        co_occurrence_label_ids=(
+            json_mod.loads(cc.co_occurrence_label_ids)
+            if cc.co_occurrence_label_ids else None
+        ),
+        co_occurrence_count=cc.co_occurrence_count,
+    )
 
 
 @app.get("/api/concepts/candidates", response_model=List[ConceptCandidateResponse])
-def get_candidates(db: Session = Depends(get_session)):
+def get_candidates(
+    run_id: Optional[int] = None,
+    kind: Optional[str] = None,
+    decision: Optional[str] = None,
+    db: Session = Depends(get_session),
+):
+    q = select(ConceptCandidate)
+    any_filter = run_id is not None or kind is not None or decision is not None
+    if run_id is not None:
+        q = q.where(ConceptCandidate.discovery_run_id == run_id)
+    if kind is not None:
+        q = q.where(ConceptCandidate.kind == kind)
+    if decision is not None:
+        q = q.where(ConceptCandidate.decision == decision)
+    if not any_filter:
+        # Backwards-compat default: only undecided/pending candidates.
+        q = q.where(ConceptCandidate.status == "pending")
+    rows = db.exec(q.order_by(ConceptCandidate.id.desc())).all()
+    return [_candidate_to_response(r) for r in rows]
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/accept",
+    response_model=AcceptCandidateResponse,
+)
+def post_accept_candidate(
+    candidate_id: int, db: Session = Depends(get_session),
+):
+    from concept_service import accept_broad_label
+    try:
+        result = accept_broad_label(candidate_id, db)
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+    return AcceptCandidateResponse(
+        candidate_id=result.candidate_id,
+        created_label_id=result.created_label_id,
+        applied_count=result.applied_count,
+    )
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/dismiss",
+    response_model=GenericOk,
+)
+def post_dismiss_candidate(
+    candidate_id: int, req: DismissRequest,
+    db: Session = Depends(get_session),
+):
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise HTTPException(status_code=404, detail="candidate not found")
+    cc.decision = "dismiss"
+    cc.decided_at = datetime.utcnow()
+    cc.status = "rejected"  # legacy
+    db.add(cc)
+    db.commit()
+    return GenericOk()
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/note",
+    response_model=GenericOk,
+)
+def post_note_candidate(
+    candidate_id: int, db: Session = Depends(get_session),
+):
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise HTTPException(status_code=404, detail="candidate not found")
+    if cc.kind != "co_occurrence":
+        raise HTTPException(
+            status_code=400,
+            detail="note requires kind='co_occurrence'",
+        )
+    cc.decision = "note"
+    cc.decided_at = datetime.utcnow()
+    db.add(cc)
+    db.commit()
+    return GenericOk()
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/make-label",
+    response_model=MakeLabelResponse,
+)
+def post_make_label(
+    candidate_id: int, db: Session = Depends(get_session),
+):
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise HTTPException(status_code=404, detail="candidate not found")
+    if cc.kind != "co_occurrence":
+        raise HTTPException(
+            status_code=400,
+            detail="make-label requires kind='co_occurrence'",
+        )
+    new_label = LabelDefinition(
+        name=cc.name, description=cc.description or None,
+    )
+    db.add(new_label)
+    db.commit()
+    db.refresh(new_label)
+    cc.decision = "accept"
+    cc.decided_at = datetime.utcnow()
+    cc.created_label_id = new_label.id
+    cc.status = "accepted"
+    db.add(cc)
+    db.commit()
+    return MakeLabelResponse(
+        candidate_id=cc.id, created_label_id=new_label.id,
+    )
+
+
+@app.post(
+    "/api/concepts/candidates/{candidate_id}/suggest-merge",
+    response_model=SuggestMergeResponse,
+)
+def post_suggest_merge(
+    candidate_id: int, req: SuggestMergeRequest,
+    db: Session = Depends(get_session),
+):
+    cc = db.get(ConceptCandidate, candidate_id)
+    if cc is None:
+        raise HTTPException(status_code=404, detail="candidate not found")
+    if cc.kind != "co_occurrence":
+        raise HTTPException(
+            status_code=400,
+            detail="suggest-merge requires kind='co_occurrence'",
+        )
+    archive_label = db.get(LabelDefinition, req.archive_label_id)
+    keep_label = db.get(LabelDefinition, req.keep_label_id)
+    if archive_label is None or keep_label is None:
+        raise HTTPException(status_code=404, detail="label not found")
+    # Reuse the same retag-then-delete pattern as POST /api/labels/merge.
+    db.exec(
+        update(LabelApplication)
+        .where(LabelApplication.label_id == req.archive_label_id)
+        .values(label_id=req.keep_label_id)
+    )
+    retagged_count = db.exec(
+        select(func.count(LabelApplication.id)).where(
+            LabelApplication.label_id == req.keep_label_id
+        )
+    ).one()
+    db.delete(archive_label)
+    cc.decision = "suggest_merge"
+    cc.decided_at = datetime.utcnow()
+    db.add(cc)
+    db.commit()
+    return SuggestMergeResponse(
+        archived_label_id=req.archive_label_id,
+        kept_label_id=req.keep_label_id,
+        retagged_count=retagged_count,
+    )
+
+
+@app.get("/api/concepts/runs", response_model=List[DiscoveryRunResponse])
+def get_discovery_runs(
+    limit: int = 20, db: Session = Depends(get_session),
+):
     rows = db.exec(
-        select(ConceptCandidate).where(ConceptCandidate.status == "pending").order_by(ConceptCandidate.created_at)
+        select(DiscoveryRun).order_by(DiscoveryRun.id.desc()).limit(limit)
     ).all()
     return [
-        ConceptCandidateResponse(
+        DiscoveryRunResponse(
             id=r.id,
-            name=r.name,
-            description=r.description,
-            example_messages=json_mod.loads(r.example_messages),
-            status=r.status,
-            source_run_id=r.source_run_id,
-            similar_to=r.similar_to,
-            created_at=r.created_at,
+            started_at=r.started_at,
+            completed_at=r.completed_at,
+            query_kind=r.query_kind,
+            trigger=r.trigger,
+            drift_value_at_trigger=r.drift_value_at_trigger,
+            pool_size_at_trigger=r.pool_size_at_trigger,
+            n_candidates=r.n_candidates,
+            error=r.error,
         )
         for r in rows
     ]

--- a/server/python/models.py
+++ b/server/python/models.py
@@ -75,11 +75,29 @@ class ConceptCandidate(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
     description: str
-    example_messages: str  # JSON string
-    status: str = "pending"  # pending | accepted | rejected
-    source_run_id: str
+    example_messages: str  # JSON string (legacy column, retained)
+
+    # Legacy fields — retained for backwards compat with old rows
+    status: str = "pending"  # pending | accepted | rejected (legacy)
+    source_run_id: str  # legacy string-keyed run id
     similar_to: Optional[str] = Field(default=None)
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    # New RAG-discovery fields
+    kind: str = "broad_label"  # "broad_label" | "co_occurrence"
+    discovery_run_id: Optional[int] = Field(
+        default=None, foreign_key="discoveryrun.id"
+    )
+    shown_at: Optional[datetime] = None
+    decided_at: Optional[datetime] = None
+    decision: Optional[str] = None  # accept | reject | dismiss | suggest_merge | note
+    created_label_id: Optional[int] = Field(
+        default=None, foreign_key="labeldefinition.id"
+    )
+    evidence_message_ids: Optional[str] = None  # JSON list of {chatlog_id, message_index}
+    co_occurrence_label_ids: Optional[str] = None  # JSON [int, int]
+    co_occurrence_count: Optional[int] = None
 
 
 class SuggestionCache(SQLModel, table=True):
@@ -91,3 +109,15 @@ class SuggestionCache(SQLModel, table=True):
     rationale: str
     labels_hash: str  # hash of all active label names; invalidated when labels change
     created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class DiscoveryRun(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    completed_at: Optional[datetime] = None
+    query_kind: str  # "broad_label" | "co_occurrence"
+    trigger: str  # "manual" | "badge"
+    drift_value_at_trigger: Optional[float] = None
+    pool_size_at_trigger: int
+    n_candidates: int = 0
+    error: Optional[str] = None

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -1,6 +1,6 @@
 # server/python/schemas.py
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional, Tuple
 from pydantic import BaseModel
 
 
@@ -164,6 +164,11 @@ class ChatlogResponse(BaseModel):
 
 # ── Concept Induction ──────────────────────────────────────────────
 
+class StartDiscoverRequest(BaseModel):
+    query_kind: Literal["broad_label", "co_occurrence"]
+    trigger: Literal["manual", "badge"] = "manual"
+
+
 class DiscoverConceptsResponse(BaseModel):
     run_id: str
     status: str  # "running"
@@ -178,6 +183,63 @@ class ConceptCandidateResponse(BaseModel):
     source_run_id: str
     similar_to: Optional[str] = None
     created_at: datetime
+    # New RAG-discovery fields
+    kind: str = "broad_label"
+    discovery_run_id: Optional[int] = None
+    decision: Optional[str] = None
+    created_label_id: Optional[int] = None
+    evidence_message_ids: Optional[List[dict]] = None
+    co_occurrence_label_ids: Optional[List[int]] = None
+    co_occurrence_count: Optional[int] = None
+
+
+class RipeSignalResponse(BaseModel):
+    ripe: bool
+    pool_size: int
+    drift_value: Optional[float] = None
+    reasons: List[str]
+
+
+class AcceptCandidateResponse(BaseModel):
+    candidate_id: int
+    created_label_id: int
+    applied_count: int
+
+
+class DismissRequest(BaseModel):
+    reason: Optional[str] = None
+
+
+class GenericOk(BaseModel):
+    ok: bool = True
+
+
+class MakeLabelResponse(BaseModel):
+    candidate_id: int
+    created_label_id: int
+
+
+class SuggestMergeRequest(BaseModel):
+    archive_label_id: int
+    keep_label_id: int
+
+
+class SuggestMergeResponse(BaseModel):
+    archived_label_id: int
+    kept_label_id: int
+    retagged_count: int
+
+
+class DiscoveryRunResponse(BaseModel):
+    id: int
+    started_at: datetime
+    completed_at: Optional[datetime] = None
+    query_kind: str
+    trigger: str
+    drift_value_at_trigger: Optional[float] = None
+    pool_size_at_trigger: int
+    n_candidates: int
+    error: Optional[str] = None
 
 
 class ResolveCandidateRequest(BaseModel):

--- a/server/python/tests/test_concept_endpoints.py
+++ b/server/python/tests/test_concept_endpoints.py
@@ -1,6 +1,10 @@
 """Tests for concept induction API endpoints."""
 import json
-from models import ConceptCandidate, LabelDefinition
+from datetime import datetime
+from models import (
+    ConceptCandidate, LabelDefinition, LabelApplication, MessageCache,
+    DiscoveryRun,
+)
 from sqlmodel import select
 
 
@@ -126,3 +130,235 @@ def test_embed_status(client):
     assert "cached" in data
     assert "total_unlabeled" in data
     assert "running" in data
+
+
+# ── New RAG-discovery endpoints ────────────────────────────────────
+
+
+def test_post_discover_rejects_unknown_query_kind(client):
+    resp = client.post("/api/concepts/discover", json={
+        "query_kind": "made_up", "trigger": "manual",
+    })
+    assert resp.status_code == 422
+
+
+def test_post_discover_rejects_unknown_trigger(client):
+    resp = client.post("/api/concepts/discover", json={
+        "query_kind": "broad_label", "trigger": "cosmic_ray",
+    })
+    assert resp.status_code == 422
+
+
+def test_get_ripe_returns_signal(client):
+    resp = client.get("/api/concepts/ripe")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "ripe" in body
+    assert "pool_size" in body
+    assert "drift_value" in body
+    assert "reasons" in body
+    assert isinstance(body["reasons"], list)
+
+
+def test_post_accept_creates_label_and_applies(client, session):
+    for i in range(2):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=2,
+    )
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+    cc = ConceptCandidate(
+        name="curious", description="curious students",
+        example_messages="[]", source_run_id=str(run.id),
+        kind="broad_label", discovery_run_id=run.id,
+        evidence_message_ids='[{"chatlog_id":1,"message_index":0}]',
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+
+    resp = client.post(f"/api/concepts/candidates/{cc.id}/accept", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["candidate_id"] == cc.id
+    assert body["created_label_id"] is not None
+    assert body["applied_count"] == 1
+
+
+def test_post_accept_404_for_unknown_candidate(client):
+    resp = client.post("/api/concepts/candidates/99999/accept", json={})
+    assert resp.status_code == 404
+
+
+def test_post_dismiss_sets_decision(client, session):
+    cc = ConceptCandidate(
+        name="x", description="", example_messages="[]",
+        source_run_id="r", kind="broad_label",
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+
+    resp = client.post(
+        f"/api/concepts/candidates/{cc.id}/dismiss",
+        json={"reason": "too narrow"},
+    )
+    assert resp.status_code == 200
+
+    session.expire_all()
+    refreshed = session.get(ConceptCandidate, cc.id)
+    assert refreshed.decision == "dismiss"
+    assert refreshed.decided_at is not None
+
+
+def test_post_note_only_for_co_occurrence(client, session):
+    cc_co = ConceptCandidate(
+        name="A+B", description="", example_messages="[]",
+        source_run_id="r", kind="co_occurrence",
+        co_occurrence_label_ids="[1,2]", co_occurrence_count=5,
+    )
+    cc_broad = ConceptCandidate(
+        name="x", description="", example_messages="[]",
+        source_run_id="r", kind="broad_label",
+    )
+    session.add_all([cc_co, cc_broad])
+    session.commit()
+    session.refresh(cc_co); session.refresh(cc_broad)
+
+    resp_ok = client.post(f"/api/concepts/candidates/{cc_co.id}/note", json={})
+    assert resp_ok.status_code == 200
+
+    resp_bad = client.post(f"/api/concepts/candidates/{cc_broad.id}/note", json={})
+    assert resp_bad.status_code == 400
+
+
+def test_post_make_label_creates_label(client, session):
+    cc = ConceptCandidate(
+        name="A+B", description="combo", example_messages="[]",
+        source_run_id="r", kind="co_occurrence",
+        co_occurrence_label_ids="[1,2]", co_occurrence_count=5,
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+
+    resp = client.post(f"/api/concepts/candidates/{cc.id}/make-label", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created_label_id"] is not None
+
+    label = session.exec(
+        select(LabelDefinition).where(LabelDefinition.id == body["created_label_id"])
+    ).one()
+    assert label.name == "A+B"
+    # No auto-apply: no LabelApplications for this label.
+    apps = session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == label.id)
+    ).all()
+    assert apps == []
+
+
+def test_post_suggest_merge_archives_and_retags(client, session):
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    session.add_all([label_a, label_b])
+    session.commit()
+    session.refresh(label_a); session.refresh(label_b)
+
+    session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label_a.id, applied_by="human",
+    ))
+    session.commit()
+
+    cc = ConceptCandidate(
+        name="A+B", description="", example_messages="[]",
+        source_run_id="r", kind="co_occurrence",
+        co_occurrence_label_ids=f"[{label_a.id},{label_b.id}]",
+        co_occurrence_count=1,
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+
+    resp = client.post(
+        f"/api/concepts/candidates/{cc.id}/suggest-merge",
+        json={"archive_label_id": label_a.id, "keep_label_id": label_b.id},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["archived_label_id"] == label_a.id
+    assert body["kept_label_id"] == label_b.id
+    assert body["retagged_count"] >= 1
+
+    session.expire_all()
+    # label_a deleted; label_b has the retagged application
+    assert session.get(LabelDefinition, label_a.id) is None
+    apps = session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == label_b.id)
+    ).all()
+    assert len(apps) == 1
+
+
+def test_get_candidates_includes_new_fields(client, session):
+    cc = ConceptCandidate(
+        name="x", description="", example_messages="[]",
+        source_run_id="r", kind="broad_label",
+        evidence_message_ids='[{"chatlog_id":1,"message_index":0}]',
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+
+    resp = client.get("/api/concepts/candidates")
+    assert resp.status_code == 200
+    rows = resp.json()
+    target = next(r for r in rows if r["id"] == cc.id)
+    assert target["kind"] == "broad_label"
+    assert target["evidence_message_ids"] == [
+        {"chatlog_id": 1, "message_index": 0}
+    ]
+    assert target.get("co_occurrence_label_ids") in (None, [])
+    assert "decision" in target
+
+
+def test_get_candidates_filters_by_kind_and_run_id(client, session):
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=0,
+    )
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+    cc1 = ConceptCandidate(
+        name="a", description="", example_messages="[]",
+        source_run_id=str(run.id), kind="broad_label", discovery_run_id=run.id,
+    )
+    cc2 = ConceptCandidate(
+        name="b", description="", example_messages="[]",
+        source_run_id=str(run.id), kind="co_occurrence", discovery_run_id=run.id,
+    )
+    session.add_all([cc1, cc2])
+    session.commit()
+    session.refresh(cc1); session.refresh(cc2)
+
+    resp = client.get(
+        f"/api/concepts/candidates?run_id={run.id}&kind=broad_label"
+    )
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    assert cc1.id in ids and cc2.id not in ids
+
+
+def test_get_runs_returns_recent(client, session):
+    for k in ("broad_label", "co_occurrence"):
+        session.add(DiscoveryRun(
+            query_kind=k, trigger="manual", pool_size_at_trigger=0,
+        ))
+    session.commit()
+
+    resp = client.get("/api/concepts/runs?limit=5")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) >= 2
+    assert all("query_kind" in r and "trigger" in r for r in rows)

--- a/server/python/tests/test_concept_generation.py
+++ b/server/python/tests/test_concept_generation.py
@@ -1,0 +1,113 @@
+"""Tests for concept_generation module — RAG-style prompts."""
+from unittest.mock import MagicMock
+
+
+def test_generate_broad_labels_resolves_evidence_back_to_message_ids(monkeypatch):
+    """Verify the prompt encodes breadth constraints, the function-call
+    response is parsed, and evidence indices are resolved back to
+    {chatlog_id, message_index} pairs."""
+    captured: dict = {}
+
+    fake_part = MagicMock()
+    fake_part.function_call.name = "suggest_broad_labels"
+    fake_part.function_call.args = {
+        "concepts": [
+            {
+                "name": "metacognition",
+                "description": "students reflecting on their own learning",
+                "evidence_message_indices": [0, 3],
+            }
+        ]
+    }
+    fake_response = MagicMock()
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+
+    def fake_generate(model=None, contents=None, config=None):
+        captured["prompt"] = contents
+        return fake_response
+
+    fake_client = MagicMock()
+    fake_client.models.generate_content.side_effect = fake_generate
+    monkeypatch.setattr("concept_generation.client", fake_client)
+
+    from concept_generation import generate_broad_labels
+
+    retrieved = [
+        {"chatlog_id": 1, "message_index": 0, "message_text": "I'm not sure if I get this"},
+        {"chatlog_id": 1, "message_index": 1, "message_text": "code didn't run"},
+        {"chatlog_id": 1, "message_index": 2, "message_text": "what does .loc do"},
+        {"chatlog_id": 1, "message_index": 3, "message_text": "am I doing this right"},
+    ]
+    drafts = generate_broad_labels(retrieved, existing_labels=[], rejected_names=[])
+
+    assert len(drafts) == 1
+    assert drafts[0]["kind"] == "broad_label"
+    assert drafts[0]["name"] == "metacognition"
+    assert {"chatlog_id": 1, "message_index": 0} in drafts[0]["evidence_message_ids"]
+    assert {"chatlog_id": 1, "message_index": 3} in drafts[0]["evidence_message_ids"]
+
+    # Prompt must include the breadth constraint.
+    prompt = captured["prompt"]
+    assert "co-apply" in prompt.lower() or "combine" in prompt.lower()
+    assert "broad" in prompt.lower()
+
+
+def test_broad_label_tool_schema_shape():
+    from concept_generation import BROAD_LABEL_TOOL
+    decl = BROAD_LABEL_TOOL.function_declarations[0]
+    assert decl.name == "suggest_broad_labels"
+    # The genai SDK wraps `parameters` as a Schema. Drill via attribute
+    # access rather than dict subscript.
+    concepts_schema = decl.parameters.properties["concepts"]
+    item_schema = concepts_schema.items
+    item_props = item_schema.properties
+    assert "name" in item_props
+    assert "description" in item_props
+    assert "evidence_message_indices" in item_props
+
+
+def test_generate_co_occurrence_returns_drafts(monkeypatch):
+    fake_part = MagicMock()
+    fake_part.function_call.name = "evaluate_co_occurrence"
+    fake_part.function_call.args = {
+        "evaluations": [
+            {
+                "label_a_id": 1, "label_b_id": 2,
+                "name": "stuck on code",
+                "description": "students who cannot run their code and feel stuck",
+                "suggested_resolution": "make_label",
+            }
+        ]
+    }
+    fake_response = MagicMock()
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+
+    fake_client = MagicMock()
+    fake_client.models.generate_content = MagicMock(return_value=fake_response)
+    monkeypatch.setattr("concept_generation.client", fake_client)
+
+    from concept_generation import generate_co_occurrence_concepts
+
+    pairs = [{
+        "label_a_id": 1, "label_b_id": 2,
+        "label_a_name": "code help", "label_b_name": "confused",
+        "count": 12,
+        "example_message_ids": [{"chatlog_id": 1, "message_index": 0}],
+    }]
+    drafts = generate_co_occurrence_concepts(pairs, existing_labels=[])
+
+    assert len(drafts) == 1
+    assert drafts[0]["kind"] == "co_occurrence"
+    assert drafts[0]["co_occurrence_label_ids"] == [1, 2]
+    assert drafts[0]["co_occurrence_count"] == 12
+    assert drafts[0]["suggested_resolution"] == "make_label"
+
+
+def test_co_occurrence_tool_schema_shape():
+    from concept_generation import CO_OCCURRENCE_TOOL
+    decl = CO_OCCURRENCE_TOOL.function_declarations[0]
+    assert decl.name == "evaluate_co_occurrence"
+    item_props = decl.parameters.properties["evaluations"].items.properties
+    assert {"label_a_id", "label_b_id", "suggested_resolution"} <= set(item_props)

--- a/server/python/tests/test_concept_models.py
+++ b/server/python/tests/test_concept_models.py
@@ -1,9 +1,9 @@
-"""Tests for MessageEmbedding and ConceptCandidate models."""
+"""Tests for MessageEmbedding, ConceptCandidate, and DiscoveryRun models."""
 import json
 import numpy as np
 from sqlmodel import select
 
-from models import MessageEmbedding, ConceptCandidate
+from models import MessageEmbedding, ConceptCandidate, DiscoveryRun, LabelDefinition
 
 
 def test_message_embedding_roundtrip(session):
@@ -51,3 +51,70 @@ def test_concept_candidate_roundtrip(session):
     examples = json.loads(loaded.example_messages)
     assert len(examples) == 1
     assert examples[0]["excerpt"] == "Let me try printing..."
+
+
+def test_concept_candidate_has_new_fields(session):
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=10
+    )
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+
+    label = LabelDefinition(name="example")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+
+    cc = ConceptCandidate(
+        name="curiosity",
+        description="student expressing curiosity",
+        example_messages="[]",
+        source_run_id="legacy",
+        kind="broad_label",
+        discovery_run_id=run.id,
+        evidence_message_ids='[{"chatlog_id": 1, "message_index": 0}]',
+        created_label_id=label.id,
+        decision="accept",
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+    assert cc.kind == "broad_label"
+    assert cc.discovery_run_id == run.id
+    assert cc.created_label_id == label.id
+    assert cc.decision == "accept"
+    assert cc.co_occurrence_label_ids is None
+    assert cc.co_occurrence_count is None
+
+
+def test_concept_candidate_legacy_fields_still_work(session):
+    cc = ConceptCandidate(
+        name="legacy",
+        description="legacy candidate without new fields",
+        example_messages="[]",
+        source_run_id="oldrun123",
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+    assert cc.kind == "broad_label"  # default
+    assert cc.discovery_run_id is None
+    assert cc.status == "pending"  # legacy column intact
+
+
+def test_discovery_run_can_be_created(session):
+    run = DiscoveryRun(
+        query_kind="broad_label",
+        trigger="manual",
+        pool_size_at_trigger=42,
+    )
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+    assert run.id is not None
+    assert run.started_at is not None
+    assert run.completed_at is None
+    assert run.n_candidates == 0
+    assert run.error is None
+    assert run.drift_value_at_trigger is None

--- a/server/python/tests/test_concept_retrieval.py
+++ b/server/python/tests/test_concept_retrieval.py
@@ -1,0 +1,174 @@
+"""Tests for the concept_retrieval module."""
+from datetime import datetime
+import numpy as np
+import pytest
+
+from concept_retrieval import (
+    select_diverse, thinly_labeled_pool, retrieve_residual,
+    retrieve_co_occurrence,
+)
+from models import MessageCache, LabelDefinition, LabelApplication
+
+
+def test_select_diverse_returns_k_indices():
+    rng = np.random.default_rng(0)
+    vectors = rng.normal(size=(20, 8)).astype(np.float32)
+    chosen = select_diverse(vectors, k=5)
+    assert len(chosen) == 5
+    assert len(set(chosen)) == 5  # no duplicates
+    assert all(0 <= i < 20 for i in chosen)
+
+
+def test_select_diverse_picks_far_apart_points():
+    # Three tight clusters of 5 points each; k=3 should pick one from each.
+    centers = np.array([[10.0, 0], [-10.0, 0], [0, 10.0]], dtype=np.float32)
+    chunks = [
+        centers[i] + np.random.RandomState(i).normal(scale=0.01, size=(5, 2))
+        for i in range(3)
+    ]
+    points = np.vstack(chunks).astype(np.float32)
+    chosen = select_diverse(points, k=3)
+    chosen_pts = points[chosen]
+    # All three picked points should be far from each other (>5 apart).
+    for i in range(3):
+        for j in range(i + 1, 3):
+            d = np.linalg.norm(chosen_pts[i] - chosen_pts[j])
+            assert d > 5, f"chosen points {i} and {j} are too close: {d}"
+
+
+def test_select_diverse_handles_k_geq_n():
+    vectors = np.eye(3, dtype=np.float32)
+    chosen = select_diverse(vectors, k=5)
+    # Cannot select more than n; returns all unique indices.
+    assert sorted(chosen) == [0, 1, 2]
+
+
+def test_thinly_labeled_pool_excludes_human_labeled(session):
+    # Three messages: human-labeled, AI-only-labeled, unlabeled.
+    for i, text in enumerate(["a", "b", "c"]):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=text))
+    label = LabelDefinition(name="L1")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+
+    # Message 0: human-applied (excluded from pool).
+    session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label.id,
+        applied_by="human", confidence=None,
+    ))
+    # Message 1: AI-applied only (still in pool).
+    session.add(LabelApplication(
+        chatlog_id=1, message_index=1, label_id=label.id,
+        applied_by="ai", confidence=0.5,
+    ))
+    session.commit()
+
+    pool = thinly_labeled_pool(session)
+    keys = {(m["chatlog_id"], m["message_index"]) for m in pool}
+    assert (1, 0) not in keys      # human-labeled — excluded
+    assert (1, 1) in keys          # AI-only — included
+    assert (1, 2) in keys          # unlabeled — included
+
+
+def test_retrieve_residual_filters_high_similarity_messages(session, monkeypatch):
+    """Messages whose embedding is close to an existing label are filtered out."""
+    for i in range(5):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+    label = LabelDefinition(name="LX", description="thing")
+    session.add(label)
+    session.commit()
+
+    # Messages 0,1 close to label; 2,3,4 far. With threshold 0.55, residual = {2,3,4}.
+    msg_vecs = np.array([
+        [1, 0, 0, 0],
+        [0.9, 0.1, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+    ], dtype=np.float32)
+    label_vecs = np.array([[1, 0, 0, 0]], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "concept_retrieval._embed_messages",
+        lambda messages, db: msg_vecs[: len(messages)],
+    )
+    monkeypatch.setattr(
+        "concept_retrieval._embed_label_definitions",
+        lambda labels, db: label_vecs,
+    )
+
+    residual = retrieve_residual(session, threshold=0.55, target_size=10)
+    keys = sorted((m["chatlog_id"], m["message_index"]) for m in residual)
+    assert keys == [(1, 2), (1, 3), (1, 4)]
+
+
+def test_retrieve_residual_caps_at_target_size(session, monkeypatch):
+    for i in range(20):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+    session.commit()
+
+    msg_vecs = np.eye(20, dtype=np.float32)
+    monkeypatch.setattr(
+        "concept_retrieval._embed_messages",
+        lambda m, db: msg_vecs[: len(m)],
+    )
+    # No labels → no label_vecs → all messages pass residual filter.
+    monkeypatch.setattr(
+        "concept_retrieval._embed_label_definitions",
+        lambda l, db: np.zeros((0, 20), dtype=np.float32),
+    )
+
+    residual = retrieve_residual(session, threshold=0.55, target_size=5)
+    assert len(residual) == 5
+
+
+def test_retrieve_co_occurrence_finds_frequent_pairs(session):
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    label_c = LabelDefinition(name="C")
+    session.add_all([label_a, label_b, label_c])
+    session.commit()
+    session.refresh(label_a); session.refresh(label_b); session.refresh(label_c)
+
+    for i in range(3):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+        session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_a.id, applied_by="human",
+        ))
+        session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_b.id, applied_by="human",
+        ))
+    # A lone C label, no pairing partner above threshold.
+    session.add(MessageCache(chatlog_id=1, message_index=99, message_text="lonely"))
+    session.add(LabelApplication(
+        chatlog_id=1, message_index=99, label_id=label_c.id, applied_by="human",
+    ))
+    session.commit()
+
+    pairs = retrieve_co_occurrence(session, min_count=2)
+    expected_pair = tuple(sorted([label_a.id, label_b.id]))
+    matching = [p for p in pairs
+                if tuple(sorted([p["label_a_id"], p["label_b_id"]])) == expected_pair]
+    assert len(matching) == 1
+    assert matching[0]["count"] == 3
+    assert len(matching[0]["example_message_ids"]) >= 1
+
+
+def test_retrieve_co_occurrence_ignores_ai_labels(session):
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    session.add_all([label_a, label_b])
+    session.commit()
+    session.refresh(label_a); session.refresh(label_b)
+    session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label_a.id,
+        applied_by="ai", confidence=0.7,
+    ))
+    session.add(LabelApplication(
+        chatlog_id=1, message_index=0, label_id=label_b.id, applied_by="human",
+    ))
+    session.commit()
+    pairs = retrieve_co_occurrence(session, min_count=1)
+    # Only one human label on this message; no human-human pair.
+    assert pairs == []

--- a/server/python/tests/test_concept_service.py
+++ b/server/python/tests/test_concept_service.py
@@ -1,9 +1,12 @@
-"""Tests for concept_service — embedding, clustering, discovery."""
+"""Tests for concept_service — embedding and RAG-style discovery orchestrator."""
 import numpy as np
 from unittest.mock import patch, MagicMock
 from sqlmodel import select
 
-from models import MessageEmbedding, ConceptCandidate, LabelDefinition
+from models import (
+    MessageEmbedding, ConceptCandidate, LabelDefinition,
+    DiscoveryRun, MessageCache, LabelApplication,
+)
 
 
 def _fake_embed_result(texts):
@@ -44,74 +47,175 @@ def test_embed_messages_caches_results(mock_client, session):
     assert np.allclose(vectors, vectors2)
 
 
-@patch("concept_service.client")
-def test_discover_concepts_returns_candidates(mock_client, session):
-    from concept_service import discover_concepts
-
-    # Set up: one existing label
-    session.add(LabelDefinition(name="Concept Probe", description="Student asks about a concept", sort_order=0))
+def test_discover_broad_label_creates_run_and_candidates(session):
+    for i in range(10):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"msg{i}"))
     session.commit()
 
-    # Mock embedding calls
-    mock_client.models.embed_content.side_effect = (
-        lambda **kwargs: _fake_embed_result(kwargs["contents"])
-    )
-
-    # Mock generative call for concept suggestion
-    mock_fn_call = MagicMock()
-    mock_fn_call.name = "suggest_concepts"
-    mock_fn_call.args = {
-        "concepts": [
-            {
-                "name": "Debugging Strategy",
-                "description": "Student systematically tests hypotheses to find errors",
-                "evidence": ["Let me try printing the output first", "What if I change this variable?"],
-                "cluster_ids": [0, 2],
-            }
-        ]
-    }
-    mock_part = MagicMock()
-    mock_part.function_call = mock_fn_call
-    mock_response = MagicMock()
-    mock_response.candidates = [MagicMock()]
-    mock_response.candidates[0].content.parts = [mock_part]
-    mock_client.models.generate_content.return_value = mock_response
-
-    messages = [
-        {"chatlog_id": i, "message_index": 0, "message_text": f"Message {i}"}
-        for i in range(20)
+    fake_retrieved = [
+        {"chatlog_id": 1, "message_index": i, "message_text": f"msg{i}"}
+        for i in range(5)
     ]
-    candidates = discover_concepts(messages, session, n_clusters=4, sample_per_cluster=3)
+    fake_drafts = [{
+        "kind": "broad_label",
+        "name": "curious",
+        "description": "students expressing curiosity",
+        "evidence_message_ids": [{"chatlog_id": 1, "message_index": 0}],
+    }]
 
+    with patch("concept_service.retrieve_residual", return_value=fake_retrieved), \
+         patch("concept_service.generate_broad_labels", return_value=fake_drafts), \
+         patch("concept_service._read_recalibration_due", return_value=False):
+        from concept_service import discover
+        run = discover(session, query_kind="broad_label", trigger="manual")
+
+    assert run.id is not None
+    assert run.completed_at is not None
+    assert run.error is None
+    assert run.n_candidates == 1
+    assert run.pool_size_at_trigger == 5
+
+    candidates = session.exec(
+        select(ConceptCandidate).where(ConceptCandidate.discovery_run_id == run.id)
+    ).all()
     assert len(candidates) == 1
-    assert candidates[0].name == "Debugging Strategy"
-    assert candidates[0].status == "pending"
-    # Verify saved to DB
-    saved = session.exec(select(ConceptCandidate)).all()
-    assert len(saved) == 1
-    # similar_to field should exist (value depends on random embeddings vs threshold)
-    assert hasattr(candidates[0], "similar_to")
+    assert candidates[0].kind == "broad_label"
+    assert candidates[0].name == "curious"
 
 
-@patch("concept_service.client")
-def test_deduplicate_concepts_filters_similar(mock_client):
-    from concept_service import _deduplicate_concepts
+def test_discover_records_error_on_failure(session):
+    with patch(
+        "concept_service.retrieve_residual",
+        side_effect=RuntimeError("boom"),
+    ), patch("concept_service._read_recalibration_due", return_value=False):
+        from concept_service import discover
+        run = discover(session, query_kind="broad_label", trigger="manual")
+    assert run.error == "boom"
+    assert run.completed_at is not None
+    assert run.n_candidates == 0
 
-    # Mock embeddings: first two very similar, third distinct
-    mock_result = MagicMock()
-    v1 = np.ones(3072, dtype=float)
-    v2 = np.ones(3072, dtype=float) * 0.99 + np.random.RandomState(0).rand(3072) * 0.01
-    v3 = np.random.RandomState(42).randn(3072).astype(float)
-    mock_result.embeddings = [MagicMock(values=list(v)) for v in [v1, v2, v3]]
-    mock_client.models.embed_content.return_value = mock_result
 
-    concepts = [
-        {"name": "code review", "description": "Student asks for code review"},
-        {"name": "code check", "description": "Student asks to check their code"},
-        {"name": "frustrated", "description": "Student expresses frustration"},
-    ]
-    result = _deduplicate_concepts(concepts, threshold=0.85)
+def test_discover_co_occurrence_path(session):
+    label_a = LabelDefinition(name="A")
+    label_b = LabelDefinition(name="B")
+    session.add_all([label_a, label_b])
+    session.commit()
+    session.refresh(label_a); session.refresh(label_b)
 
-    assert len(result) == 2
-    assert result[0]["name"] == "code review"
-    assert result[1]["name"] == "frustrated"
+    for i in range(2):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+        session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_a.id, applied_by="human",
+        ))
+        session.add(LabelApplication(
+            chatlog_id=1, message_index=i, label_id=label_b.id, applied_by="human",
+        ))
+    session.commit()
+
+    fake_drafts = [{
+        "kind": "co_occurrence", "name": "combo",
+        "description": "A+B together",
+        "co_occurrence_label_ids": [label_a.id, label_b.id],
+        "co_occurrence_count": 2,
+        "suggested_resolution": "independent",
+        "evidence_message_ids": [],
+    }]
+
+    with patch("concept_service.generate_co_occurrence_concepts", return_value=fake_drafts), \
+         patch("concept_service._read_recalibration_due", return_value=False):
+        from concept_service import discover
+        run = discover(session, query_kind="co_occurrence", trigger="manual", min_count=1)
+
+    assert run.query_kind == "co_occurrence"
+    assert run.n_candidates == 1
+    cc = session.exec(
+        select(ConceptCandidate).where(ConceptCandidate.discovery_run_id == run.id)
+    ).one()
+    assert cc.kind == "co_occurrence"
+    assert cc.co_occurrence_count == 2
+
+
+def test_accept_broad_label_creates_label_and_ai_applies(session):
+    for i in range(3):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+    run = DiscoveryRun(
+        query_kind="broad_label", trigger="manual", pool_size_at_trigger=3,
+    )
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+
+    cc = ConceptCandidate(
+        name="metacognition",
+        description="reflection on own learning",
+        example_messages="[]",
+        source_run_id=str(run.id),
+        kind="broad_label",
+        discovery_run_id=run.id,
+        evidence_message_ids='[{"chatlog_id":1,"message_index":0},{"chatlog_id":1,"message_index":2}]',
+    )
+    session.add(cc)
+    session.commit()
+    session.refresh(cc)
+
+    from concept_service import accept_broad_label
+    result = accept_broad_label(cc.id, session)
+
+    assert result.created_label_id is not None
+    assert result.applied_count == 2
+
+    session.refresh(cc)
+    assert cc.decision == "accept"
+    assert cc.decided_at is not None
+    assert cc.created_label_id == result.created_label_id
+
+    apps = session.exec(
+        select(LabelApplication).where(
+            LabelApplication.label_id == result.created_label_id
+        )
+    ).all()
+    assert len(apps) == 2
+    assert all(a.applied_by == "ai" for a in apps)
+    assert all(a.confidence == 0.6 for a in apps)
+
+
+def test_accept_broad_label_rejects_co_occurrence_kind(session):
+    import pytest as _pytest
+    run = DiscoveryRun(
+        query_kind="co_occurrence", trigger="manual", pool_size_at_trigger=0,
+    )
+    session.add(run); session.commit(); session.refresh(run)
+    cc = ConceptCandidate(
+        name="x+y", description="", example_messages="[]",
+        source_run_id=str(run.id),
+        kind="co_occurrence", discovery_run_id=run.id,
+    )
+    session.add(cc); session.commit(); session.refresh(cc)
+    from concept_service import accept_broad_label
+    with _pytest.raises(ValueError, match="kind"):
+        accept_broad_label(cc.id, session)
+
+
+def test_is_discovery_ripe_returns_signal_dict(session):
+    from concept_service import is_discovery_ripe
+    sig = is_discovery_ripe(session, min_pool=5)
+    assert sig["ripe"] is False
+    assert "pool_size" in sig
+    assert "drift_value" in sig
+    assert "reasons" in sig
+    assert "pool_below_threshold" in sig["reasons"]
+
+
+def test_is_discovery_ripe_when_pool_large_and_recal_due(session, monkeypatch):
+    for i in range(10):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+    session.commit()
+    monkeypatch.setattr(
+        "concept_service._read_recalibration_due", lambda db: True
+    )
+    from concept_service import is_discovery_ripe
+    sig = is_discovery_ripe(session, min_pool=5)
+    assert sig["ripe"] is True
+    assert sig["drift_value"] == 1.0
+    assert sig["pool_size"] >= 5
+    assert sig["reasons"] == ["ok"]

--- a/server/python/tests/test_migration.py
+++ b/server/python/tests/test_migration.py
@@ -1,0 +1,56 @@
+"""Tests for idempotent SQLite column-add migrations on schema evolution."""
+from sqlalchemy import create_engine, text, inspect
+
+from database import migrate_concept_candidate_columns
+
+
+def _make_old_concept_candidate_table(engine):
+    """Create a conceptcandidate table with only the legacy columns,
+    matching the schema before the RAG-discovery rework."""
+    with engine.connect() as conn:
+        conn.execute(text("""
+            CREATE TABLE conceptcandidate (
+                id INTEGER PRIMARY KEY,
+                name TEXT,
+                description TEXT,
+                example_messages TEXT,
+                status TEXT,
+                source_run_id TEXT,
+                similar_to TEXT,
+                created_at TEXT
+            )
+        """))
+        conn.commit()
+
+
+def test_migration_adds_missing_columns(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'old.db'}"
+    engine = create_engine(db_url)
+    _make_old_concept_candidate_table(engine)
+
+    with engine.connect() as conn:
+        migrate_concept_candidate_columns(conn)
+        cols = [c["name"] for c in inspect(conn).get_columns("conceptcandidate")]
+
+    for required in [
+        "kind", "discovery_run_id", "shown_at", "decided_at",
+        "decision", "created_label_id", "evidence_message_ids",
+        "co_occurrence_label_ids", "co_occurrence_count",
+    ]:
+        assert required in cols, f"missing column: {required}"
+
+
+def test_migration_is_idempotent(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'fresh.db'}"
+    engine = create_engine(db_url)
+    _make_old_concept_candidate_table(engine)
+
+    with engine.connect() as conn:
+        migrate_concept_candidate_columns(conn)
+        # Second call must not error or duplicate columns.
+        migrate_concept_candidate_columns(conn)
+        cols = [c["name"] for c in inspect(conn).get_columns("conceptcandidate")]
+
+    # No duplicates expected; len == unique count.
+    assert len(cols) == len(set(cols))
+    assert "kind" in cols

--- a/src/components/queue/DiscoverModal.tsx
+++ b/src/components/queue/DiscoverModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { api } from '../../services/api'
 import type { ConceptCandidate, LabelDefinition } from '../../types'
 
 interface Props {
@@ -9,6 +10,11 @@ interface Props {
   onDiscover: () => void
   onClose: () => void
   discovering: boolean
+  /**
+   * Optional callback fired when a Mode B candidate becomes a label,
+   * is dismissed, noted, or merged. Lets the parent refresh state.
+   */
+  onCandidateChanged?: () => void
 }
 
 export default function DiscoverModal({
@@ -19,6 +25,7 @@ export default function DiscoverModal({
   onDiscover,
   onClose,
   discovering,
+  onCandidateChanged,
 }: Props) {
   const [renaming, setRenaming] = useState<{ id: number; value: string } | null>(null)
 
@@ -68,59 +75,23 @@ export default function DiscoverModal({
             </p>
             <div className="flex flex-col gap-2">
               {candidates.map(c => (
-                <div key={c.id} className="bg-neutral-800/40 border border-neutral-700/50 rounded-lg p-2.5">
-                  {/* Name row + actions */}
-                  <div className="flex justify-between items-start gap-2 mb-0.5">
-                    {renaming?.id === c.id ? (
-                      <input
-                        autoFocus
-                        className="flex-1 bg-neutral-900 border border-amber-500/40 rounded px-1.5 py-0.5 text-xs text-amber-300 font-medium outline-none focus:border-amber-500"
-                        value={renaming.value}
-                        onChange={e => setRenaming({ id: c.id, value: e.target.value })}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter' && renaming.value.trim()) {
-                            onAccept(c.id, renaming.value.trim())
-                            setRenaming(null)
-                          }
-                          if (e.key === 'Escape') setRenaming(null)
-                        }}
-                        onBlur={() => setRenaming(null)}
-                      />
-                    ) : (
-                      <span
-                        className="text-xs font-medium text-amber-300 cursor-pointer hover:underline"
-                        onClick={() => setRenaming({ id: c.id, value: c.name })}
-                        title="Click to rename"
-                      >
-                        {c.name}
-                      </span>
-                    )}
-                    <div className="flex gap-1 shrink-0">
-                      <button
-                        onClick={() => onAccept(c.id)}
-                        className="px-2 py-0.5 rounded text-[10px] bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
-                      >
-                        Accept
-                      </button>
-                      <button
-                        onClick={() => onReject(c.id)}
-                        className="px-2 py-0.5 rounded text-[10px] bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors"
-                      >
-                        Reject
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Similarity tag */}
-                  {c.similar_to && (
-                    <p className="text-[9px] text-violet-400 mb-1">
-                      similar to: <span className="text-violet-300">{c.similar_to}</span>
-                    </p>
-                  )}
-
-                  {/* Description */}
-                  <p className="text-[10px] text-neutral-500 leading-snug">{c.description}</p>
-                </div>
+                c.kind === 'co_occurrence' ? (
+                  <CoOccurrenceCard
+                    key={c.id}
+                    c={c}
+                    labels={labels}
+                    onChanged={onCandidateChanged}
+                  />
+                ) : (
+                  <BroadLabelCard
+                    key={c.id}
+                    c={c}
+                    renaming={renaming}
+                    setRenaming={setRenaming}
+                    onAccept={onAccept}
+                    onReject={onReject}
+                  />
+                )
               ))}
             </div>
           </div>
@@ -143,6 +114,169 @@ export default function DiscoverModal({
           </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+
+function BroadLabelCard({
+  c, renaming, setRenaming, onAccept, onReject,
+}: {
+  c: ConceptCandidate
+  renaming: { id: number; value: string } | null
+  setRenaming: (r: { id: number; value: string } | null) => void
+  onAccept: (id: number, name?: string) => Promise<void>
+  onReject: (id: number) => Promise<void>
+}) {
+  return (
+    <div className="bg-neutral-800/40 border border-neutral-700/50 rounded-lg p-2.5">
+      <div className="flex justify-between items-start gap-2 mb-0.5">
+        {renaming?.id === c.id ? (
+          <input
+            autoFocus
+            className="flex-1 bg-neutral-900 border border-amber-500/40 rounded px-1.5 py-0.5 text-xs text-amber-300 font-medium outline-none focus:border-amber-500"
+            value={renaming.value}
+            onChange={e => setRenaming({ id: c.id, value: e.target.value })}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && renaming.value.trim()) {
+                onAccept(c.id, renaming.value.trim())
+                setRenaming(null)
+              }
+              if (e.key === 'Escape') setRenaming(null)
+            }}
+            onBlur={() => setRenaming(null)}
+          />
+        ) : (
+          <span
+            className="text-xs font-medium text-amber-300 cursor-pointer hover:underline"
+            onClick={() => setRenaming({ id: c.id, value: c.name })}
+            title="Click to rename"
+          >
+            {c.name}
+          </span>
+        )}
+        <div className="flex gap-1 shrink-0">
+          <button
+            onClick={() => onAccept(c.id)}
+            className="px-2 py-0.5 rounded text-[10px] bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
+          >
+            Accept
+          </button>
+          <button
+            onClick={() => onReject(c.id)}
+            className="px-2 py-0.5 rounded text-[10px] bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+
+      {c.similar_to && (
+        <p className="text-[9px] text-violet-400 mb-1">
+          similar to: <span className="text-violet-300">{c.similar_to}</span>
+        </p>
+      )}
+      <p className="text-[10px] text-neutral-500 leading-snug">{c.description}</p>
+      {c.discovery_run_id != null && (
+        <p className="mt-1 text-[9px] text-neutral-600">
+          run #{c.discovery_run_id} · broad
+        </p>
+      )}
+    </div>
+  )
+}
+
+
+function CoOccurrenceCard({
+  c, labels, onChanged,
+}: {
+  c: ConceptCandidate
+  labels: LabelDefinition[]
+  onChanged?: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const ids = c.co_occurrence_label_ids ?? [0, 0]
+  const count = c.co_occurrence_count ?? 0
+  const labelById = new Map(labels.map(l => [l.id, l.name]))
+  const a = labelById.get(ids[0]) ?? `#${ids[0]}`
+  const b = labelById.get(ids[1]) ?? `#${ids[1]}`
+
+  const note = async () => {
+    setBusy(true)
+    try { await api.noteConceptCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+  const makeLabel = async () => {
+    setBusy(true)
+    try { await api.makeLabelFromCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+  const dismiss = async () => {
+    setBusy(true)
+    try { await api.dismissConceptCandidate(c.id); onChanged?.() }
+    finally { setBusy(false) }
+  }
+  const suggestMerge = async () => {
+    if (!ids[0] || !ids[1]) return
+    const archive = Math.min(ids[0], ids[1])
+    const keep = Math.max(ids[0], ids[1])
+    setBusy(true)
+    try {
+      await api.suggestMergeFromCandidate(c.id, archive, keep)
+      onChanged?.()
+    } finally { setBusy(false) }
+  }
+
+  return (
+    <div className="bg-neutral-800/40 border border-neutral-700/50 rounded-lg p-2.5">
+      <p className="text-xs font-medium text-violet-300">
+        Pattern: <span className="text-violet-400">{a}</span>
+        {' + '}
+        <span className="text-violet-400">{b}</span>
+      </p>
+      <p className="text-[10px] text-neutral-500 mt-0.5">
+        co-occur on {count} message{count === 1 ? '' : 's'}
+      </p>
+      {c.description && (
+        <p className="mt-1 text-[10px] text-neutral-500 leading-snug">{c.description}</p>
+      )}
+
+      <div className="mt-2 flex flex-wrap gap-1">
+        <button
+          disabled={busy}
+          onClick={makeLabel}
+          className="px-2 py-0.5 rounded text-[10px] bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 transition-colors disabled:opacity-50"
+        >
+          Make a combo label
+        </button>
+        <button
+          disabled={busy}
+          onClick={suggestMerge}
+          className="px-2 py-0.5 rounded text-[10px] bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 transition-colors disabled:opacity-50"
+        >
+          Suggest merge
+        </button>
+        <button
+          disabled={busy}
+          onClick={note}
+          className="px-2 py-0.5 rounded text-[10px] bg-neutral-700/50 text-neutral-300 hover:bg-neutral-700 transition-colors disabled:opacity-50"
+        >
+          Note only
+        </button>
+        <button
+          disabled={busy}
+          onClick={dismiss}
+          className="px-2 py-0.5 rounded text-[10px] bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors disabled:opacity-50"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      {c.discovery_run_id != null && (
+        <p className="mt-1 text-[9px] text-neutral-600">
+          run #{c.discovery_run_id} · co-occurrence
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/queue/DiscoverSection.tsx
+++ b/src/components/queue/DiscoverSection.tsx
@@ -1,10 +1,16 @@
-import type { ConceptCandidate } from '../../types'
+import { useEffect, useState } from 'react'
+import { api } from '../../services/api'
+import type {
+  ConceptCandidate, ConceptCandidateKind, RipeSignal,
+} from '../../types'
 
 interface Props {
   candidates: ConceptCandidate[]
   aiUnlocked: boolean
   labeledCount: number
-  onDiscover: () => void
+  /** Number of messages with at least 2 human labels — gates Mode B button. */
+  multiLabeledCount?: number
+  onDiscover: (queryKind?: ConceptCandidateKind) => void
   onOpenModal: () => void
   discovering: boolean
 }
@@ -13,22 +19,66 @@ export default function DiscoverSection({
   candidates,
   aiUnlocked,
   labeledCount,
+  multiLabeledCount = 0,
   onDiscover,
   onOpenModal,
   discovering,
 }: Props) {
+  const [ripe, setRipe] = useState<RipeSignal | null>(null)
+
+  // Poll the ripeness signal every 30s while mounted.
+  useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const sig = await api.getConceptRipe()
+        if (!cancelled) setRipe(sig)
+      } catch {
+        /* ignore polling errors */
+      }
+    }
+    tick()
+    const id = setInterval(tick, 30_000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
   const nudgeThresholds = [30, 50, 80]
-  const showNudge = candidates.length === 0 && nudgeThresholds.some(t => labeledCount >= t && labeledCount < t + 5)
+  const showNudge =
+    candidates.length === 0 &&
+    nudgeThresholds.some((t) => labeledCount >= t && labeledCount < t + 5)
 
   if (!aiUnlocked) return null
 
+  const showCoOccurButton = multiLabeledCount >= 2
+  const ripeForAny = ripe?.ripe === true
+
+  if (candidates.length > 0) {
+    return (
+      <div className="mb-3">
+        <p className="text-[10px] uppercase tracking-widest text-neutral-500 mb-1.5">
+          Discover
+        </p>
+        <button
+          onClick={onOpenModal}
+          className="w-full text-xs py-1.5 px-2 rounded border border-violet-500/50 bg-violet-500/10 text-violet-300 hover:bg-violet-500/20 transition-colors"
+        >
+          ✦ {candidates.length} suggestion{candidates.length !== 1 ? 's' : ''}
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div className="mb-3">
-      <p className="text-[10px] uppercase tracking-widest text-neutral-500 mb-1.5">Discover</p>
-
-      {candidates.length === 0 ? (
+      <p className="text-[10px] uppercase tracking-widest text-neutral-500 mb-1.5">
+        Discover
+      </p>
+      <div className="flex flex-col gap-1.5">
         <button
-          onClick={onDiscover}
+          onClick={() => onDiscover('broad_label')}
           disabled={discovering}
           className="w-full text-xs py-1.5 px-2 rounded border border-dashed border-violet-500/50 text-violet-300 hover:bg-violet-500/10 transition-colors disabled:opacity-50 disabled:cursor-wait"
         >
@@ -39,7 +89,18 @@ export default function DiscoverSection({
             </span>
           ) : (
             <>
-              ✦ Discover New Labels
+              ✦ Find missing labels
+              {ripeForAny && (
+                <span
+                  aria-label="discovery is ripe"
+                  title={
+                    ripe
+                      ? `${ripe.pool_size} unlabeled · drift ${ripe.drift_value ?? '–'}`
+                      : ''
+                  }
+                  className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full bg-emerald-400 align-middle"
+                />
+              )}
               {showNudge && (
                 <span className="block text-[10px] text-amber-400 mt-0.5">
                   Some messages may not fit your labels
@@ -48,14 +109,17 @@ export default function DiscoverSection({
             </>
           )}
         </button>
-      ) : (
-        <button
-          onClick={onOpenModal}
-          className="w-full text-xs py-1.5 px-2 rounded border border-violet-500/50 bg-violet-500/10 text-violet-300 hover:bg-violet-500/20 transition-colors"
-        >
-          ✦ {candidates.length} suggestion{candidates.length !== 1 ? 's' : ''}
-        </button>
-      )}
+
+        {showCoOccurButton && (
+          <button
+            onClick={() => onDiscover('co_occurrence')}
+            disabled={discovering}
+            className="w-full text-xs py-1.5 px-2 rounded border border-dashed border-amber-500/50 text-amber-300 hover:bg-amber-500/10 transition-colors disabled:opacity-50 disabled:cursor-wait"
+          >
+            ✦ Find label patterns
+          </button>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/queue/ProgressSidebar.tsx
+++ b/src/components/queue/ProgressSidebar.tsx
@@ -33,9 +33,10 @@ interface Props {
   onReorderLabels: (labelIds: number[]) => void
   onArchiveLabel: (labelId: number) => void
   candidates: ConceptCandidate[]
-  onDiscover: () => void
+  onDiscover: (queryKind?: 'broad_label' | 'co_occurrence') => void
   onOpenDiscoverModal: () => void
   discovering: boolean
+  multiLabeledCount?: number
   recalibration: {
     phase: 'blind' | 'reconcile'
     originalLabelIds: Set<number>
@@ -166,7 +167,7 @@ export function ProgressSidebar({
   session: _session, labels, stats, skippedCount,
   appliedLabelIds, onToggleLabel, onCreateAndApply, onUpdateLabel,
   onStartAutolabel, autolabelStatus, remaining, history, onSelectHistoryItem, reviewingKey, onReorderLabels,
-  onArchiveLabel, candidates, onDiscover, onOpenDiscoverModal, discovering,
+  onArchiveLabel, candidates, onDiscover, onOpenDiscoverModal, discovering, multiLabeledCount,
   recalibration, recalibrationStats,
 }: Props) {
   const [showPopover, setShowPopover] = useState(false)
@@ -321,6 +322,7 @@ export function ProgressSidebar({
         candidates={candidates}
         aiUnlocked={(stats?.labeled_count ?? 0) >= 20}
         labeledCount={stats?.labeled_count ?? 0}
+        multiLabeledCount={multiLabeledCount}
         onDiscover={onDiscover}
         onOpenModal={onOpenDiscoverModal}
         discovering={discovering}

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -599,11 +599,11 @@ export function QueuePage() {
 		}, 2000);
 	};
 
-	const handleDiscover = async () => {
+	const handleDiscover = async (queryKind: 'broad_label' | 'co_occurrence' = 'broad_label') => {
 		setDiscovering(true);
-		await api.discoverConcepts();
+		await api.discoverConcepts(queryKind, 'manual');
 		discoverPollRef.current = setInterval(async () => {
-			const result = await api.getCandidates();
+			const result = await api.getCandidates({ kind: queryKind });
 			const embedStatus = await api.getEmbedStatus();
 			if (result.length > 0) {
 				setCandidates(result);

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -937,6 +937,7 @@ export function QueuePage() {
 						onDiscover={handleDiscover}
 						onOpenDiscoverModal={() => setDiscoverModalOpen(true)}
 						discovering={discovering}
+						multiLabeledCount={stats?.multi_labeled_count ?? 0}
 						recalibration={recalibration ? {
 							phase: recalibration.phase,
 							originalLabelIds: new Set(recalibration.item.original_label_ids),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,6 +6,7 @@ import type {
   ConceptCandidate, EmbedStatus, ConversationMessage, AnalysisSummary, TemporalAnalysis,
   LabelExample, SplitAutoLabelRequest, ApplyBatchRequest, ConciseResponse,
   RecalibrationItem, RecalibrationStats, SaveRecalibrationRequest, SaveRecalibrationResponse,
+  ConceptCandidateKind, RipeSignal, DiscoveryRun,
 } from '../types'
 import { mockApi } from '../mocks'
 
@@ -111,14 +112,27 @@ export const api = {
     USE_MOCK ? Promise.resolve({ archived: ids.length } as any)
              : req('/api/history/archive-orphaned', { method: 'POST', ...json({ messages: ids }) }),
 
-  // Concept Discovery
-  discoverConcepts: (limit = 10): Promise<any> =>
-    USE_MOCK ? Promise.resolve({ candidates: [], status: { cached: 0, total_unlabeled: 0, running: false } })
-             : req(`/api/concepts/discover?limit=${limit}`, { method: 'POST' }),
+  // Concept Discovery — RAG-style mode-aware API
+  discoverConcepts: (
+    query_kind: ConceptCandidateKind = 'broad_label',
+    trigger: 'manual' | 'badge' = 'manual',
+  ): Promise<{ run_id: number | string; status: string }> =>
+    USE_MOCK ? Promise.resolve({ run_id: 'starting', status: 'running' })
+             : req('/api/concepts/discover', {
+                 method: 'POST', ...json({ query_kind, trigger }),
+               }),
 
-  getCandidates: (): Promise<ConceptCandidate[]> =>
-    USE_MOCK ? Promise.resolve([])
-             : req('/api/concepts/candidates'),
+  getCandidates: (
+    filters: { run_id?: number; kind?: ConceptCandidateKind; decision?: string } = {},
+  ): Promise<ConceptCandidate[]> => {
+    if (USE_MOCK) return Promise.resolve([])
+    const p = new URLSearchParams()
+    if (filters.run_id != null) p.set('run_id', String(filters.run_id))
+    if (filters.kind) p.set('kind', filters.kind)
+    if (filters.decision) p.set('decision', filters.decision)
+    const qs = p.toString() ? `?${p.toString()}` : ''
+    return req(`/api/concepts/candidates${qs}`)
+  },
 
   resolveCandidate: (id: number, action: 'accept' | 'reject', name?: string): Promise<LabelDefinition | { ok: boolean }> =>
     USE_MOCK ? Promise.resolve({ ok: true })
@@ -127,6 +141,55 @@ export const api = {
   getEmbedStatus: (): Promise<EmbedStatus> =>
     USE_MOCK ? Promise.resolve({ cached: 0, total_unlabeled: 0, running: false })
              : req('/api/concepts/embed-status'),
+
+  getConceptRipe: (): Promise<RipeSignal> =>
+    USE_MOCK ? Promise.resolve({ ripe: false, pool_size: 0, drift_value: 0, reasons: ['pool_below_threshold'] })
+             : req('/api/concepts/ripe'),
+
+  acceptConceptCandidate: (
+    id: number,
+  ): Promise<{ candidate_id: number; created_label_id: number; applied_count: number }> =>
+    USE_MOCK ? Promise.resolve({ candidate_id: id, created_label_id: 0, applied_count: 0 })
+             : req(`/api/concepts/candidates/${id}/accept`, {
+                 method: 'POST', ...json({}),
+               }),
+
+  dismissConceptCandidate: (id: number, reason?: string): Promise<{ ok: true }> =>
+    USE_MOCK ? Promise.resolve({ ok: true as const })
+             : req(`/api/concepts/candidates/${id}/dismiss`, {
+                 method: 'POST', ...json({ reason }),
+               }),
+
+  noteConceptCandidate: (id: number): Promise<{ ok: true }> =>
+    USE_MOCK ? Promise.resolve({ ok: true as const })
+             : req(`/api/concepts/candidates/${id}/note`, {
+                 method: 'POST', ...json({}),
+               }),
+
+  makeLabelFromCandidate: (
+    id: number,
+  ): Promise<{ candidate_id: number; created_label_id: number }> =>
+    USE_MOCK ? Promise.resolve({ candidate_id: id, created_label_id: 0 })
+             : req(`/api/concepts/candidates/${id}/make-label`, {
+                 method: 'POST', ...json({}),
+               }),
+
+  suggestMergeFromCandidate: (
+    id: number, archive_label_id: number, keep_label_id: number,
+  ): Promise<{ archived_label_id: number; kept_label_id: number; retagged_count: number }> =>
+    USE_MOCK ? Promise.resolve({
+                 archived_label_id: archive_label_id,
+                 kept_label_id: keep_label_id,
+                 retagged_count: 0,
+               })
+             : req(`/api/concepts/candidates/${id}/suggest-merge`, {
+                 method: 'POST',
+                 ...json({ archive_label_id, keep_label_id }),
+               }),
+
+  getDiscoveryRuns: (limit = 20): Promise<DiscoveryRun[]> =>
+    USE_MOCK ? Promise.resolve([])
+             : req(`/api/concepts/runs?limit=${limit}`),
 
   getConversationMessages: (chatlogId: number): Promise<ConversationMessage[]> =>
     USE_MOCK ? Promise.resolve([])

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,6 +99,7 @@ export interface QueueStats {
   total_messages: number
   labeled_count: number
   skipped_count: number
+  multi_labeled_count?: number
 }
 
 export interface ApplyLabelRequest {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,11 @@ export interface HistoryItem {
   processed_at: string
 }
 
+export type ConceptCandidateKind = 'broad_label' | 'co_occurrence'
+
+export type ConceptDecision =
+  | 'accept' | 'reject' | 'dismiss' | 'suggest_merge' | 'note'
+
 export interface ConceptCandidate {
   id: number
   name: string
@@ -169,6 +174,33 @@ export interface ConceptCandidate {
   source_run_id: string
   similar_to: string | null
   created_at: string
+  // New RAG-discovery fields (optional for backwards compat with legacy rows)
+  kind?: ConceptCandidateKind
+  discovery_run_id?: number | null
+  decision?: ConceptDecision | null
+  created_label_id?: number | null
+  evidence_message_ids?: { chatlog_id: number; message_index: number }[] | null
+  co_occurrence_label_ids?: [number, number] | null
+  co_occurrence_count?: number | null
+}
+
+export interface RipeSignal {
+  ripe: boolean
+  pool_size: number
+  drift_value: number | null
+  reasons: string[]
+}
+
+export interface DiscoveryRun {
+  id: number
+  started_at: string
+  completed_at: string | null
+  query_kind: ConceptCandidateKind
+  trigger: 'manual' | 'badge'
+  drift_value_at_trigger: number | null
+  pool_size_at_trigger: number
+  n_candidates: number
+  error: string | null
 }
 
 export interface EmbedStatus {


### PR DESCRIPTION
## Summary
- Reworks concept induction (PR #32) to fit Chatsight's multi-label, broad-labels-applied-in-combination paradigm. Addresses the **D brief** (`docs/suggestions/D-concept-induction-rework.md`) — concept induction was producing narrow, single-use sub-categories, fighting the grain of the workflow.
- Replaces the KMeans + "name these clusters" pipeline with a **RAG-style discovery framework** with two query modes:
  - **Mode A — Missing broad labels**: residual-set retrieval (messages farthest from every label centroid) + max-min farthest-point diversity selection. Breadth is encoded in the *retrieval*, so the LLM cannot return a narrow label that spans the spread.
  - **Mode B — Co-occurrence patterns**: aggregates pairs of human-applied labels that co-occur on ≥ N messages; LLM evaluates each as `make_label` / `merge` / `independent`.
- New `DiscoveryRun` table captures `query_kind`, `trigger` (`manual` | `badge`), `drift_value_at_trigger`, `pool_size_at_trigger`, `n_candidates`, and `error` — instrumentation for the brief's "is drift the right premise?" experiment.
- Discovery never auto-fires; a *ripeness badge* (drift signal from PR #36 + pool size) suggests when to run, but the instructor decides.
- Acceptance of a Mode A candidate creates the new `LabelDefinition` *and* auto-applies it to the retrieved evidence with `applied_by="ai"`, `confidence=0.6` — leveraging the existing AI/human distinction so the work is auditable and revertible.

Spec and plan are checked in:
- `docs/superpowers/specs/2026-05-01-concept-induction-rag-design.md`
- `docs/superpowers/plans/2026-05-01-concept-induction-rag.md`

### Files of interest
- Backend: `server/python/concept_retrieval.py` (new), `concept_generation.py` (new), `concept_service.py` (rewritten — KMeans path deleted, orchestrator added), `models.py` (DiscoveryRun + extended ConceptCandidate), `database.py` (idempotent migration), `main.py` (new endpoints).
- Frontend: `src/components/queue/DiscoverSection.tsx` (two mode buttons + ripeness pill), `src/components/queue/DiscoverModal.tsx` (kind-discriminated cards), `src/types/index.ts`, `src/services/api.ts`.

### Tests
- 130 backend tests passing (pytest), including 8 retrieval, 4 generation, 8 orchestrator/accept/ripeness, 12 endpoint, 2 migration, plus 5 model tests.
- 60 frontend tests passing (vitest).
- TypeScript clean (`npx tsc --noEmit`).

## Test plan
- [ ] Pull the branch and run `cd server/python && uv run pytest` — confirm 130 passing.
- [ ] Run `npm test` — confirm 60 passing.
- [ ] Run `npx tsc --noEmit` — confirm no type errors.
- [ ] **Manual Mode A walkthrough**: with ~30 human labels applied, click *Find missing labels*. Confirm the modal shows broad-label cards with `Accept` / `Reject` buttons. Click `Accept` on one — verify the new label appears in the legend and that AI-applied labels show on the relevant queue messages with the existing AI provenance (revertibility intact).
- [ ] **Manual Mode B walkthrough**: with ≥ 2 messages carrying ≥ 2 human labels, click *Find label patterns*. Confirm the modal shows co-occurrence cards (no `Accept` button — instead: `Make a combo label`, `Suggest merge`, `Note only`, `Dismiss`). Click `Make a combo label` — verify a new label appears in the legend with no auto-application.
- [ ] **Ripeness badge**: with PR #36 drift signal elevated and pool size ≥ 30, confirm the green dot appears on the *Find missing labels* button. Tooltip shows pool size + drift.
- [ ] **Verify instrumentation**: `sqlite3 server/python/chatsight.db "SELECT id, query_kind, trigger, n_candidates, drift_value_at_trigger, pool_size_at_trigger FROM discoveryrun ORDER BY id DESC LIMIT 5;"` — confirm rows populate as expected per run.
- [ ] **Migration**: open an existing pre-rework `chatsight.db`, start the backend, confirm `conceptcandidate` gains the new columns without data loss.

## Out of scope (explicitly deferred)
- Replacing the legacy `status` and `source_run_id` columns on `ConceptCandidate` (kept for backwards compat with old rows).
- Promoting the badge to an auto-trigger (pending the drift-as-premise experiment data).
- Mode C (missing-axes query), confirm-each acceptance UX, discovery-health UI panel.