### PR TITLE
feat: paired labels — promote multi-label to /run with pre-seeded decisions

### DIFF
--- a/server/python/database.py
+++ b/server/python/database.py
@@ -66,6 +66,15 @@ def _migrate_label_definition(conn, inspect, text):
         conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN classified_count INTEGER"))
     if "classification_total" not in cols:
         conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN classification_total INTEGER"))
+    if "paired_label_id" not in cols:
+        conn.execute(text(
+            "ALTER TABLE labeldefinition ADD COLUMN paired_label_id INTEGER "
+            "REFERENCES labeldefinition(id)"
+        ))
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS idx_labeldef_paired "
+            "ON labeldefinition(paired_label_id)"
+        ))
 
 
 def _migrate_label_application(conn, inspect, text):

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -28,7 +28,7 @@ from schemas import (
     CreateLabelRequest, DeleteLabelResponse, UpdateLabelRequest, ApplyLabelRequest,
     ApplyBatchRequest, SkipMessageRequest, SuggestRequest, ConciseRequest, ConciseResponse,
     MergeLabelRequest, SplitLabelRequest, SplitAutoLabelRequest, ReorderLabelsRequest,
-    AdvanceRequest, UndoRequest, LabelExampleResponse, LabelDefinitionResponse,
+    AdvanceRequest, UndoRequest, LabelExampleResponse, LabelDefinitionResponse, PairedLabelSummary,
     QueueItemResponse, SessionResponse, LabelApplicationResponse, ChatlogSummary,
     ChatlogResponse, OrphanedMessagesResponse, OrphanedMessageItem, ArchiveResponse,
     DiscoverConceptsResponse, ConceptCandidateResponse, ResolveCandidateRequest, EmbedStatusResponse,
@@ -390,6 +390,22 @@ def get_labels(include_archived: bool = False, db: Session = Depends(get_session
                 _is_multi_application(),
             )
         ).one()
+        paired = db.exec(
+            select(LabelDefinition)
+            .where(LabelDefinition.paired_label_id == label.id)
+            .where(LabelDefinition.archived_at == None)  # noqa: E711
+        ).first()
+        paired_summary = None
+        if paired:
+            yes, no, skip, _ = decision_service.label_counts(db, paired.id)
+            paired_summary = PairedLabelSummary(
+                label_id=paired.id,
+                name=paired.name,
+                phase=paired.phase,
+                yes_count=yes,
+                no_count=no,
+                skip_count=skip,
+            )
         result.append(
             LabelDefinitionResponse(
                 id=label.id,
@@ -397,6 +413,8 @@ def get_labels(include_archived: bool = False, db: Session = Depends(get_session
                 description=label.description,
                 created_at=label.created_at,
                 count=count,
+                paired_label_id=paired.id if paired else None,
+                paired_summary=paired_summary,
             )
         )
     return result
@@ -607,6 +625,54 @@ def archive_label(label_id: int, db: Session = Depends(get_session)):
         archived_at=label.archived_at,
         messages_returned_to_queue=orphan_count,
     )
+
+
+@app.post("/api/labels/{multi_id}/promote", response_model=SingleLabelResponse)
+def promote_label(multi_id: int, db: Session = Depends(get_session)):
+    """Promote a multi-label to /run by creating a paired single-mode label.
+    Pre-seeds the paired single with 'yes' decisions for every message currently
+    multi-labeled with the source. Idempotent: returns the existing paired
+    single if one already exists and is not archived."""
+    src = _assert_multi_write(db, multi_id)
+    if src.archived_at is not None:
+        raise HTTPException(status_code=409, detail="Cannot promote an archived label")
+
+    existing = db.exec(
+        select(LabelDefinition)
+        .where(LabelDefinition.paired_label_id == multi_id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+    ).first()
+    if existing:
+        return _label_to_response(db, existing)
+
+    max_pos = db.exec(
+        select(func.max(LabelDefinition.queue_position))
+        .where(LabelDefinition.mode == "single")
+        .where(LabelDefinition.phase == "queued")
+    ).one()
+    next_pos = (max_pos + 1) if max_pos is not None else 0
+    paired = LabelDefinition(
+        name=src.name,
+        description=src.description,
+        mode="single",
+        phase="queued",
+        is_active=False,
+        queue_position=next_pos,
+        paired_label_id=multi_id,
+    )
+    db.add(paired)
+    db.commit()
+    db.refresh(paired)
+
+    multi_apps = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .where(LabelApplication.label_id == multi_id)
+        .where(_is_multi_application())
+    ).all()
+    for cid, midx in multi_apps:
+        decision_service.record_decision(db, paired.id, cid, midx, "yes")
+
+    return _label_to_response(db, paired)
 
 
 # ── Session routes ────────────────────────────────────────────────────────────
@@ -2113,6 +2179,28 @@ def get_analysis_summary(db: Session = Depends(get_session)):
 
     unlabeled = max(0, total - labeled_any)
 
+    # Composed view: for each multi-label that has been promoted to /run, surface
+    # the paired single's yes/no/skip counts under the parent's name. Keyed by
+    # parent name to align with `label_counts` / `human_label_counts` so the
+    # frontend can show "discovery vs validated" side-by-side.
+    paired_label_counts: dict = {}
+    for paired in db.exec(
+        select(LabelDefinition)
+        .where(LabelDefinition.paired_label_id.is_not(None))
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+    ).all():
+        parent = db.get(LabelDefinition, paired.paired_label_id)
+        if not parent:
+            continue
+        yes, no, skip, _ = decision_service.label_counts(db, paired.id)
+        paired_label_counts[parent.name] = {
+            "paired_id": paired.id,
+            "phase": paired.phase,
+            "yes": yes,
+            "no": no,
+            "skip": skip,
+        }
+
     return {
         "label_counts": label_counts,
         "human_label_counts": human_label_counts,
@@ -2125,6 +2213,7 @@ def get_analysis_summary(db: Session = Depends(get_session)):
             "total": total,
         },
         "position_distribution": position_distribution,
+        "paired_label_counts": paired_label_counts,
     }
 
 

--- a/server/python/models.py
+++ b/server/python/models.py
@@ -20,6 +20,11 @@ class LabelDefinition(SQLModel, table=True):
     summary_json: Optional[str] = Field(default=None)  # cached AI summary blob
     classified_count: Optional[int] = Field(default=None)  # progress: rows AI has classified
     classification_total: Optional[int] = Field(default=None)  # progress: total to classify
+    # Sequential/composable: a mode='single' label promoted from a mode='multi' label
+    # carries a back-reference here. Populated by POST /api/labels/{multi_id}/promote.
+    paired_label_id: Optional[int] = Field(
+        default=None, foreign_key="labeldefinition.id", index=True
+    )
 
 
 class LabelApplication(SQLModel, table=True):

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -86,12 +86,26 @@ class LabelExampleResponse(BaseModel):
 class ConciseResponse(BaseModel):
     concise_text: str
 
+class PairedLabelSummary(BaseModel):
+    """Stats for the mode='single' label that's been promoted from a multi-label.
+    `count` on the parent stays multi-only (Phase 1 semantics); this object
+    surfaces the validation-pass numbers separately so the UI can show both."""
+    label_id: int
+    name: str
+    phase: str  # queued | labeling | classifying | handed_off | failed | complete
+    yes_count: int
+    no_count: int
+    skip_count: int
+
+
 class LabelDefinitionResponse(BaseModel):
     id: int
     name: str
     description: Optional[str]
     created_at: datetime
     count: int
+    paired_label_id: Optional[int] = None
+    paired_summary: Optional[PairedLabelSummary] = None
 
 
 class QueueItemResponse(BaseModel):

--- a/server/python/tests/test_promote.py
+++ b/server/python/tests/test_promote.py
@@ -1,0 +1,204 @@
+"""Phase-2 tests: POST /api/labels/{multi_id}/promote creates a paired
+mode='single' LabelDefinition, pre-seeds it with 'yes' decisions, links it
+back via paired_label_id, and is idempotent. /api/labels and
+/api/analysis/summary surface the paired summary alongside the multi count.
+"""
+import pytest
+from datetime import datetime
+from sqlalchemy import text
+from sqlmodel import select
+
+from database import _cleanup_polluted_multi_label_rows
+from models import LabelApplication, LabelDefinition
+
+
+def _make_multi(session, name="validation", description=None):
+    lbl = LabelDefinition(name=name, description=description, mode="multi")
+    session.add(lbl)
+    session.commit()
+    session.refresh(lbl)
+    return lbl
+
+
+def _seed_multi_apps(session, label_id, n=5, chatlog_id=100):
+    for i in range(n):
+        session.add(LabelApplication(
+            label_id=label_id, chatlog_id=chatlog_id, message_index=i,
+            applied_by="human",
+        ))
+    session.commit()
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+def test_promote_creates_paired_single_with_preseed(client, session):
+    multi = _make_multi(session, "validation", description="Concept check")
+    _seed_multi_apps(session, multi.id, n=5)
+
+    r = client.post(f"/api/labels/{multi.id}/promote")
+    assert r.status_code == 200
+    paired = r.json()
+    assert paired["mode"] == "single"
+    assert paired["phase"] == "queued"
+    assert paired["name"] == "validation"
+    assert paired["yes_count"] == 5
+
+    # DB-level checks: paired link, multi rows untouched, pre-seed rows present.
+    paired_def = session.get(LabelDefinition, paired["id"])
+    assert paired_def.paired_label_id == multi.id
+    assert paired_def.description == "Concept check"
+
+    multi_rows = session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == multi.id)
+    ).all()
+    assert len(multi_rows) == 5
+    assert all(r.value is None for r in multi_rows)
+
+    paired_rows = session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == paired_def.id)
+    ).all()
+    assert len(paired_rows) == 5
+    assert all(r.value == "yes" and r.applied_by == "human" for r in paired_rows)
+
+
+def test_promote_assigns_queue_position_at_end(client, session):
+    multi_a = _make_multi(session, "alpha")
+    multi_b = _make_multi(session, "beta")
+    # An existing queued single from an earlier flow.
+    existing = LabelDefinition(
+        name="prior", mode="single", phase="queued", queue_position=0,
+    )
+    session.add(existing)
+    session.commit()
+
+    pa = client.post(f"/api/labels/{multi_a.id}/promote").json()
+    pb = client.post(f"/api/labels/{multi_b.id}/promote").json()
+    assert pa["queue_position"] == 1
+    assert pb["queue_position"] == 2
+
+
+# ── Idempotency ──────────────────────────────────────────────────────────────
+
+def test_promote_is_idempotent_when_pair_active(client, session):
+    multi = _make_multi(session)
+    _seed_multi_apps(session, multi.id, n=3)
+
+    r1 = client.post(f"/api/labels/{multi.id}/promote").json()
+    r2 = client.post(f"/api/labels/{multi.id}/promote").json()
+    assert r1["id"] == r2["id"]
+
+    # Pre-seed shouldn't double up.
+    paired_rows = session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == r1["id"])
+    ).all()
+    assert len(paired_rows) == 3
+
+
+def test_promote_creates_fresh_pair_after_archive(client, session):
+    multi = _make_multi(session)
+    _seed_multi_apps(session, multi.id, n=2)
+
+    first = client.post(f"/api/labels/{multi.id}/promote").json()
+    paired_def = session.get(LabelDefinition, first["id"])
+    paired_def.archived_at = datetime.utcnow()
+    session.add(paired_def)
+    session.commit()
+
+    second = client.post(f"/api/labels/{multi.id}/promote").json()
+    assert second["id"] != first["id"]
+    assert second["yes_count"] == 2  # pre-seed re-runs
+
+
+# ── Guards ───────────────────────────────────────────────────────────────────
+
+def test_promote_rejects_single_mode_label(client, session):
+    single = LabelDefinition(name="seeking answer", mode="single", phase="labeling", is_active=True)
+    session.add(single)
+    session.commit()
+    session.refresh(single)
+
+    r = client.post(f"/api/labels/{single.id}/promote")
+    assert r.status_code == 409
+    assert "expected 'multi'" in r.json()["detail"]
+
+
+def test_promote_rejects_archived_multi(client, session):
+    multi = _make_multi(session)
+    multi.archived_at = datetime.utcnow()
+    session.add(multi)
+    session.commit()
+
+    r = client.post(f"/api/labels/{multi.id}/promote")
+    assert r.status_code == 409
+    assert "archived" in r.json()["detail"]
+
+
+def test_promote_404_when_multi_missing(client):
+    r = client.post("/api/labels/999999/promote")
+    assert r.status_code == 404
+
+
+# ── Composed reads ───────────────────────────────────────────────────────────
+
+def test_labels_endpoint_surfaces_paired_summary(client, session):
+    multi = _make_multi(session, "validation")
+    _seed_multi_apps(session, multi.id, n=4)
+    client.post(f"/api/labels/{multi.id}/promote")
+
+    labels = client.get("/api/labels").json()
+    by_name = {lbl["name"]: lbl for lbl in labels}
+    card = by_name["validation"]
+    # Multi count stays multi-only (Phase 1 semantics).
+    assert card["count"] == 4
+    assert card["paired_label_id"] is not None
+    assert card["paired_summary"]["yes_count"] == 4
+    assert card["paired_summary"]["no_count"] == 0
+    assert card["paired_summary"]["phase"] == "queued"
+
+
+def test_labels_endpoint_paired_summary_absent_when_no_pair(client, session):
+    multi = _make_multi(session, "validation")
+    _seed_multi_apps(session, multi.id, n=2)
+
+    card = client.get("/api/labels").json()[0]
+    assert card["paired_label_id"] is None
+    assert card["paired_summary"] is None
+
+
+def test_analysis_summary_includes_paired_label_counts(client, session):
+    multi = _make_multi(session, "validation")
+    _seed_multi_apps(session, multi.id, n=3)
+    promoted = client.post(f"/api/labels/{multi.id}/promote").json()
+
+    # Add a paired-single "no" decision to verify it's broken out properly.
+    session.add(LabelApplication(
+        label_id=promoted["id"], chatlog_id=100, message_index=99,
+        applied_by="human", value="no",
+    ))
+    session.commit()
+
+    summary = client.get("/api/analysis/summary").json()
+    assert "paired_label_counts" in summary
+    plc = summary["paired_label_counts"]
+    assert "validation" in plc
+    assert plc["validation"]["yes"] == 3
+    assert plc["validation"]["no"] == 1
+    assert plc["validation"]["phase"] == "queued"
+
+
+# ── Cleanup migration safety ─────────────────────────────────────────────────
+
+def test_preseed_yes_rows_survive_cleanup_migration(client, session):
+    multi = _make_multi(session)
+    _seed_multi_apps(session, multi.id, n=4)
+    promoted = client.post(f"/api/labels/{multi.id}/promote").json()
+
+    # Phase-1 cleanup must not touch the paired single's rows (mode='single').
+    _cleanup_polluted_multi_label_rows(session.connection(), text)
+    session.commit()
+
+    paired_rows = session.exec(
+        select(LabelApplication).where(LabelApplication.label_id == promoted["id"])
+    ).all()
+    assert len(paired_rows) == 4
+    assert all(r.value == "yes" for r in paired_rows)

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,7 +1,7 @@
 // src/mocks/index.ts
 import type {
   LabelDefinition, QueueItem, LabelingSession, SuggestResponse, HistoryItem, AnalysisSummary,
-  TemporalAnalysis, RecalibrationItem, RecalibrationStats,
+  TemporalAnalysis, RecalibrationItem, RecalibrationStats, SingleLabel,
 } from '../types'
 
 export const mockApi = {
@@ -23,10 +23,27 @@ export const mockApi = {
   ] satisfies QueueItem[],
 
   labels: [
-    { id: 1, name: "Concept Question", description: "Student asks for an explanation of a new concept", created_at: "2026-03-28T00:00:00", count: 5 },
+    {
+      id: 1, name: "Concept Question",
+      description: "Student asks for an explanation of a new concept",
+      created_at: "2026-03-28T00:00:00", count: 5,
+      paired_label_id: 101,
+      paired_summary: {
+        label_id: 101, name: "Concept Question", phase: "handed_off",
+        yes_count: 87, no_count: 31, skip_count: 4,
+      },
+    },
     { id: 2, name: "Clarification", description: null, created_at: "2026-03-28T00:00:00", count: 3 },
     { id: 3, name: "Debug Help", description: "Student needs help fixing an error", created_at: "2026-03-28T00:00:00", count: 2 },
   ] satisfies LabelDefinition[],
+
+  singleLabel: {
+    id: 101, name: "Concept Question",
+    description: "Student asks for an explanation of a new concept",
+    mode: "single", phase: "queued", is_active: false, queue_position: 0,
+    yes_count: 5, no_count: 0, skip_count: 0,
+    conversations_walked: 1, total_conversations: 12,
+  } satisfies SingleLabel,
 
   session: {
     id: 1,
@@ -78,6 +95,9 @@ export const mockApi = {
       Clarification: { early: 10, mid: 12, late: 6 },
       'Debug Help': { early: 6, mid: 9, late: 7 },
       'Syntax / API': { early: 8, mid: 3, late: 1 },
+    },
+    paired_label_counts: {
+      'Concept Question': { paired_id: 101, phase: 'handed_off', yes: 87, no: 31, skip: 4 },
     },
   } satisfies AnalysisSummary,
 

--- a/src/pages/AnalysisPage.tsx
+++ b/src/pages/AnalysisPage.tsx
@@ -246,24 +246,28 @@ export function AnalysisPage() {
 
   if (!summary) return null
 
-  /** `label` = category (Y-axis). Avoid `name` on rows — it conflicts with Recharts `<Bar name="…">` for stacked series. */
-  let freqData: { label: string; count: number; human: number; ai: number }[]
+  /** `label` = category (Y-axis). Avoid `name` on rows — it conflicts with Recharts `<Bar name="…">` for stacked series.
+   * `validated` is the paired single-label /run "yes" count, surfaced separately so it's never silently summed
+   * with the discovery counts (multi NULL applications). */
+  const pairedCounts = summary.paired_label_counts ?? {}
+  let freqData: {
+    label: string; count: number; human: number; ai: number;
+    validated: number; validatedPhase?: string;
+  }[]
   if (labelFreqMode === 'human') {
     freqData = Object.entries(summary.human_label_counts)
       .map(([label, count]) => ({
-        label,
-        count: Number(count),
-        human: Number(count),
-        ai: 0,
+        label, count: Number(count), human: Number(count), ai: 0,
+        validated: pairedCounts[label]?.yes ?? 0,
+        validatedPhase: pairedCounts[label]?.phase,
       }))
       .sort((a, b) => b.count - a.count)
   } else if (labelFreqMode === 'ai') {
     freqData = Object.entries(summary.ai_label_counts)
       .map(([label, count]) => ({
-        label,
-        count: Number(count),
-        human: 0,
-        ai: Number(count),
+        label, count: Number(count), human: 0, ai: Number(count),
+        validated: pairedCounts[label]?.yes ?? 0,
+        validatedPhase: pairedCounts[label]?.phase,
       }))
       .sort((a, b) => b.count - a.count)
   } else {
@@ -277,12 +281,18 @@ export function AnalysisPage() {
         const human = Number(summary.human_label_counts[label] ?? 0)
         const ai = Number(summary.ai_label_counts[label] ?? 0)
         const count = human + ai
-        return { label, human, ai, count }
+        return {
+          label, human, ai, count,
+          validated: pairedCounts[label]?.yes ?? 0,
+          validatedPhase: pairedCounts[label]?.phase,
+        }
       })
       .sort((a, b) => b.count - a.count)
   }
 
-  const freqChartMax = freqData.length ? Math.max(1, ...freqData.map((d) => d.count)) : 1
+  const freqChartMax = freqData.length
+    ? Math.max(1, ...freqData.map((d) => Math.max(d.count, d.validated)))
+    : 1
 
   const covTotal = Math.max(1, summary.coverage.total)
   const covHuman = summary.coverage.human_labeled
@@ -454,42 +464,56 @@ export function AnalysisPage() {
                     const wHuman = (row.human / denom) * 100
                     const wAi = (row.ai / denom) * 100
                     const lenPct = row.count === 0 ? 0 : Math.max((row.count / freqChartMax) * 100, 1.2)
+                    const validatedPct = row.validated === 0
+                      ? 0
+                      : Math.max((row.validated / freqChartMax) * 100, 1.2)
                     return (
-                      <div key={row.label} className="flex items-center gap-2 text-xs min-h-[26px]">
+                      <div key={row.label} className="flex items-start gap-2 text-xs min-h-[26px]">
                         <div
-                          className="w-[130px] shrink-0 truncate text-tertiary text-right pr-1"
+                          className="w-[130px] shrink-0 truncate text-tertiary text-right pr-1 pt-1"
                           title={row.label}
                         >
                           {row.label}
                         </div>
-                        <div className="flex-1 min-w-0 h-6 rounded-md bg-elevated/60 border border-edge-subtle/80 relative">
-                          {row.count > 0 && (
-                            <div
-                              className="absolute left-0 top-0 bottom-0 flex rounded overflow-hidden border border-edge-subtle shadow-sm"
-                              style={{
-                                width: `${lenPct}%`,
-                                minWidth: row.count > 0 ? 3 : 0,
-                              }}
-                              title={`${row.label}: human ${row.human}, AI ${row.ai}, total ${row.count} (${lenPct.toFixed(0)}% of max label)`}
-                            >
-                              {row.human > 0 && (
-                                <div
-                                  className="h-full bg-emerald-500 min-w-0 shrink-0"
-                                  style={{ width: `${wHuman}%` }}
-                                  title={`Human: ${row.human}`}
-                                />
-                              )}
-                              {row.ai > 0 && (
-                                <div
-                                  className="h-full bg-indigo-500 min-w-0 shrink-0"
-                                  style={{ width: `${wAi}%` }}
-                                  title={`AI: ${row.ai}`}
-                                />
-                              )}
+                        <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+                          <div className="h-6 rounded-md bg-elevated/60 border border-edge-subtle/80 relative">
+                            {row.count > 0 && (
+                              <div
+                                className="absolute left-0 top-0 bottom-0 flex rounded overflow-hidden border border-edge-subtle shadow-sm"
+                                style={{
+                                  width: `${lenPct}%`,
+                                  minWidth: row.count > 0 ? 3 : 0,
+                                }}
+                                title={`${row.label}: human ${row.human}, AI ${row.ai}, total ${row.count} (discovery)`}
+                              >
+                                {row.human > 0 && (
+                                  <div
+                                    className="h-full bg-emerald-500 min-w-0 shrink-0"
+                                    style={{ width: `${wHuman}%` }}
+                                    title={`Human: ${row.human}`}
+                                  />
+                                )}
+                                {row.ai > 0 && (
+                                  <div
+                                    className="h-full bg-indigo-500 min-w-0 shrink-0"
+                                    style={{ width: `${wAi}%` }}
+                                    title={`AI: ${row.ai}`}
+                                  />
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {row.validated > 0 && (
+                            <div className="h-2 rounded bg-elevated/40 border border-amber-900/40 relative">
+                              <div
+                                className="absolute left-0 top-0 bottom-0 bg-amber-500 rounded"
+                                style={{ width: `${validatedPct}%` }}
+                                title={`Validated (paired /run): ${row.validated}${row.validatedPhase ? ` · ${row.validatedPhase.replace('_', ' ')}` : ''}`}
+                              />
                             </div>
                           )}
                         </div>
-                        <span className="w-10 shrink-0 text-right tabular-nums text-muted">
+                        <span className="w-10 shrink-0 text-right tabular-nums text-muted pt-1">
                           {row.count.toLocaleString()}
                         </span>
                       </div>
@@ -499,11 +523,15 @@ export function AnalysisPage() {
                 <div className="flex flex-wrap gap-4 pt-1 text-xs text-faint">
                   <span className="inline-flex items-center gap-1.5">
                     <span className="h-2 w-2 shrink-0 rounded-sm bg-emerald-500" />
-                    Human
+                    Human (discovery)
                   </span>
                   <span className="inline-flex items-center gap-1.5">
                     <span className="h-2 w-2 shrink-0 rounded-sm bg-indigo-500" />
-                    AI
+                    AI (discovery)
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-2 w-2 shrink-0 rounded-sm bg-amber-500" />
+                    Validated (paired /run "yes")
                   </span>
                 </div>
               </div>

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { api } from '../services/api'
+import { useMode } from '../hooks/useMode'
 import type { LabelDefinition, LabelExample, SuggestResponse } from '../types'
 
 // ── Components ───────────────────────────────────────────────────────────────
@@ -420,6 +422,40 @@ function DeleteConfirmModal({ label, onClose, onConfirm }: { label: LabelDefinit
         <div className="flex gap-3">
           <button onClick={onClose} className="flex-1 py-2 text-xs font-bold text-faint hover:text-tertiary">Cancel</button>
           <button onClick={onConfirm} className="flex-1 py-2 bg-danger text-white text-xs font-bold rounded hover:bg-danger-hover transition-colors">Delete Label</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * PromoteConfirmModal: confirms promotion of a multi-label to a paired /run pass.
+ * Pre-seeds the new single label with "yes" decisions for every existing
+ * multi-label application — explained up front so the instructor knows.
+ */
+function PromoteConfirmModal({
+  label, onClose, onConfirm,
+}: { label: LabelDefinition; onClose: () => void; onConfirm: () => void }) {
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-md p-4">
+      <div className="bg-surface border border-edge-subtle rounded-lg p-8 max-w-sm w-full text-center shadow-2xl">
+        <div className="w-16 h-16 bg-elevated text-accent-text border border-edge rounded-full flex items-center justify-center mx-auto mb-6">
+          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+          </svg>
+        </div>
+        <h3 className="text-lg font-bold text-on-canvas mb-2">Promote "{label.name}" to /run?</h3>
+        <p className="text-sm text-faint mb-2 leading-relaxed">
+          A new single-label run will be queued for this label.
+        </p>
+        <p className="text-xs text-muted mb-8 leading-relaxed">
+          {label.count > 0
+            ? `${label.count} existing multi-label application${label.count === 1 ? '' : 's'} will be pre-seeded as "yes" decisions on the new run, so you only need to validate the rest.`
+            : `No existing applications to pre-seed; you'll start the run from scratch.`}
+        </p>
+        <div className="flex gap-3">
+          <button onClick={onClose} className="flex-1 py-2 text-xs font-bold text-faint hover:text-tertiary">Cancel</button>
+          <button onClick={onConfirm} className="flex-1 py-2 bg-accent text-white text-xs font-bold rounded hover:bg-accent-hover transition-colors">Promote</button>
         </div>
       </div>
     </div>
@@ -956,6 +992,8 @@ export function LabelsPage() {
   const [splittingLabel, setSplittingLabel] = useState<LabelDefinition | null>(null)
   const [mergeState, setMergeState] = useState<{ source: LabelDefinition, target: LabelDefinition } | null>(null)
   const [deletingLabel, setDeletingLabel] = useState<LabelDefinition | null>(null)
+  const [promotingLabel, setPromotingLabel] = useState<LabelDefinition | null>(null)
+  const { setMode } = useMode()
   
   const [draggedId, setDraggedId] = useState<number | null>(null)
 
@@ -1012,6 +1050,17 @@ export function LabelsPage() {
     try {
       await api.deleteLabel(deletingLabel.id, true)
       setDeletingLabel(null)
+      fetchLabels()
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handlePromote = async () => {
+    if (!promotingLabel) return
+    try {
+      await api.promoteLabel(promotingLabel.id)
+      setPromotingLabel(null)
       fetchLabels()
     } catch (err) {
       console.error(err)
@@ -1113,29 +1162,51 @@ export function LabelsPage() {
 
               <div className="flex justify-between items-start mb-5">
                 <span className="text-2xl font-black text-disabled group-hover:text-disabled transition-colors">#{label.id}</span>
-                <span className="px-2 py-0.5 bg-canvas text-accent-text border border-edge-subtle rounded text-[10px] font-bold tracking-wider">
-                  {label.count}
-                </span>
+                <div className="flex flex-col items-end gap-1">
+                  <span className="px-2 py-0.5 bg-canvas text-accent-text border border-edge-subtle rounded text-[10px] font-bold tracking-wider" title="Multi-label discovery applications">
+                    {label.count} <span className="text-disabled font-normal">discovery</span>
+                  </span>
+                  {label.paired_summary && (
+                    <Link
+                      to="/run"
+                      onClick={() => setMode('single')}
+                      className="px-2 py-0.5 bg-amber-950/40 text-amber-300 border border-amber-900/60 rounded text-[10px] font-bold tracking-wider hover:bg-amber-900/40 transition-colors flex items-center gap-1"
+                      title={`Paired /run pass — phase: ${label.paired_summary.phase}`}
+                    >
+                      {label.paired_summary.yes_count} <span className="text-amber-500/80 font-normal">validated</span>
+                      <span className="text-[8px] uppercase tracking-tighter text-amber-500/60 ml-0.5">· {label.paired_summary.phase.replace('_', ' ')}</span>
+                    </Link>
+                  )}
+                </div>
               </div>
-              
+
               <h3 className="text-base font-bold text-on-surface mb-2 leading-tight group-hover:text-white transition-colors">{label.name}</h3>
               <p className="text-xs text-faint line-clamp-2 min-h-[3em] leading-relaxed italic">
                 {label.description || 'No description provided.'}
               </p>
 
               <div className="mt-8 flex gap-3 opacity-0 group-hover:opacity-100 transition-all transform translate-y-1 group-hover:translate-y-0">
-                <button 
+                <button
                   onClick={() => setRefiningLabel(label)}
                   className="flex-1 py-1.5 bg-accent text-white text-[10px] font-black uppercase tracking-widest rounded hover:bg-accent-hover transition-colors shadow-lg shadow-blue-900/20"
                 >
                   Refine
                 </button>
-                <button 
+                <button
                   onClick={() => setSplittingLabel(label)}
                   className="px-3 py-1.5 bg-elevated text-tertiary text-[10px] font-black uppercase tracking-widest rounded border border-edge hover:bg-elevated-hl transition-colors"
                 >
                   Split
                 </button>
+                {!label.paired_label_id && (
+                  <button
+                    onClick={() => setPromotingLabel(label)}
+                    className="px-3 py-1.5 bg-elevated text-amber-300 text-[10px] font-black uppercase tracking-widest rounded border border-amber-900/60 hover:bg-amber-950/40 transition-colors"
+                    title="Promote to /run for deep validation"
+                  >
+                    Promote
+                  </button>
+                )}
                 <div className="relative group/tooltip">
                   <div className="p-1.5 bg-elevated text-muted rounded hover:bg-elevated-hl hover:text-accent-text transition-colors cursor-help border border-edge">
                     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
@@ -1182,6 +1253,14 @@ export function LabelsPage() {
           label={deletingLabel}
           onClose={() => setDeletingLabel(null)}
           onConfirm={handleDelete}
+        />
+      )}
+
+      {promotingLabel && (
+        <PromoteConfirmModal
+          label={promotingLabel}
+          onClose={() => setPromotingLabel(null)}
+          onConfirm={handlePromote}
         />
       )}
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -197,6 +197,10 @@ export const api = {
     USE_MOCK ? Promise.resolve({ archived_at: new Date().toISOString(), messages_returned_to_queue: 0 })
              : req(`/api/labels/${labelId}/archive`, { method: 'PUT' }),
 
+  promoteLabel: (labelId: number): Promise<SingleLabel> =>
+    USE_MOCK ? Promise.resolve(mockApi.singleLabel)
+             : req(`/api/labels/${labelId}/promote`, { method: 'POST' }),
+
   suggestLabel: (chatlog_id: number, message_index: number): Promise<SuggestResponse> =>
     USE_MOCK ? Promise.resolve({ label_name: '', evidence: '', rationale: '' })
              : req('/api/queue/suggest', { method: 'POST', ...json({ chatlog_id, message_index }) }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,25 @@
 // src/types/index.ts
 
+export interface PairedLabelSummary {
+  label_id: number
+  name: string
+  /** queued | labeling | classifying | handed_off | failed | complete */
+  phase: string
+  yes_count: number
+  no_count: number
+  skip_count: number
+}
+
 export interface LabelDefinition {
   id: number
   name: string
   description: string | null
   created_at: string
+  /** Multi-label NULL applications only (the discovery count). Validation
+   * counts from the paired single live in `paired_summary`. */
   count: number
+  paired_label_id?: number | null
+  paired_summary?: PairedLabelSummary | null
 }
 
 export interface LabelExample {
@@ -56,6 +70,15 @@ export interface SuggestResponse {
   rationale: string
 }
 
+export interface PairedLabelCount {
+  paired_id: number
+  /** queued | labeling | classifying | handed_off | failed | complete */
+  phase: string
+  yes: number
+  no: number
+  skip: number
+}
+
 export interface AnalysisSummary {
   label_counts: Record<string, number>
   human_label_counts: Record<string, number>
@@ -68,6 +91,9 @@ export interface AnalysisSummary {
     total: number
   }
   position_distribution: Record<string, { early: number; mid: number; late: number }>
+  /** Keyed by parent multi-label name; present for any multi-label that has
+   * been promoted to /run via POST /api/labels/{id}/promote. */
+  paired_label_counts: Record<string, PairedLabelCount>
 }
 
 /** Weekday 0 = Sunday … 6 = Saturday in `display_timezone` (same convention as PostgreSQL DOW). */


### PR DESCRIPTION
## Summary
- Adds `POST /api/labels/{multi_id}/promote` to create a paired single-mode label from an existing multi-label, pre-seeding `yes` decisions for every current multi-label application. Idempotent — returns the existing paired single if one already exists.
- Surfaces the paired single's yes/no/skip stats on `GET /api/labels` (`paired_label_id` + `paired_summary`) and on `GET /api/analysis/summary` (`paired_label_counts` keyed by parent name) so the UI can show discovery vs validated counts side-by-side.
- Schema: new `LabelDefinition.paired_label_id` self-FK; UI changes in `LabelsPage` + `AnalysisPage` to render the pair, plus mocks/types.

## Test plan
- [ ] `cd server/python && uv run pytest tests/test_promote.py` — promote endpoint covered (idempotency, pre-seeding, archived-source rejection)
- [ ] `cd server/python && uv run pytest` — full backend suite green
- [ ] `npm run build` — typecheck + build clean
- [ ] Manual: promote a multi-label from `/labels`, confirm it appears in `/run` queue with the expected yes count, and that `/analysis` shows the paired summary alongside the parent's multi-label count