### PR TITLE
Bug-audit hardening: assist scope, race-safe run, recoverable split

### DIFF
--- a/server/python/assist_service.py
+++ b/server/python/assist_service.py
@@ -15,7 +15,7 @@ from models import LabelApplication, MessageCache, MessageEmbedding
 _lock = threading.Lock()
 
 
-def _build_cache(db: Session) -> dict:
+def _build_cache(db: Session, fingerprint: tuple[int, int, int]) -> dict:
     rows = db.exec(
         select(
             MessageEmbedding.chatlog_id,
@@ -24,7 +24,7 @@ def _build_cache(db: Session) -> dict:
         )
     ).all()
     if not rows:
-        return {"matrix": None, "keys_idx": {}, "count": 0}
+        return {"matrix": None, "keys_idx": {}, "fingerprint": fingerprint}
     keys = [(c, i) for (c, i, _) in rows]
     vecs = np.stack([np.frombuffer(b, dtype=np.float32) for (_, _, b) in rows])
     norms = np.linalg.norm(vecs, axis=1, keepdims=True)
@@ -33,19 +33,34 @@ def _build_cache(db: Session) -> dict:
     return {
         "matrix": matrix,
         "keys_idx": {k: i for i, k in enumerate(keys)},
-        "count": len(rows),
+        "fingerprint": fingerprint,
     }
 
 
+def _embedding_fingerprint(db: Session) -> tuple[int, int, int]:
+    """A cheap signal that detects inserts, deletes, and in-place re-embeds.
+    (count, max_id, sum_id) — pure-count was insufficient because re-embedding
+    an existing (chatlog_id, message_index) does not change the row count, but
+    does change which rows we are now serving."""
+    row = db.exec(
+        select(
+            func.count(MessageEmbedding.id),
+            func.coalesce(func.max(MessageEmbedding.id), 0),
+            func.coalesce(func.sum(MessageEmbedding.id), 0),
+        )
+    ).one()
+    return (int(row[0]), int(row[1]), int(row[2]))
+
+
 def _get_cache(db: Session) -> dict:
-    """Per-engine cached matrix; reloads when MessageEmbedding row count diverges."""
+    """Per-engine cached matrix; reloads when the embedding fingerprint diverges."""
     bind = db.get_bind()
-    current = db.exec(select(func.count()).select_from(MessageEmbedding)).one()
+    current = _embedding_fingerprint(db)
     with _lock:
         cache = bind.info.get("assist_cache") if hasattr(bind, "info") else None
-        if cache is not None and cache["count"] == current:
+        if cache is not None and cache.get("fingerprint") == current:
             return cache
-        cache = _build_cache(db)
+        cache = _build_cache(db, current)
         if hasattr(bind, "info"):
             bind.info["assist_cache"] = cache
         return cache
@@ -57,9 +72,12 @@ def nearest_neighbors(
     chatlog_id: int,
     message_index: int,
     k: int = 3,
+    assignment_id: int | None = None,
 ) -> list[dict]:
     """Up to k cosine-nearest human yes/no labeled neighbors of the focused message.
     Returns [] if the focused message has no embedding or no labeled neighbors do.
+    When assignment_id is set, neighbors are restricted to messages tagged with the
+    same assignment so calibration anchors stay within the same lab/project context.
     Each result: {chatlog_id, message_index, value, similarity, message_text}."""
     cache = _get_cache(db)
     if cache["matrix"] is None:
@@ -72,17 +90,22 @@ def nearest_neighbors(
         return []
     focused = matrix[focused_idx]
 
-    apps = db.exec(
-        select(
-            LabelApplication.chatlog_id,
-            LabelApplication.message_index,
-            LabelApplication.value,
-        ).where(
-            LabelApplication.label_id == label_id,
-            LabelApplication.applied_by == "human",
-            LabelApplication.value.in_(["yes", "no"]),  # noqa: comparator
-        )
-    ).all()
+    stmt = select(
+        LabelApplication.chatlog_id,
+        LabelApplication.message_index,
+        LabelApplication.value,
+    ).where(
+        LabelApplication.label_id == label_id,
+        LabelApplication.applied_by == "human",
+        LabelApplication.value.in_(["yes", "no"]),  # noqa: comparator
+    )
+    if assignment_id is not None:
+        stmt = stmt.join(
+            MessageCache,
+            (MessageCache.chatlog_id == LabelApplication.chatlog_id)
+            & (MessageCache.message_index == LabelApplication.message_index),
+        ).where(MessageCache.assignment_id == assignment_id)
+    apps = db.exec(stmt).all()
 
     candidate_idx: list[int] = []
     candidate_meta: list[tuple[int, int, str]] = []
@@ -139,6 +162,12 @@ def rebuild_cache_if_stale(db: Session, label_id: int) -> bool:
 
 
 def get_cached_neighbors(
-    db: Session, label_id: int, chatlog_id: int, message_index: int
+    db: Session,
+    label_id: int,
+    chatlog_id: int,
+    message_index: int,
+    assignment_id: int | None = None,
 ) -> list[dict]:
-    return nearest_neighbors(db, label_id, chatlog_id, message_index, k=3)
+    return nearest_neighbors(
+        db, label_id, chatlog_id, message_index, k=3, assignment_id=assignment_id
+    )

--- a/server/python/autolabel_service.py
+++ b/server/python/autolabel_service.py
@@ -3,13 +3,22 @@
 Given human-labeled examples and label definitions, classifies unlabeled
 student messages into existing label categories.
 """
+import logging
 import os
 import json
 from google import genai
 from google.genai import types
 from typing import List, Dict, Any
 
+log = logging.getLogger(__name__)
+
 client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+class ClassifyToolMissing(RuntimeError):
+    """Gemini did not return the classify_messages tool call.
+    Distinct from network errors so callers can decide whether to retry,
+    log+continue, or surface to the UI."""
 
 TOOL = types.Tool(function_declarations=[
     types.FunctionDeclaration(
@@ -102,7 +111,15 @@ def classify_batch(
             args = dict(part.function_call.args)
             return list(args.get("classifications", []))
 
-    return []
+    text_reply = getattr(response, "text", None)
+    log.warning(
+        "classify_batch: no tool call returned; n_messages=%d text=%r",
+        len(messages),
+        (text_reply or "")[:200],
+    )
+    raise ClassifyToolMissing(
+        f"Gemini did not call classify_messages (n={len(messages)})"
+    )
 
 def summarize_message(message_text: str) -> str:
     """Summarize a student message to be concise."""
@@ -118,12 +135,9 @@ def summarize_message(message_text: str) -> str:
         temperature=0,
     )
     
-    try:
-        response = client.models.generate_content(
-            model="gemini-2.0-flash",
-            contents=message_text,
-            config=config,
-        )
-        return response.text.strip()
-    except Exception as e:
-        return f"Error summarizing: {e}"
+    response = client.models.generate_content(
+        model="gemini-2.0-flash",
+        contents=message_text,
+        config=config,
+    )
+    return response.text.strip()

--- a/server/python/definition_service.py
+++ b/server/python/definition_service.py
@@ -39,6 +39,8 @@ def select_best_example(label_name: str, description: str, example_messages: Lis
     Given a label's description and a list of candidate human-labeled messages,
     return the single message that best exemplifies the description.
     """
+    if not example_messages:
+        raise ValueError("select_best_example requires at least one example_messages entry")
     numbered = "\n".join(f"{i + 1}. {m}" for i, m in enumerate(example_messages))
 
     prompt = f"""You are helping an instructor review labels in a student-AI tutoring chatlog labeling system.

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1009,17 +1009,30 @@ def get_queue_history(
     else:
         all_entries.sort(key=lambda e: e["processed_at"] if e["processed_at"] else "", reverse=True)
 
+    # Pre-fetch message text so the search filter can be applied BEFORE slicing.
+    # Otherwise `total` reflects the pre-search count and pagination math drifts:
+    # the client thinks there are N pages but each page silently drops items.
+    cached_msgs = db.exec(select(MessageCache)).all()
+    cache_lookup = {(c.chatlog_id, c.message_index): c for c in cached_msgs}
+
+    if search:
+        needle = search.lower()
+        all_entries = [
+            e for e in all_entries
+            if needle in (
+                cache_lookup.get((e["chatlog_id"], e["message_index"])).message_text.lower()
+                if cache_lookup.get((e["chatlog_id"], e["message_index"]))
+                else ""
+            )
+        ]
+
     total = len(all_entries)
     page = all_entries[offset:offset + limit]
 
     if not page:
         return {"items": [], "total": total}
 
-    # Batch fetch message text from cache (one query for all page items)
-    page_keys = [(e["chatlog_id"], e["message_index"]) for e in page]
-    page_key_set = set(page_keys)
-    cached_msgs = db.exec(select(MessageCache)).all()
-    cache_lookup = {(c.chatlog_id, c.message_index): c for c in cached_msgs}
+    page_key_set = {(e["chatlog_id"], e["message_index"]) for e in page}
 
     # Batch fetch all labels for labeled items on this page (one query)
     labeled_keys = [(e["chatlog_id"], e["message_index"]) for e in page if e["status"] == "labeled"]
@@ -1050,10 +1063,6 @@ def get_queue_history(
         context_before = cached.context_before if cached else None
         context_after = cached.context_after if cached else None
 
-        # Apply search filter
-        if search and search.lower() not in message_text.lower():
-            continue
-
         processed_at = entry["processed_at"]
         result.append({
             "chatlog_id": chatlog_id,
@@ -1077,6 +1086,7 @@ _autolabel_status = {"running": False, "processed": 0, "total": 0, "error": None
 
 
 def _run_split_autolabel(
+    original_label_id: int,
     original_label_name: str,
     new_label_a_id: int,
     new_label_a_name: str,
@@ -1085,7 +1095,13 @@ def _run_split_autolabel(
     human_examples: List[Dict[str, Any]],  # [{text, label_name}]
     remaining_messages: List[Dict[str, Any]],  # [{chatlog_id, message_index, message_text}]
 ):
-    """Background task: split remaining messages between two new labels using Gemini."""
+    """Background task: split remaining messages between two new labels using Gemini.
+
+    On full success, deletes the (already-archived) original label and its
+    applications. If any batch fails, leaves the original archived-but-intact
+    so an admin can un-archive it and replay rather than losing the human
+    examples that produced this split.
+    """
     from autolabel_service import classify_batch
 
     global _autolabel_status
@@ -1108,6 +1124,7 @@ def _run_split_autolabel(
 
     label_map = {new_label_a_name: new_label_a_id, new_label_b_name: new_label_b_id}
 
+    any_batch_failed = False
     BATCH_SIZE = 30
     for i in range(0, len(remaining_messages), BATCH_SIZE):
         batch = remaining_messages[i : i + BATCH_SIZE]
@@ -1116,6 +1133,7 @@ def _run_split_autolabel(
             results = classify_batch(label_defs, examples_by_label, batch)
         except Exception as e:
             _autolabel_status["error"] = f"Gemini error at batch {i}: {str(e)}"
+            any_batch_failed = True
             continue
 
         with Session(engine) as db:
@@ -1136,6 +1154,20 @@ def _run_split_autolabel(
             db.commit()
 
         _autolabel_status["processed"] = min(i + BATCH_SIZE, len(remaining_messages))
+
+    # Atomic cleanup: only purge the snapshot once classification succeeded
+    # for every batch. Otherwise leave it archived-but-recoverable.
+    if not any_batch_failed and original_label_id not in (new_label_a_id, new_label_b_id):
+        with Session(engine) as db:
+            old_apps = db.exec(
+                select(LabelApplication).where(LabelApplication.label_id == original_label_id)
+            ).all()
+            for a in old_apps:
+                db.delete(a)
+            old = db.get(LabelDefinition, original_label_id)
+            if old is not None:
+                db.delete(old)
+            db.commit()
 
     _autolabel_status["running"] = False
 
@@ -1478,7 +1510,10 @@ def get_concise_message(req: ConciseRequest, db: Session = Depends(get_session))
         raise HTTPException(status_code=404, detail="Message not found")
 
     from autolabel_service import summarize_message
-    concise = summarize_message(row[0])
+    try:
+        concise = summarize_message(row[0])
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Summarization failed: {e}")
     return {"concise_text": concise}
 
 
@@ -1633,19 +1668,25 @@ def split_label_autolabel(
                     }
                 )
 
-    # Delete original label and its applications
-    for app_ in remaining_apps:
-        db.delete(app_)
-    
-    # Only delete original if it's not one of the target labels (edge case)
+    # Defer deletion of the original label and its applications to the
+    # background task. If we deleted now and the Gemini classification later
+    # failed (rate limit, content policy, network), the human-applied examples
+    # would be permanently lost with no retry path. Instead: archive the
+    # original so the UI hides it, leave its rows intact as a recovery
+    # snapshot, and let the background task purge them after classification
+    # succeeds. If the background task fails, the original remains archived
+    # but un-archivable for retry.
     if original_label.id not in [label_a.id, label_b.id]:
-        db.delete(original_label)
-    
+        original_label.archived_at = datetime.utcnow()
+        db.add(original_label)
+
     db.commit()
 
-    # Start background task
+    # Start background task. It will delete original_label_id (and its
+    # remaining applications) only on full success.
     background_tasks.add_task(
         _run_split_autolabel,
+        original_label.id,
         original_label.name,
         label_a.id,
         label_a.name,
@@ -2758,10 +2799,13 @@ def get_assist(
     label_id: int,
     chatlog_id: int,
     message_index: int,
+    assignment_id: Optional[int] = None,
     db: Session = Depends(get_session),
 ):
     """Return cached nearest-neighbor decisions for the focused message.
-    The cache is built lazily by /next; if there is no row, returns []."""
+    The cache is built lazily by /next; if there is no row, returns [].
+    When assignment_id is provided, neighbors are restricted to the same assignment
+    so calibration stays within the lab/project context the run is scoped to."""
     label = db.get(LabelDefinition, label_id)
     if not label:
         raise HTTPException(status_code=404, detail=f"No label with id={label_id}")
@@ -2772,7 +2816,7 @@ def get_assist(
         )
 
     neighbors = assist_service.get_cached_neighbors(
-        db, label_id, chatlog_id, message_index
+        db, label_id, chatlog_id, message_index, assignment_id=assignment_id
     )
     return AssistResponse(
         neighbors=[AssistNeighbor(**n) for n in neighbors]
@@ -2789,6 +2833,13 @@ def post_decide(
     label = db.get(LabelDefinition, label_id)
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="Single-label not found")
+    if label.phase != "labeling":
+        # Reject decisions on queued/handed-off/reviewing/complete labels so a
+        # stale browser tab can't silently overwrite a finished run's data.
+        raise HTTPException(
+            status_code=409,
+            detail=f"Label {label_id} is in phase {label.phase!r}; decisions only allowed in 'labeling'",
+        )
     if req.value not in {"yes", "no", "skip"}:
         raise HTTPException(status_code=400, detail="value must be yes|no|skip")
     decision_service.record_decision(

--- a/src/components/run/AbortConfirmModal.tsx
+++ b/src/components/run/AbortConfirmModal.tsx
@@ -11,19 +11,30 @@ interface Props {
 export function AbortConfirmModal({ labelName, yesCount, noCount, onConfirm, onCancel }: Props) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel()
+      if (e.key !== 'Escape') return
+      // Stop propagation so a stacked modal or page-level Escape handler
+      // doesn't also fire on the same keystroke.
+      e.stopPropagation()
+      onCancel()
     }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
+    window.addEventListener('keydown', handler, { capture: true })
+    return () => window.removeEventListener('keydown', handler, { capture: true })
   }, [onCancel])
 
   const total = yesCount + noCount
 
+  // Track mousedown target on the overlay so a click that started inside the
+  // inner card (e.g., text selection drag) doesn't dismiss when released
+  // outside it.
+  const handleOverlayMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onCancel()
+  }
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay" onClick={onCancel}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay" onMouseDown={handleOverlayMouseDown}>
       <div
         className="bg-surface border border-edge rounded-xl p-6 max-w-sm w-full shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center gap-2 mb-3">
           <span className="text-brick text-lg">&#9888;</span>

