### PR TITLE
Five themed handoff briefs + WORKFLOW.md rewrite

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,80 +1,104 @@
-# Chatsight Workflow Needs
+# Chatsight workflow
 
-## Research Context
+This file is the canonical "what is chatsight, what's built, what's open" pointer for collaborators. CLAUDE.md is for code orientation; this is for *research* orientation. When the two disagree, the more recently edited file wins — please flag the conflict.
 
-Chatsight originated as an investigation into student-AI tutoring interactions in an undergraduate data science course. The AI tutor is fine-tuned to reference course material (homeworks, labs, projects) during student conversations.
-
-### Research Evolution
-
-1. **Initial goal**: Analyze transcript data to understand how students interact with AI tutors. Available methods (sentiment analysis, summary statistics, AI-generated summaries) were insufficient for rich qualitative insights.
-
-2. **Second pivot**: Quantify "how well students use AI" via a theoretical scoring equation applied to categorized student messages. This required labeled data.
-
-3. **Manual labeling attempt**: The research group manually labeled chatlog data to build a training set. Key problems surfaced:
-   - Rubrics defined upfront became too broad or too narrow mid-process, requiring full relabeling
-   - Team members had different threshold interpretations of rubric criteria, causing inconsistency
-   - Wasted effort and high anxiety when label schemas needed revision after significant work
-
-4. **Current focus** (HCI + CS Ed research): Build an interface that makes chatlog labeling *efficient and consistent* for instructors. The scoring equation is deprioritized — the labeling tool itself is the research contribution.
+Last rewritten: 2026-05-07. Supersedes the 2026-03-28 version (which described the multi-label queue era, before the single-label binary pivot).
 
 ---
 
-## Current Goal
+## Research context
 
-Help instructors label student-AI chatlog data with minimal friction:
-- Sessions of approximately 30 minutes to 1 hour
-- Labels emerge bottom-up from reading data (no fixed rubric required upfront)
-- AI assists in suggesting and validating labels
-- After instructor labels a sufficient sample, AI auto-labels the rest
+Chatsight is HCI + CS-Education research on student–AI tutoring interactions in an undergraduate data-science course. The AI tutor under study is fine-tuned to reference course material (homeworks, labs, projects) when answering student questions.
+
+The research contribution is **the labeling tool itself** — an interface that makes hybrid AI-assisted chatlog labeling efficient and consistent for instructors. An earlier "scoring equation" framing was deprioritized; what remains valuable is the workflow innovation, not the downstream metric.
 
 ---
 
-## Workflow Needs
+## Current state (post single-label pivot)
 
-### 1. Instructor-First Labeling
-- Instructors read through messages (or a sample) and create label categories as they go
-- Labels emerge from the data rather than being predefined
-- Instructors apply labels to individual student messages within transcripts
-- Interface should support creating a new label on the fly while reading
+The primary flow is a **per-label binary classification run**: the instructor selects one label at a time and decides yes / no / skip on each student message in a queue. After enough decisions, the run can be handed off so a Gemini classifier labels the rest, and the instructor reviews ambiguous cases.
 
-### 2. AI-Assisted Label Suggestion
-- After instructors establish some initial labels, AI (Gemini) suggests labels for unlabeled messages
-- AI may also propose new candidate label categories it detects in the data
-- Instructor reviews and accepts/rejects AI suggestions
-- Inspired by **LLOOM** (concept-based LLM analysis) and **DocWrangler** (interactive LLM-assisted document labeling)
+The older multi-label queue (apply N labels per message in one pass) still works and has its own page, but is dormant for new feature work.
 
-### 3. Label Management & Refinement
-- View all messages grouped by label to assess category consistency
-- **Split**: identify a label that is too broad and divide it into subcategories
-- **Merge**: identify two labels that mean the same thing and combine them
-- **Rename/redefine**: clarify what a label means after seeing real examples
-- This view is critical for maintaining labeling consistency across team members
+What's in place today (as of 2026-05-07):
 
-### 4. Sampling Strategy (Open Question)
-Two directions under consideration:
-- **Random sampling**: select a random subset of messages/conversations to label
-- **Diverse/robust sampling**: use some method (e.g., embedding-based diversity, stratified by notebook/topic) to ensure the sample is representative
+- **Single-label run** (`src/pages/LabelRunPage.tsx`, `server/python/decision_service.py`, `queue_service.py`). One label, one focused message, three keys: yes / no / skip.
+- **Assist flank**: a per-message panel showing the three nearest cosine-NN neighbors among the instructor's prior decisions, as a calibration anchor (`assist_service.py`, `MessageEmbedding` table). Now scoped by `assignment_id` (PR #41).
+- **Assignment mappings**: regex-named groups (e.g. `^lab0?3` → "Lab 3") so a run can be filtered to one lab or project (`AssignmentMapping`, `AssignmentsPage.tsx`).
+- **Handoff + sample handoff**: classify all (or `?sample_size=N`) remaining messages with Gemini once the human run is done; instructor reviews low-confidence cases before merge.
+- **Label management**: create / merge / split / archive labels; archived labels orphan their applications, which can be returned to the queue or auto-classified into new labels.
+- **Concept induction** (`concept_service.py`): cluster unlabeled messages via embedding + KMeans, ask Gemini to name each cluster, surface as candidate labels. Implemented but **lightly used** — not currently part of the primary onboarding flow.
+- **Recalibration design** at `docs/superpowers/specs/2026-04-11-recalibration-design.md`: blind re-labeling at adaptive intervals to detect drift. Designed, scaffolding tests exist, **not implemented end-to-end**.
+- **Analysis page** (`AnalysisPage.tsx`): coverage table, position distribution, temporal usage, label/notebook heatmap. Reasonably full but not yet research-grade.
+- **Bug-audit pass** landed 2026-05-07 (PR #41) hardened assist scope, race guards in the run flow, and a deferred-deletion split-label flow.
 
-Goal: ensure a short labeling session yields a training set that generalizes to the full dataset.
-
-### 5. AI Auto-Labeling the Rest
-- Once instructors have labeled a sufficient sample, AI labels remaining messages
-- Preferred: interpretable and transparent rather than a black box
-- Open question: few-shot prompting with Gemini, fine-tuned model, or traditional classifier trained on embeddings
+> **TODO (user)**: anything in the above list that's wrong, missing, or oversold — please call out before this doc is referenced from collaborator briefs.
 
 ---
 
-## Open Design Questions
+## Primary flows
 
-1. **Labeling unit**: Individual messages? Message pairs (student + AI response)? Conversation-level?
-2. **Sampling**: Random vs. representative — how do we know when we have "enough" labeled data?
-3. **Multi-instructor**: How do we handle disagreements when two instructors label the same message differently?
-4. **Label schema versioning**: When labels are merged or split, how do we handle previously labeled data?
-5. **Session scope**: Do instructors label within one conversation at a time, or across many conversations looking for patterns?
+| Flow | Page | Status |
+|------|------|--------|
+| Single-label run (yes / no / skip per message, one label at a time) | `LabelRunPage.tsx` (`/run`) | **Active** — primary flow |
+| Multi-label queue (apply N labels per message) | `QueuePage.tsx` (`/queue`) | Legacy; no new feature work |
+| Label management (create / merge / split / archive) | `LabelsPage.tsx` (`/labels`) | Active |
+| Assignment mappings (regex → assignment name) | `AssignmentsPage.tsx` (`/assignments`) | Active |
+| Handoff summaries (post-run AI classification status) | `SummariesPage.tsx` (`/summaries`) | Active |
+| Analysis | `AnalysisPage.tsx` (`/analysis`) | Active, sparse on research-grade views |
+| History | `HistoryPage.tsx` (`/history`) | Active, minimal |
+
+---
+
+## AI integration points
+
+| Surface | Service | What it does |
+|---------|---------|---------------|
+| Assist flank | `assist_service.py` (cosine-NN over `MessageEmbedding`) | Surfaces 3 most-similar prior decisions to anchor calibration |
+| Handoff classifier | `binary_autolabel_service.py` (Gemini function-calling) | Classifies remaining messages yes / no for one label |
+| Multi-label batch (legacy) | `autolabel_service.py` | Classifies messages into N existing label categories |
+| Label description from examples | `definition_service.py` | One-sentence Gemini-written label definitions |
+| Concept candidates | `concept_service.py` (embedding + KMeans + Gemini naming) | Bottom-up label suggestions from unlabeled clusters |
+| Concise summary | `autolabel_service.summarize_message` | Shortens long student messages for display |
+
+---
+
+## What's mature vs WIP
+
+**Mature**: single-label run, assist flank, label management (create / archive / merge / split-with-handoff), assignment mappings, basic analysis coverage.
+
+**WIP / sparse**:
+- Recalibration / drift detection (designed, not implemented).
+- Multi-rater support (data model still flat per message).
+- Classifier evaluation (no systematic measurement of Gemini's quality).
+- Classifier prompt / few-shot strategy (uses a fixed prompt, naive examples).
+- Concept induction integration (the service exists; the UX flow does not surface it well).
+- Analysis page as a research-grade dashboard.
+
+**Dormant**: multi-label queue page (intentional — kept working but not prioritized).
+
+---
+
+## Open questions
+
+These supersede the 2026-03 list (which was tied to the older multi-label flow). Five of these are being assigned to research collaborators as week-of-part-time-work briefs (see `docs/handoffs/`):
+
+1. **Smart picker** — what should the queue show next? Current ordering is conversation-aware but not signal-driven. Active-learning literature offers several routes (uncertainty sampling, diversity, calibration-anchored selection).
+2. **Drift** — how do we detect and surface labeler inconsistency within a session? The recalibration design is one answer; others exist.
+3. **Multi-rater** — how do we model and resolve disagreement when more than one instructor labels the same data?
+4. **Classifier quality** — how good is the Gemini handoff classifier today, and what prompt / few-shot strategy actually moves the needle? Build the eval harness first, then run experiments on top of it.
+5. **Onboarding / first-30-minutes UX** — what does a new instructor see on first open? The current flow assumes they already know what "single-label binary" means. Design the first-session experience: tutorial, defaults, what to label first, when to hand off.
+
+Independent (not currently assigned to collaborators):
+
+- **Schema versioning across runs** — when labels are merged or split mid-project, what happens to the analytical history? Today the archive flow handles orphans at the application level; project-wide schema evolution is unclear.
+- **Concept induction in the user flow** — the LLOOM-inspired concept service exists but doesn't integrate cleanly with the single-label flow. Where should bottom-up candidates surface?
 
 ---
 
 ## Inspirations
 
-- **LLOOM** (Lam et al.): LLM-driven concept extraction and iterative refinement over text corpora
-- **DocWrangler** (Jiang et al.): Interactive interface for LLM-assisted document labeling with merge/split/refine operations
+- **LLOOM** (Lam et al.) — LLM-driven concept extraction and iterative refinement over text corpora. Conceptual ancestor of `concept_service.py`.
+- **DocWrangler** (Jiang et al.) — Interactive LLM-assisted document labeling with merge / split / refine. Conceptual ancestor of the label-management flow.
+
+Neither is a direct technical dependency; the influence is on workflow design (bottom-up labels, iterative refinement, AI-as-suggestion-not-arbiter).

--- a/docs/handoffs/.gitignore
+++ b/docs/handoffs/.gitignore
@@ -1,0 +1,4 @@
+/.quarto/
+**/*.quarto_ipynb
+_output/
+*.pdf

--- a/docs/handoffs/00-shared-background.qmd
+++ b/docs/handoffs/00-shared-background.qmd
@@ -1,0 +1,51 @@
+## Background — what chatsight is, before you start
+
+Chatsight is HCI + CS-Education research on student–AI tutoring conversations from an undergraduate data-science course. The AI tutor under study is fine-tuned to reference course material when answering students. The research artifact is **the labeling tool itself** — an interface that helps instructors label these conversations efficiently and consistently.
+
+The tool is currently mid-pivot. The primary flow is a **per-label binary classification run**: the instructor picks one label, then for each message in a queue presses yes / no / skip. After enough decisions, a Gemini classifier labels the rest, and the instructor reviews ambiguous cases. An older multi-label queue still works but is dormant for new feature work.
+
+### Read these before you start
+
+- `WORKFLOW.md` — the canonical "what's built, what's open" doc. Recently rewritten; trust it over the older specs.
+- `CLAUDE.md` — code orientation: where things live, how to run dev, env vars, two-DB setup.
+- `docs/superpowers/specs/2026-04-27-single-label-pivot-design.md` — the canonical design of the current flow.
+- The latest 5–10 `git log --oneline` entries on `main`. Recent commits document recent fixes and new features faster than any spec.
+- `.agents/research/2026-05-07-bug-audit-main.md` if it's still around — fragile areas to be careful around (it's gitignored, so ask).
+
+### Setting up dev
+
+Two terminals, in this order:
+
+```bash
+# Terminal A — backend
+cd server/python
+uv run uvicorn main:app --reload    # :8000
+
+# Terminal B — frontend
+npm run dev                          # :5173
+```
+
+You will need `GEMINI_API_KEY` and a `kubectl port-forward` to the external Postgres on `localhost:5432` for chatlog reads. If you only need the labeling UI without real chatlogs, set `VITE_USE_MOCK=true`.
+
+Tests:
+
+```bash
+cd server/python && uv run pytest    # backend
+npm test -- --run                     # frontend
+npx tsc --noEmit                      # type-check
+```
+
+### Conventions
+
+- Branch off `main`. Branch name: `handoff/<theme-slug>` (e.g. `handoff/smart-picker`).
+- Open a draft PR early, even at sketch stage. We'd rather see direction at day 2 than a finished thing on day 7.
+- Mid-week (≈ day 4) is a natural code-review checkpoint. Tag the maintainers on the PR or DM them.
+- The single-label run flow (`/run`) is in active production-ish use by the lab; do not break it. Behind-feature-flag is fine.
+- Comments only when WHY is non-obvious. Names should explain WHAT.
+- No drive-by refactors of unrelated code in your PR — keep the diff scoped.
+
+### Effort and shape
+
+Roughly **one week of part-time work**. The deliverable is a PR, not a paper. The thinking is yours; we'll meet you wherever the design lands so long as it's defensible and the code is shippable.
+
+If you finish "early," the **Stretch** section in your brief lists directions to push further. If you fall behind, the **Evaluation** section describes the minimum we'd merge.

--- a/docs/handoffs/01-smart-picker.qmd
+++ b/docs/handoffs/01-smart-picker.qmd
@@ -1,0 +1,73 @@
+---
+title: "Smart picker — what should the queue show next?"
+subtitle: "Chatsight handoff brief · theme 1 of 5"
+author: "Recipient: ____________"
+date: today
+format:
+  pdf:
+    toc: false
+    geometry:
+      - margin=1in
+expected_effort: "≈1 week, part-time"
+---
+
+{{< include 00-shared-background.qmd >}}
+
+## The theme
+
+When an instructor begins a single-label run, the queue walks messages in a conversation-aware fixed order: one conversation at a time, in order of `chatlog_id` (which derives from `MIN(events.id)` per conversation). That ordering is fine but it doesn't *use* anything we know about the messages or the run so far. **Should it?**
+
+Active-learning literature has been arguing for thirty years that picking what to label next is a leverage point. The question for chatsight: which signal — and what kind of pluggable picker — actually moves the needle for an instructor labeling for ~30 minutes? Some directions you might consider, none of which are right or wrong:
+
+- **Uncertainty sampling** — pick the message a calibrated classifier is least sure about.
+- **Diversity sampling** — pick messages that maximize coverage of the embedding space.
+- **Calibration anchors** — pick messages that *resemble* recent decisions, so the assist flank stays informative.
+- **Hybrid** — uncertainty for the first half, diversity for the second.
+- **Conversation-coherent** — keep grouping by conversation but choose which conversation next using a signal.
+
+The recipient picks one (or composes their own), prototypes it as a pluggable picker behind a feature flag, and evaluates against existing labeled data.
+
+## Why it matters
+
+If a smarter picker shaves the labels-needed-before-handoff number from, say, 80 to 50, that is a 35% reduction in instructor labor for the same downstream classifier quality. It is also genuinely interesting research territory — the assist flank already does cosine NN, so embedding-based pickers compose naturally.
+
+## Pointers
+
+- **`server/python/queue_service.py`** — `next_message_for_label()` is where the current ordering lives. Make this pluggable.
+- **`server/python/assist_service.py`** — already builds an in-memory cosine-NN matrix over `MessageEmbedding`. Reuse this; do not build a second embedding cache.
+- **`server/python/decision_service.py`** — `compute_readiness()` shows the existing readiness tiers. A new picker could use yes/no/skip counts as input.
+- **`ConversationCursor` model** — tracks `last_message_index_decided` per `(label, chatlog)`. Smart pickers may want to extend this or replace it.
+- **PR #41 (bug audit)** introduced `assignment_id` scoping for the assist flank. Whatever picker you write should also respect `assignment_id`.
+- **Active-learning literature**: Settles 2009 survey is the canonical entry. BALD (Houlsby 2011) for uncertainty in deep models. LLOOM (Lam et al.) and DocWrangler (Jiang et al.) for adjacent HCI takes.
+
+What *not* to assume:
+
+- Don't assume a single "correct" picker exists for this domain. The point of the brief is to compare your choice against a baseline.
+- Don't assume the existing `MessageEmbedding` cache covers every message. Some messages may not be embedded yet — handle gracefully.
+
+## Constraints
+
+- Branch: **`handoff/smart-picker`**.
+- Deliverable: a PR that lands a pluggable picker interface plus at least one non-trivial implementation, gated by a feature flag (env var or column on `LabelDefinition`). The default behavior should be unchanged for everyone not on the flag.
+- Do not modify the user-facing `/run` UI shape. The smart picker is a backend swap.
+- Tests: at least one test in `server/python/tests/` exercising the new picker against fixture data; the existing `test_queue_actions.py` and `test_decision_service.py` patterns are good models.
+- Code-review checkpoint at ~day 4: open a draft PR with the interface and a stub implementation by then.
+
+## Evaluation (self-check)
+
+You can confidently say "done" when:
+
+- A `Picker` interface (or equivalent abstraction) exists in `server/python/`, with at least one concrete implementation beyond the current ordering.
+- The default is unchanged when the flag is off; the new picker is reachable when the flag is on.
+- A small offline benchmark — even a single notebook in `docs/handoffs/01-smart-picker-results/` — compares your picker against the current ordering on existing human-labeled data, on at least one defensible metric (calls to handoff, classifier P/R/F1 after handoff, label-balance variance, etc.).
+- A short rationale in the PR body explaining the picker you chose and what you'd try next.
+
+We'd merge that, even if the picker doesn't win the benchmark. The point is that the door is open.
+
+## Stretch
+
+If you finish early:
+
+- Explore the picker as an *online* algorithm that reacts within a session (Thompson sampling, ε-greedy across multiple pickers).
+- Wire the picker's "expected information gain" into the `ProgressSidebar` so the instructor sees *why* a message was chosen.
+- Add a second concrete picker so the comparison is three-way (current vs picker-A vs picker-B).

--- a/docs/handoffs/02-drift.qmd
+++ b/docs/handoffs/02-drift.qmd
@@ -1,0 +1,72 @@
+---
+title: "Drift — detecting and correcting label inconsistency in a session"
+subtitle: "Chatsight handoff brief · theme 2 of 5"
+author: "Recipient: ____________"
+date: today
+format:
+  pdf:
+    toc: false
+    geometry:
+      - margin=1in
+expected_effort: "≈1 week, part-time"
+---
+
+{{< include 00-shared-background.qmd >}}
+
+## The theme
+
+Instructors drift. Halfway through a 30-minute single-label run, the bar for "yes" shifts subtly — the same kind of message that was a clean YES at message 5 is now a NO at message 60, or vice versa. This is observable in the existing data; it is not solved.
+
+A 2026-04 design (`docs/superpowers/specs/2026-04-11-recalibration-design.md`) proposes blind re-labeling at adaptive intervals, with a sparkline-based consistency trend and a reconciliation UI when the instructor disagrees with their past self. The design has scaffolding tests but is **not implemented** end-to-end.
+
+The open question is upstream of that design: **what is "drift" in this domain, and how should we surface it?** Some defensible interpretations:
+
+- **Self-disagreement on blind re-labels** — what the recalibration spec measures.
+- **Shifting label distribution** — is the YES rate trending up or down within a session in a way that doesn't track the underlying data?
+- **Increasing skip rate** — proxy for fatigue or confusion.
+- **Decision-time creep** — labels coming faster (cursoriness) or slower (uncertainty).
+- **Disagreement with neighbors in the assist flank** — the instructor labels something differently from three nearest prior decisions.
+
+The recipient picks one or two definitions, prototypes detection plus a UI surface, and evaluates on either real session data or a synthetic-drift fixture.
+
+## Why it matters
+
+Drift is a quality-of-labels problem. If we don't catch it, the resulting human-labeled set is internally inconsistent and the downstream Gemini classifier learns a smeared decision boundary. If we catch it but nag the instructor too much, the tool becomes annoying and gets put down. The brief is to find the line.
+
+## Pointers
+
+- **`docs/superpowers/specs/2026-04-11-recalibration-design.md`** — read it. The recipient is **free to depart from it**: keep what's right, discard what isn't, justify in the PR.
+- **`server/python/models.py`** — `RecalibrationEvent` is already in the schema. So is the adaptive-interval scaffolding.
+- **`server/python/tests/test_recalibration.py`** — the adaptive-interval tests assume the spec's framing. Update or delete as your design dictates.
+- **`server/python/decision_service.py`** — `record_decision()` is where you'd hook drift signals (e.g., flag a decision that disagrees with assist-flank neighbors).
+- **`src/components/queue/RecalibrationOverlay.tsx`** — a drafted UI surface for the spec's flow. Could be reused or replaced.
+- **Literature**: concept-drift detection (DDM, Page-Hinkley, ADWIN); inter-rater agreement over time; "calibration drift" in clinical scoring.
+
+What *not* to assume:
+
+- Don't assume the existing recalibration design is the right answer. The spec was written before the assist flank existed and may be over-engineered now that the instructor has live calibration anchors.
+- Don't ship a UI that interrupts the instructor's flow on every drift signal. False positives are toxic here.
+
+## Constraints
+
+- Branch: **`handoff/drift`**.
+- Deliverable: a PR that lands at least one drift signal (computed) and one UI surface (either an in-flow indicator like a sparkline, or an opt-in "review my recent decisions" affordance). Behind a feature flag if you're nervous.
+- The single-label run flow must still work for users who haven't opted into drift detection.
+- Tests: drift signal computation should have unit tests using fixture decision sequences.
+- Code-review checkpoint at ~day 4.
+
+## Evaluation (self-check)
+
+You can confidently say "done" when:
+
+- The PR defines drift in one or two specific ways and explains the choice.
+- At least one signal is computed end-to-end (decision row → drift score) with tests.
+- At least one UI surface exists (need not be polished; ASCII-grade is fine for the prototype).
+- A short evaluation — synthetic drift injected into a fixture, signal triggers as expected; or real session data with drift visibly identified.
+- The PR body has a "what I'd do next" paragraph; future iterations build on it.
+
+## Stretch
+
+- Compare two drift definitions head-to-head on the same session data; recommend one for v2.
+- Extend the signal to **between-session** drift (instructor's calibration shifts across days, not just within an hour).
+- Wire drift into the `Smart picker` brief's pluggable picker — drift could downweight messages that are too close to ones already labeled with shifting bars.

--- a/docs/handoffs/03-multi-rater.qmd
+++ b/docs/handoffs/03-multi-rater.qmd
@@ -1,0 +1,72 @@
+---
+title: "Two instructors, one dataset — multi-rater support"
+subtitle: "Chatsight handoff brief · theme 3 of 5"
+author: "Recipient: ____________"
+date: today
+format:
+  pdf:
+    toc: false
+    geometry:
+      - margin=1in
+expected_effort: "≈1 week, part-time"
+---
+
+{{< include 00-shared-background.qmd >}}
+
+## The theme
+
+Today, exactly one human can label any given `(label, chatlog_id, message_index)`. The `LabelApplication` row is unique on that triple. If two instructors looked at the same data, the second would silently overwrite the first.
+
+Real labeling-research practice cares about inter-rater reliability. **How should chatsight model and support more than one human labeling the same messages?**
+
+Three intertwined design questions, each with several defensible answers:
+
+- **Data model**: a `rater_id` column? A new `LabelDecision` table that's many-to-one to `LabelApplication`? A separate "consensus" application that's the function of N raters?
+- **Agreement metric**: Cohen's κ for two raters? Fleiss' κ for ≥3? Krippendorff's α (handles ordinal labels and missing data)? Or just F1 between rater pairs?
+- **Disagreement-resolution UI**: side-by-side viewer? Third-rater tiebreak? Discussion thread? Auto-promote when `n` raters agree?
+
+Recipient designs the data model, computes at least one metric, and prototypes a disagreement-resolution surface.
+
+## Why it matters
+
+This unlocks the next layer of research credibility. Without IRR, every claim about "instructors labeled X" is single-source. With it, we can talk about how *replicable* a labeling decision is — and use that to weight what the AI classifier should learn from.
+
+It's also an interesting cross-cut into the existing flow: the assist flank, drift detection (theme 2), and the auto-handoff classifier all behave differently when the ground-truth is a *distribution* over raters rather than a single label.
+
+## Pointers
+
+- **`server/python/models.py`** — `LabelApplication` is the row to think about extending or layering.
+- **`server/python/decision_service.py`** — `record_decision()` is the single chokepoint for human writes. Multi-rater changes route through here.
+- **`server/python/main.py`** — many endpoints assume a single human, including `/queue/history`, `/analysis/summary`, and the readiness math. Inventory which need multi-rater awareness.
+- **`src/pages/AnalysisPage.tsx`** — the natural surface for an IRR/agreement view. Currently sparse on research-grade metrics.
+- **Literature**: Cohen 1960 (κ); Fleiss 1971 (multi-rater κ); Krippendorff (α); Hallin & Mancini for political science methodology of comparable scope; Artstein & Poesio 2008 for an NLP-flavored survey of inter-annotator agreement.
+
+What *not* to assume:
+
+- Don't assume "user accounts" exist in chatsight today. They don't — the tool is single-tenant. A `rater_id` could come from a cookie, an env var, or a CLI flag at session start, depending on your taste. Pick one and justify.
+- Don't try to retrofit existing `LabelApplication` rows under a new schema unless you really want to. A clean cutover is acceptable: pre-multi-rater rows are "rater_id = legacy" or similar.
+- Don't ship a feature that requires real-time collaboration. Asynchronous multi-rater is the bar.
+
+## Constraints
+
+- Branch: **`handoff/multi-rater`**.
+- Deliverable: a PR that lands a data model accommodating multiple raters, at least one IRR metric computed and surfaced (anywhere defensible — the Analysis page is the obvious target), and a minimum-viable disagreement-resolution UI.
+- The single-rater happy path must continue to work without changes for someone who hasn't onboarded a second rater.
+- Tests: schema migration, decision recording with multiple raters, metric computation against a fixture.
+- Code-review checkpoint at ~day 4 — bring the schema decision early, that's the highest-leverage choice.
+
+## Evaluation (self-check)
+
+You can confidently say "done" when:
+
+- Schema accommodates ≥2 raters per message.
+- At least one IRR metric is computed and displayed somewhere.
+- A disagreement view shows side-by-side what two raters chose.
+- The single-rater flow is uncriticically supported (existing pre-multi-rater data still rendered correctly).
+- The PR body explains schema choice + metric choice + the call you made on resolution UX.
+
+## Stretch
+
+- Implement a third-rater tiebreak flow.
+- Use rater agreement as a *signal into the auto-handoff classifier*: train the Gemini handoff prompt only on messages where ≥2 raters agreed.
+- Extend the `Smart picker` brief's picker with an "uncertain disagreement" mode that prioritizes what raters disagree on.

--- a/docs/handoffs/04-classifier-quality.qmd
+++ b/docs/handoffs/04-classifier-quality.qmd
@@ -1,0 +1,72 @@
+---
+title: "How good is the AI? — classifier quality, end-to-end"
+subtitle: "Chatsight handoff brief · theme 4 of 5"
+author: "Recipient: ____________"
+date: today
+format:
+  pdf:
+    toc: false
+    geometry:
+      - margin=1in
+expected_effort: "≈1 week, part-time (slightly meatier than the others)"
+---
+
+{{< include 00-shared-background.qmd >}}
+
+## The theme
+
+After enough human decisions, chatsight hands off to a Gemini-based binary classifier (`server/python/binary_autolabel_service.py`) that labels the rest of the messages yes / no for that label. **We have no systematic measurement of how good that classifier is, and no record of which prompt / few-shot strategy works.**
+
+This brief is two related deliverables in one:
+
+1. **An evaluation harness**: a re-runnable measurement of classifier quality (per-label P/R/F1, calibration, confusion, hard-case mining) against a held-out subset of human-labeled data.
+2. **A prompt / few-shot improvement experiment**: using that harness as a benchmark, run at least two prompt variants (e.g. CoT vs none, definition emphasis, negative examples) and at least two few-shot example-selection strategies (random vs nearest-neighbor vs stratified-by-label), pick the best, land it.
+
+The harness is the foundation; the experiment is where the design judgment lives.
+
+## Why it matters
+
+We are about to lean harder on the auto-handoff (sample handoff just shipped, full handoff is next). If the classifier is silently wrong or wrong in patterned ways, the resulting "AI-labeled" data corrupts both the research dataset and the analysis dashboards. Measuring it is overdue.
+
+Once we can measure, prompt and few-shot decisions become evidence-driven instead of vibes-based. That's a meaningful step up from where we are.
+
+## Pointers
+
+- **`server/python/binary_autolabel_service.py`** — the current classifier. Read `classify_binary` and `summarize_batch` carefully.
+- **`server/python/assist_service.py`** — already does cosine NN over `MessageEmbedding`. Reuse this for nearest-neighbor few-shot selection.
+- **`server/python/tests/test_handoff_flow.py`** — fixture pattern for stubbed Gemini calls. Your harness should follow the same pattern (real Gemini in a CLI, stubs in tests).
+- **`server/python/models.py`** — `LabelApplication.applied_by` distinguishes `"human"` vs `"ai"`. The harness's holdout split lives over `applied_by == "human"`.
+- **`docs/handoffs/`** — your harness's *output* probably wants to be a Quarto report rendered to PDF, alongside the briefs. That's the deliverable shape we expect.
+- **Literature**: prompt engineering for classification (Brown 2020, Min et al. 2022 on few-shot in-context learning), calibration (Guo 2017 on temperature scaling), confidence estimation in LLM-as-classifier setups.
+
+What *not* to assume:
+
+- Don't assume the classifier has been measured in *any* defensible way before. A 1-page baseline report is already net new.
+- Don't blow your week on the harness. Plan: harness in 3 days, experiments in 4. If the harness takes longer, scope the experiment narrower.
+- Don't run experiments against the production Gemini key in a tight loop without thinking about cost. Cache responses; use small holdout sets initially.
+
+## Constraints
+
+- Branch: **`handoff/classifier-quality`**.
+- Deliverable: a PR that lands (a) the eval harness as a CLI + a Quarto report, (b) a prompt or few-shot change with measured improvement, and (c) the report PDF committed under `docs/classifier-eval/` so the lab can read it without setup.
+- Re-runnability is non-negotiable: someone running `uv run python -m eval.run` (or whatever you call it) should reproduce the report.
+- Hold the prompt variants and few-shot strategies behind an env-var or CLI flag so we can A/B them in production without redeploying.
+- Tests: cached / stubbed Gemini runs with deterministic outputs, asserting metrics computation.
+- Code-review checkpoint at ~day 4 — bring the harness output early so we can sanity-check the metrics before you commit to an experimental direction.
+
+## Evaluation (self-check)
+
+You can confidently say "done" when:
+
+- A holdout-based eval harness exists, callable, and produces per-label P/R/F1 + a calibration plot + a confusion matrix.
+- The harness runs against real Gemini *and* against stubs (for CI).
+- At least one prompt change *and* one few-shot change have been measured against the baseline.
+- The "winner" is documented (with metrics) in the PR and committed to the codebase.
+- The Quarto report renders cleanly and is committed.
+
+## Stretch
+
+- Hard-case mining: surface the messages the classifier gets wrong with high confidence; turn those into a "human review queue" that loops back into the run.
+- Per-assignment quality breakdown — does the classifier do worse on Lab 3 than Lab 4? That's an actionable signal for the Smart Picker brief.
+- Calibration via temperature scaling on the Gemini-returned confidences; measure if it changes the review-threshold UX downstream.
+- Compare cost-quality tradeoffs across `gemini-2.0-flash`, `gemini-2.5-pro`, etc.

--- a/docs/handoffs/05-onboarding-ux.qmd
+++ b/docs/handoffs/05-onboarding-ux.qmd
@@ -1,0 +1,78 @@
+---
+title: "First thirty minutes — onboarding UX for a new instructor"
+subtitle: "Chatsight handoff brief · theme 5 of 5"
+author: "Recipient: ____________"
+date: today
+format:
+  pdf:
+    toc: false
+    geometry:
+      - margin=1in
+expected_effort: "≈1 week, part-time"
+---
+
+{{< include 00-shared-background.qmd >}}
+
+## The theme
+
+A new instructor opens chatsight for the first time. **What do they see, and what does the tool ask them to do?**
+
+Today, the answer is roughly: a navigation bar to four pages, a queue mode that assumes you understand "single-label binary," a `LabelsPage` that assumes you already have labels in mind, an `AssignmentsPage` that assumes you know what an assignment regex should match, and an `AnalysisPage` that's empty until labels exist. The tool is opinionated for someone who already knows the workflow. **For someone who doesn't, it's intimidating.**
+
+The theme is to design and prototype the first-30-minutes experience. Some directions, none mandatory:
+
+- **A guided first-run tutorial** — interactive walkthrough that creates a label, applies it to two messages, hands off, and explains what happened.
+- **Sensible defaults that the empty state explains** — pre-suggested first labels (from `concept_service.py`?), an "I'm not sure where to start" affordance.
+- **A coaching layer** — inline tooltips, progressive disclosure, "what does this number mean" hovers on the readiness chip.
+- **Reordering of the navigation** — `Assignments` may belong before `Run` in the tab order for a new user.
+- **A demo mode** — pre-seeded fake data so the new user can try the workflow before pointing it at real chatlogs.
+
+The recipient picks one or two directions, prototypes them, and writes a short rationale.
+
+## Why it matters
+
+The lab will hand chatsight to other research collaborators (and maybe undergrads or pilot instructors) over the next quarter. Every one of them currently has to be onboarded by a human. If the tool can onboard itself, the labor savings are direct, and the artifact's research credibility goes up — a tool that requires a co-author to operate is less generalizable than one that doesn't.
+
+This is also the brief most disconnected from "deeper algorithmic work" — useful if the recipient's strength is product / interaction design rather than ML.
+
+## Pointers
+
+- **Code surface (frontend)**:
+  - `src/App.tsx` — top-level routing, mode switch.
+  - `src/components/Navigation.tsx` — the nav bar, the first thing a user sees.
+  - `src/pages/LabelRunPage.tsx` — the empty state when no active label exists.
+  - `src/pages/LabelsPage.tsx` — the empty state when no labels exist.
+  - `src/pages/AssignmentsPage.tsx` — empty state and the regex input experience.
+  - `src/components/run/ReadinessChip.tsx` — assumes you know what readiness tiers mean.
+- **`server/python/concept_service.py`** — already proposes label candidates from unlabeled clusters. Could power "suggested first labels" in the empty state.
+- **`VITE_USE_MOCK=true` mode** — exists already. Could be repurposed as a demo mode.
+- **Literature**: Nielsen on first-use UX; "minimal manual" (Carroll 1990) on learning by doing; Don Norman's affordances chapter; the onboarding patterns in tools like Linear, Notion, Vercel as references.
+
+What *not* to assume:
+
+- Don't assume the lab wants a flashy in-app tutorial. Honest, unintrusive coaching often wins. Optimize for the user who *does* want help finding it; don't trap the one who doesn't.
+- Don't redesign things outside the first 30 minutes. The brief is bounded.
+- Don't gate the onboarding on a backend change unless it's a small one. Most onboarding work should be frontend-only.
+
+## Constraints
+
+- Branch: **`handoff/onboarding-ux`**.
+- Deliverable: a PR that ships a meaningful onboarding intervention. Could be one strong piece (a tutorial) or a coordinated set of smaller pieces (defaults + tooltips + nav reorder).
+- Existing user flows must remain reachable; the onboarding shouldn't trap an experienced user in a tutorial they can't dismiss.
+- Tests: any new component should have at least a render/interaction test in `src/__tests__/` following the existing `vitest` patterns.
+- Code-review checkpoint at ~day 4 — share screenshots or a video of the prototype, not just code.
+
+## Evaluation (self-check)
+
+You can confidently say "done" when:
+
+- A new user can land on `/` (or whatever the first page is), get to a successful first-label decision, and understand what they did, without a teammate present.
+- The intervention you built is dismissible / opt-out — experienced users can skip.
+- The PR body has a short rationale: who you imagined the new user to be, what choices you made, what you cut, what's next.
+- Screenshots / a screen-recorded gif are in the PR description.
+
+## Stretch
+
+- Run the prototype with one or two real first-time users (lab teammates, classmates, anyone who hasn't seen chatsight). Watch them. Capture two or three concrete failure points and either fix them or note them.
+- Think about *re-onboarding*: someone who used chatsight a month ago and forgot the workflow. Different from first-time UX; equally underserved.
+- Pair with the `Multi-rater` brief: onboarding for the *second* rater on a project that already has labels is its own mini-flow.

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,32 @@
+# Handoff briefs
+
+Five themed briefs for week-of-part-time-work delegations to research collaborators. Each `.qmd` renders to a 4-page PDF that's the artifact you hand a recipient.
+
+## The five themes
+
+| # | Theme | Brief |
+|---|-------|-------|
+| 1 | Smart picker — what should the queue show next? | `01-smart-picker.qmd` |
+| 2 | Drift — detecting and correcting label inconsistency | `02-drift.qmd` |
+| 3 | Multi-rater support | `03-multi-rater.qmd` |
+| 4 | How good is the AI? — classifier quality, end-to-end | `04-classifier-quality.qmd` |
+| 5 | First thirty minutes — onboarding UX | `05-onboarding-ux.qmd` |
+
+## Render
+
+```bash
+cd docs/handoffs
+quarto render            # renders all 5 to _output/
+```
+
+PDFs land in `_output/` (gitignored). Each is self-contained — `00-shared-background.qmd` is included into each via Quarto's `{{< include >}}`.
+
+## Adding a new brief
+
+1. Copy an existing brief as a template; keep the YAML structure and the include directive.
+2. Add the new file to the `render:` list in `_quarto.yml`.
+3. Re-render.
+
+## Editing the shared background
+
+`00-shared-background.qmd` is included into each brief and not rendered standalone. Edit it once and re-render to update all five PDFs.

--- a/docs/handoffs/_quarto.yml
+++ b/docs/handoffs/_quarto.yml
@@ -1,0 +1,17 @@
+project:
+  type: default
+  output-dir: _output
+  render:
+    - "01-smart-picker.qmd"
+    - "02-drift.qmd"
+    - "03-multi-rater.qmd"
+    - "04-classifier-quality.qmd"
+    - "05-onboarding-ux.qmd"
+
+format:
+  pdf:
+    pdf-engine: xelatex
+    geometry:
+      - margin=1in
+    fontsize: 11pt
+    colorlinks: true


### PR DESCRIPTION
## Summary

Rewrites `WORKFLOW.md` to reflect post-pivot reality and ships five themed Quarto briefs under `docs/handoffs/` for delegating research-collaborator work. Each `.qmd` renders to a 4-page PDF via `quarto render`. No code changes.

## Why

`WORKFLOW.md` was last meaningful in March 2026 — it described the multi-label queue era and the deprioritized "scoring equation" framing. The 5 "open design questions" listed there are mostly answered or supplanted by the single-label pivot, the assist flank, and the assignment-mappings work.

The lab wants to delegate work on genuinely-open questions to research collaborators (~1 week part-time, deliverable = PR). Five such questions identified; one brief per question.

## What's in the briefs

| # | Theme | Open question |
|---|-------|----------------|
| 1 | Smart picker | What should the queue show next? Active-learning territory. |
| 2 | Drift | How do we detect and surface labeler inconsistency in a session? |
| 3 | Multi-rater | How do we model and resolve disagreement when ≥2 instructors label the same data? |
| 4 | Classifier quality | How good is Gemini on this task, and what prompt/few-shot strategy moves the needle? Combined eval-harness + prompt-experiments brief. |
| 5 | Onboarding UX | What does a new instructor see in their first 30 minutes? |

Each brief is deliberately open-ended: it poses a question and points at relevant code, not a prescribed solution. Recipients own the design call.

## Structure

- `WORKFLOW.md` — rewrite, with a `TODO (user)` callout in the "Current state" section flagging where I want @m1nce to verify factual accuracy before this is referenced from collaborator briefs.
- `docs/handoffs/00-shared-background.qmd` — shared preamble (read-this-first, dev setup, conventions). Included into each brief via Quarto's `{{< include >}}` so each PDF is self-contained.
- `docs/handoffs/01-smart-picker.qmd` … `05-onboarding-ux.qmd` — five briefs, ~150–250 lines of `.qmd` each, rendering to 4-page PDFs.
- `docs/handoffs/_quarto.yml` — render config. Output goes to `_output/` (gitignored).
- `docs/handoffs/README.md` — how to render, how to add a new brief, how to edit the shared background.

## Verification

- [x] `cd docs/handoffs && quarto render` — produces 5 PDFs without errors
- [x] All 5 PDFs are 4 pages each (uniform structure)
- [x] No source code changes (`server/` and `src/` untouched)
- [ ] @m1nce reviews `WORKFLOW.md` "Current state" section for factual accuracy
- [ ] @m1nce names recipients for each brief and starts handoff

## Order of merge

This PR can land independently of #41 (bug audit). It branches off `main` directly. Once merged, hand off the rendered PDFs.