--- a/src/pages/AnalysisPage.tsx
+++ b/src/pages/AnalysisPage.tsx
@@ -294,6 +294,30 @@ export function AnalysisPage() {
   const barScale = rawBarPctSum > 100 ? 100 / rawBarPctSum : 1
   const barPct = (n: number) => pctOfTotal(n) * barScale
 
+  // Largest-remainder rounding so the three coverage % rows sum to exactly
+  // 100.0% (with rounding to 1 decimal). Otherwise three independent
+  // .toFixed(1) calls can land on 33.3 + 33.3 + 33.3 = 99.9.
+  const coveragePct = ((): { human: string; ai: string; unlabeled: string } => {
+    const raw = [pctOfTotal(covHuman), pctOfTotal(covAi), pctOfTotal(covUnlabeled)]
+    const totalRaw = raw.reduce((a, b) => a + b, 0)
+    if (totalRaw === 0) return { human: "0.0", ai: "0.0", unlabeled: "0.0" }
+    const target = totalRaw <= 100 ? totalRaw : 100  // overlap edge case
+    const scaled = raw.map((v) => (v / totalRaw) * target * 10)  // tenths of a %
+    const floors = scaled.map(Math.floor)
+    let leftover = Math.round(target * 10) - floors.reduce((a, b) => a + b, 0)
+    const order = scaled
+      .map((v, i) => ({ i, frac: v - Math.floor(v) }))
+      .sort((a, b) => b.frac - a.frac)
+    const tenths = floors.slice()
+    for (const { i } of order) {
+      if (leftover <= 0) break
+      tenths[i] += 1
+      leftover -= 1
+    }
+    const fmt = (t: number) => (t / 10).toFixed(1)
+    return { human: fmt(tenths[0]), ai: fmt(tenths[1]), unlabeled: fmt(tenths[2]) }
+  })()
+
   const posData = Object.entries(summary.position_distribution)
     .map(([label, buckets]) => ({
       label,
@@ -571,17 +595,17 @@ export function AnalysisPage() {
                     <tr className="border-t border-edge-subtle">
                       <td className="p-2">Human-labeled</td>
                       <td className="p-2 text-right tabular-nums">{covHuman.toLocaleString()}</td>
-                      <td className="p-2 text-right tabular-nums">{pctOfTotal(covHuman).toFixed(1)}%</td>
+                      <td className="p-2 text-right tabular-nums">{coveragePct.human}%</td>
                     </tr>
                     <tr className="border-t border-edge-subtle">
                       <td className="p-2">AI-labeled</td>
                       <td className="p-2 text-right tabular-nums">{covAi.toLocaleString()}</td>
-                      <td className="p-2 text-right tabular-nums">{pctOfTotal(covAi).toFixed(1)}%</td>
+                      <td className="p-2 text-right tabular-nums">{coveragePct.ai}%</td>
                     </tr>
                     <tr className="border-t border-edge-subtle">
                       <td className="p-2">Unlabeled</td>
                       <td className="p-2 text-right tabular-nums">{covUnlabeled.toLocaleString()}</td>
-                      <td className="p-2 text-right tabular-nums">{pctOfTotal(covUnlabeled).toFixed(1)}%</td>
+                      <td className="p-2 text-right tabular-nums">{coveragePct.unlabeled}%</td>
                     </tr>
                     <tr className="border-t border-edge-subtle bg-surface/60 font-medium text-on-canvas">
                       <td className="p-2">Total messages</td>

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { StripBar } from '../components/run/StripBar'
 import { QueueLine } from '../components/run/QueueLine'
 import { ConversationMeta } from '../components/run/ConversationMeta'
@@ -42,16 +42,27 @@ export function LabelRunPage() {
   const [assistNeighbors, setAssistNeighbors] = useState<AssistNeighbor[]>([])
   const [abortOpen, setAbortOpen] = useState(false)
 
-  const syncActiveLabelCounts = useCallback((state: ReadinessState) => {
-    setActiveLabel((prev) => {
-      if (!prev) return prev
-      return {
-        ...prev,
-        yes_count: state.yes_count,
-        no_count: state.no_count,
-      }
-    })
-  }, [])
+  // Mirrors activeLabel.id so async handlers can detect a label switch that
+  // occurred while a decide/undo/skip was in flight, and avoid clobbering
+  // state of the new active label with the old one's response.
+  const activeLabelIdRef = useRef<number | null>(null)
+  useEffect(() => {
+    activeLabelIdRef.current = activeLabel?.id ?? null
+  }, [activeLabel?.id])
+
+  const syncActiveLabelCounts = useCallback(
+    (labelId: number, state: ReadinessState) => {
+      setActiveLabel((prev) => {
+        if (!prev || prev.id !== labelId) return prev
+        return {
+          ...prev,
+          yes_count: state.yes_count,
+          no_count: state.no_count,
+        }
+      })
+    },
+    []
+  )
 
   // Auto-clear the inline confirmation in the dock after a few seconds.
   useEffect(() => {
@@ -59,6 +70,14 @@ export function LabelRunPage() {
     const t = setTimeout(() => setRecent(null), 4000)
     return () => clearTimeout(t)
   }, [recent])
+
+  // Reset the assignment filter when the active label changes (handoff,
+  // abort, queue activation). Otherwise the new label inherits the previous
+  // label's filter and may show "done" prematurely if the new label has no
+  // messages in that assignment.
+  useEffect(() => {
+    setSelectedAssignmentId(null)
+  }, [activeLabel?.id])
 
   // Fetch assist neighbors whenever the focused message changes. Clear
   // synchronously so the previous message's neighbors don't linger during
@@ -71,13 +90,14 @@ export function LabelRunPage() {
       activeLabel.id,
       focused.chatlog_id,
       focused.thread[focused.focus_index].message_index,
+      selectedAssignmentId ?? undefined,
     ).then((res) => {
       if (!cancelled) setAssistNeighbors(res.neighbors)
     }).catch(() => {
       if (!cancelled) setAssistNeighbors([])
     })
     return () => { cancelled = true }
-  }, [activeLabel?.id, focused?.chatlog_id, focused?.focus_index])
+  }, [activeLabel?.id, focused?.chatlog_id, focused?.focus_index, selectedAssignmentId])
 
   // Refetch the page state. Called on mount, after decisions, after undo, after queue add.
   const refresh = useCallback(async () => {
@@ -128,16 +148,19 @@ export function LabelRunPage() {
       if (!activeLabel || !focused || busy) return
       setBusy(true)
       const decided = focused
+      const labelId = activeLabel.id
       try {
-        const next = await api.decide(activeLabel.id, {
+        const next = await api.decide(labelId, {
           chatlog_id: decided.chatlog_id,
           message_index: decided.message_index,
           value,
         }, selectedAssignmentId ?? undefined)
+        if (activeLabelIdRef.current !== labelId) return
         setFocused(next)
-        const ready = await api.getReadiness(activeLabel.id)
+        const ready = await api.getReadiness(labelId)
+        if (activeLabelIdRef.current !== labelId) return
         setReadiness(ready)
-        syncActiveLabelCounts(ready)
+        syncActiveLabelCounts(labelId, ready)
         setRecent({ value, label: `#${decided.chatlog_id}.${decided.message_index}` })
       } finally {
         setBusy(false)
@@ -149,13 +172,17 @@ export function LabelRunPage() {
   const handleUndo = useCallback(async () => {
     if (!activeLabel || busy) return
     setBusy(true)
+    const labelId = activeLabel.id
     try {
-      await api.undoLastDecision(activeLabel.id)
-      const next = await api.getNextFocused(activeLabel.id, selectedAssignmentId ?? undefined)
+      await api.undoLastDecision(labelId)
+      if (activeLabelIdRef.current !== labelId) return
+      const next = await api.getNextFocused(labelId, selectedAssignmentId ?? undefined)
+      if (activeLabelIdRef.current !== labelId) return
       setFocused(next)
-      const ready = await api.getReadiness(activeLabel.id)
+      const ready = await api.getReadiness(labelId)
+      if (activeLabelIdRef.current !== labelId) return
       setReadiness(ready)
-      syncActiveLabelCounts(ready)
+      syncActiveLabelCounts(labelId, ready)
       setRecent(null)
     } finally {
       setBusy(false)
@@ -166,12 +193,15 @@ export function LabelRunPage() {
     if (!activeLabel || !focused || busy) return
     const skippedCid = focused.chatlog_id
     setBusy(true)
+    const labelId = activeLabel.id
     try {
-      const next = await api.skipConversation(activeLabel.id, skippedCid)
+      const next = await api.skipConversation(labelId, skippedCid)
+      if (activeLabelIdRef.current !== labelId) return
       setFocused(next)
-      const ready = await api.getReadiness(activeLabel.id)
+      const ready = await api.getReadiness(labelId)
+      if (activeLabelIdRef.current !== labelId) return
       setReadiness(ready)
-      syncActiveLabelCounts(ready)
+      syncActiveLabelCounts(labelId, ready)
       setRecent({ value: 'skip', label: `every remaining message in #${skippedCid}` })
     } finally {
       setBusy(false)

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -99,9 +99,25 @@ export function QueuePage() {
 	const currentMessage = queue[currentIdx] ?? null;
 	const isBackNav = navPos !== null;
 	const isRecalibrating = recalibration !== null;
-	const displayedMessage = recalibration?.item
-		?? (isBackNav ? navStack[navPos!] : (reviewTarget ?? currentMessage));
-	const isReviewing = reviewTarget !== null;
+	// Single source of truth for the on-screen message + which mode produced
+	// it. Handlers should branch on `displayMode` rather than independently
+	// testing recalibration / backNav / reviewTarget — when those got out of
+	// sync, archive-review keyboard handlers used to apply labels to the
+	// wrong message.
+	type DisplayMode = 'recalibration' | 'backnav' | 'archive-review' | 'queue';
+	const { displayedMessage, displayMode } = (() => {
+		if (recalibration?.item) {
+			return { displayedMessage: recalibration.item, displayMode: 'recalibration' as DisplayMode };
+		}
+		if (isBackNav) {
+			return { displayedMessage: navStack[navPos!], displayMode: 'backnav' as DisplayMode };
+		}
+		if (reviewTarget) {
+			return { displayedMessage: reviewTarget, displayMode: 'archive-review' as DisplayMode };
+		}
+		return { displayedMessage: currentMessage, displayMode: 'queue' as DisplayMode };
+	})();
+	const isReviewing = displayMode === 'archive-review';
 	const aiUnlocked = (stats?.labeled_count ?? 0) >= 20;
 
 	const loadQueue = useCallback(async () => {
@@ -113,7 +129,9 @@ export function QueuePage() {
 	}, []);
 
 	useEffect(() => {
-		Promise.all([
+		// Use allSettled so a single failing endpoint (e.g., /candidates while
+		// concept-induction is unavailable) doesn't blank the whole queue.
+		Promise.allSettled([
 			api.startSession(),
 			api.getLabels(),
 			api.getQueue(20),
@@ -121,23 +139,29 @@ export function QueuePage() {
 			api.getQueuePosition(),
 			api.getRecentHistory(5),
 			api.getCandidates(),
-		])
-			.then(([sess, lbls, q, st, pos, hist, cands]) => {
-				setSession(sess);
-				setLabels(lbls);
-				setQueue(q);
-				setStats(st);
-				setSkippedCount(st.skipped_count);
-				setRemaining(pos.total_remaining);
-				setHistory(hist);
-				setCandidates(cands);
-				setLoading(false);
-				api.getRecalibrationStats().then(setRecalibrationStats).catch(() => {});
-			})
-			.catch((err) => {
-				console.error("Failed to load queue data:", err);
-				setLoading(false);
-			});
+		]).then(([sess, lbls, q, st, pos, hist, cands]) => {
+			if (sess.status === "fulfilled") setSession(sess.value);
+			if (lbls.status === "fulfilled") setLabels(lbls.value);
+			if (q.status === "fulfilled") setQueue(q.value);
+			if (st.status === "fulfilled") {
+				setStats(st.value);
+				setSkippedCount(st.value.skipped_count);
+			}
+			if (pos.status === "fulfilled") setRemaining(pos.value.total_remaining);
+			if (hist.status === "fulfilled") setHistory(hist.value);
+			if (cands.status === "fulfilled") setCandidates(cands.value);
+
+			const failures = [
+				["session", sess], ["labels", lbls], ["queue", q], ["stats", st],
+				["position", pos], ["history", hist], ["candidates", cands],
+			].filter(([, r]) => (r as PromiseSettledResult<unknown>).status === "rejected");
+			if (failures.length > 0) {
+				console.error("Queue load partial failure:",
+					failures.map(([k, r]) => [k, (r as PromiseRejectedResult).reason]));
+			}
+			setLoading(false);
+			api.getRecalibrationStats().then(setRecalibrationStats).catch(() => {});
+		});
 	}, []);
 
 	useEffect(() => {
@@ -665,8 +689,17 @@ export function QueuePage() {
 
 	const handleArchiveAnyway = useCallback(async () => {
 		if (!archiveConfirm) return;
-		await api.archiveLabel(archiveConfirm.labelId);
+		const archivedId = archiveConfirm.labelId;
+		await api.archiveLabel(archivedId);
 		setArchiveConfirm(null);
+		// Drop the archived label from any in-memory toggle state so a subsequent
+		// re-application doesn't target a now-archived label id.
+		setAppliedLabelIds((prev) => {
+			if (!prev.has(archivedId)) return prev;
+			const next = new Set(prev);
+			next.delete(archivedId);
+			return next;
+		});
 		const [lbls, q, st] = await Promise.all([
 			api.getLabels(),
 			api.getQueue(20),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -19,8 +19,15 @@ import {
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
 
 async function req<T>(path: string, options?: RequestInit): Promise<T> {
+  const method = (options?.method ?? 'GET').toUpperCase()
   const res = await fetch(path, options)
-  if (!res.ok) throw new Error(`${res.status} ${await res.text()}`)
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`${method} ${path} → ${res.status} ${body}`)
+  }
+  if (res.status === 204 || res.headers.get('content-length') === '0') {
+    return undefined as T
+  }
   return res.json()
 }
 
@@ -319,24 +326,30 @@ export const api = {
     labelId: number,
     chatlogId: number,
     messageIndex: number,
-  ): Promise<AssistResponse> =>
-    USE_MOCK
-      ? Promise.resolve({
-          neighbors: [
-            { chatlog_id: 100, message_index: 0, value: 'yes',
-              similarity: 0.84,
-              message_text: "i'm stuck on q3, can you walk me through how to compute the standard deviation" },
-            { chatlog_id: 101, message_index: 0, value: 'yes',
-              similarity: 0.79,
-              message_text: 'how do i actually solve part 2 — i tried mean(arr) but the autograder says wrong' },
-            { chatlog_id: 102, message_index: 0, value: 'no',
-              similarity: 0.71,
-              message_text: 'why does numpy default to dividing by n instead of n minus 1' },
-          ],
-        })
-      : req(
-          `/api/single-labels/${labelId}/assist?chatlog_id=${chatlogId}&message_index=${messageIndex}`,
-        ),
+    assignmentId?: number,
+  ): Promise<AssistResponse> => {
+    if (USE_MOCK) {
+      return Promise.resolve({
+        neighbors: [
+          { chatlog_id: 100, message_index: 0, value: 'yes',
+            similarity: 0.84,
+            message_text: "i'm stuck on q3, can you walk me through how to compute the standard deviation" },
+          { chatlog_id: 101, message_index: 0, value: 'yes',
+            similarity: 0.79,
+            message_text: 'how do i actually solve part 2 — i tried mean(arr) but the autograder says wrong' },
+          { chatlog_id: 102, message_index: 0, value: 'no',
+            similarity: 0.71,
+            message_text: 'why does numpy default to dividing by n instead of n minus 1' },
+        ],
+      })
+    }
+    const q = new URLSearchParams({
+      chatlog_id: String(chatlogId),
+      message_index: String(messageIndex),
+    })
+    if (assignmentId !== undefined) q.set('assignment_id', String(assignmentId))
+    return req(`/api/single-labels/${labelId}/assist?${q.toString()}`)
+  },
 
   handoffSingleLabel: (id: number, sampleSize?: number): Promise<HandoffResponse> => {
     const qs = sampleSize !== undefined ? `?sample_size=${sampleSize}` : ''

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,10 @@ export interface LabelExample {
   message_index: number
   message_text: string
   label_id: number
-  applied_by: string
+  /** "human" | "ai" for actual labelings; "none" for unlabeled candidates
+   * surfaced by QuickRefineModal. Filters that branch on this string must
+   * handle the "none" case. */
+  applied_by: "human" | "ai" | "none"
 }
 
 export interface ConciseResponse {


### PR DESCRIPTION
## Summary

A targeted bug-audit pass on `main` after PR #40. Fixes 17 issues across the new single-label run flow, the assist (cosine-NN) service, the autolabel pipeline, and the queue/analysis UI. Three audit findings were withdrawn after verification (already correct or latent-only); one was reclassified as a non-bug.

## What changes

### Backend (`fix(backend): bug-audit hardening...`)
- **assist**: scope cosine NN by `assignment_id` so calibration neighbors stay in the run's lab/project context. Replace row-count cache invalidation with a `(count, max_id, sum_id)` fingerprint so in-place re-embeds don't poison the matrix.
- **autolabel**: `classify_batch` raises `ClassifyToolMissing` instead of returning `[]` when Gemini doesn't tool-call; `summarize_message` no longer returns `"Error summarizing: ..."` as a normal summary string (`/queue/concise` now returns 502).
- **split-label autolabel**: defer destructive deletion of the original label to the background task and only on full success. The synchronous handler archives the original so the UI hides it, but the rows stay recoverable if Gemini fails mid-classification.
- **decide**: reject `/single-labels/{id}/decide` when the label isn't in `labeling` phase, so a stale tab can't write to a finished run.
- **queue history**: apply the search filter before slicing — `total` was off when search dropped page items.
- **definition_service**: typed `ValueError` instead of `IndexError` when `select_best_example` is called with no examples.

### Frontend (`fix(frontend): defensive API client + race-safe run handlers`)
- `req()` handles 204 / empty bodies and includes `METHOD path` in error messages.
- `getAssist` threads `assignment_id` through.
- `LabelRunPage` captures `activeLabel.id` at handler entry and gates every post-await state update on a ref check, so a label switch (handoff / abort / queue activation) mid-flight cannot clobber the new label's state with the previous label's response. `syncActiveLabelCounts` now takes `labelId` and no-ops on mismatch.
- Reset `selectedAssignmentId` on label change so a new label doesn't inherit the previous filter.
- `AbortConfirmModal`: capture-phase Escape with `stopPropagation`, mousedown-on-overlay dismissal so text-selection drags don't dismiss.

### Queue (`refactor(queue): single-source displayedMessage...`)
- Collapse `displayedMessage`'s three resolution sources into a single selector that returns both the message and a `DisplayMode` tag — handlers can branch on the mode rather than independently testing recalibration / backNav / reviewTarget.
- Drop archived label ids from `appliedLabelIds` so a subsequent re-application can't target a now-archived label.
- Initial load uses `Promise.allSettled` so a single failing endpoint doesn't blank the whole page.

### Analysis + types (`fix(analysis,types): coverage % sum-to-100...`)
- Coverage rows use largest-remainder rounding (was: three independent `.toFixed(1)` summing to 99.9% / 100.1%).
- `LabelExample.applied_by` widened to `"human" | "ai" | "none"` to match runtime usage in `QuickRefineModal`.

## What was NOT changed

- Migrating `datetime.utcnow()` → tz-aware datetimes (separate codebase-wide cleanup; current naive-vs-naive comparisons are consistent today).
- Folding readiness into the `/decide` response (would eliminate the second round-trip; current ref-guard fix is sufficient and lower-risk).
- Surfacing `tutor_usage.error` in the AnalysisPage UI (backend already returns it; UI banner is a follow-up).

## Test plan

- [x] `cd server/python && uv run pytest` — 175 passed
- [x] `npm test -- --run` — 67 passed
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: run the full single-label flow end-to-end with two assignments, switch labels mid-decide, abort active label
- [ ] Manual: trigger `/labels/split-autolabel`, kill Gemini API key mid-run, confirm original label is recoverable from `archived_at`
- [ ] Manual: confirm `/queue/history?search=...` returns matching `total` and items