### PR TITLE
feat(handoff): Gemini Batch API live progress + multi-sub-batch splitting

### DIFF
--- a/server/python/binary_autolabel_service.py
+++ b/server/python/binary_autolabel_service.py
@@ -6,7 +6,18 @@ from typing import Any, Dict, List, Optional
 from google import genai
 from google.genai import types
 
-client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+# Per-request timeout (milliseconds). Without this the genai SDK defaults to no
+# read timeout, and a half-open TCP connection to Google can block a worker
+# thread indefinitely (we hit exactly this — a single hung chunk stalled an
+# otherwise-complete 17k-message run at 99.7%). 120s is generous for one
+# 50-message chunk; once the timeout fires, the parallel retry-loop in
+# `_classify_in_parallel` reissues the call.
+GEMINI_REQUEST_TIMEOUT_MS = 120_000
+
+client = genai.Client(
+    api_key=os.environ.get("GEMINI_API_KEY", ""),
+    http_options=types.HttpOptions(timeout=GEMINI_REQUEST_TIMEOUT_MS),
+)
 
 CLASSIFY_MODEL = "gemini-2.0-flash"
 

--- a/server/python/database.py
+++ b/server/python/database.py
@@ -75,6 +75,18 @@ def _migrate_label_definition(conn, inspect, text):
             "CREATE INDEX IF NOT EXISTS idx_labeldef_paired "
             "ON labeldefinition(paired_label_id)"
         ))
+    if "batch_job_name" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN batch_job_name VARCHAR"))
+    if "batch_state" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN batch_state VARCHAR"))
+    if "batch_submitted_at" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN batch_submitted_at DATETIME"))
+    if "batch_polled_at" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN batch_polled_at DATETIME"))
+    if "batch_total_count" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN batch_total_count INTEGER"))
+    if "batch_completed_count" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN batch_completed_count INTEGER"))
 
 
 def _migrate_label_application(conn, inspect, text):

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3194,9 +3194,25 @@ def get_readiness(label_id: int, db: Session = Depends(get_session)):
 
 
 CLASSIFICATION_CHUNK_SIZE = 50
-PARALLEL_CONCURRENCY = 8
-BATCH_THRESHOLD = 500
+# 3 was chosen after `PARALLEL_CONCURRENCY = 8` blew through Gemini's
+# per-project quota in the first second of a fresh run. The retry-on-429
+# logic in `_classify_in_parallel` self-throttles below this when needed.
+PARALLEL_CONCURRENCY = 3
+# Retry settings for the chunk-classifier when Gemini returns 429. Other
+# error classes fail-fast so genuine bugs surface immediately.
+PARALLEL_RETRY_MAX_ATTEMPTS = 4   # initial try + 3 retries
+PARALLEL_RETRY_BACKOFF_SECONDS = [2.0, 4.0, 8.0]
+# TEMPORARY: bumped from 500 to route label-21 (17,416 msgs) through the
+# parallel-sync path after Google's Batch queue stalled hard. Revert to 500
+# after the label finishes so future large handoffs still get the Batch
+# discount + SLA.
+BATCH_THRESHOLD = 100_000
 BATCH_POLL_INTERVAL_SEC = 15
+# Above this size, _classify_via_batch_api splits work across multiple Gemini
+# Batch jobs so the UI can show real "X of N sub-batches done" progress (the
+# SDK exposes no per-request progress within a single job — only state).
+# Sized so a typical 17k-message handoff yields ~5 sub-batches → 20% steps.
+BATCH_SPLIT_TARGET_MESSAGES = 4000
 
 
 def _do_classification(
@@ -3309,7 +3325,17 @@ def _classify_in_parallel(
     each calling `classify_binary` (still patchable for tests). DB writes happen
     in the main thread as futures complete; `classified_count` advances by the
     count of each completed chunk. Exceptions propagate to the caller (matching
-    the legacy fail-fast behavior expected by test_failed_handoff_still_appears_with_error)."""
+    the legacy fail-fast behavior expected by test_failed_handoff_still_appears_with_error).
+
+    Thread-safety note: SQLAlchemy sessions are NOT thread-safe. We snapshot the
+    handful of `label` fields workers need as plain values *before* spawning
+    the pool. If workers touched ORM attributes directly, the lazy-load on an
+    expired instance would race with the main thread's commits and corrupt the
+    session, surfacing as a spurious `ObjectDeletedError` later."""
+    label_id = label.id
+    label_name = label.name
+    label_description = label.description
+
     chunks = [
         pending[i:i + CLASSIFICATION_CHUNK_SIZE]
         for i in range(0, len(pending), CLASSIFICATION_CHUNK_SIZE)
@@ -3319,14 +3345,40 @@ def _classify_in_parallel(
 
     def run_chunk(chunk):
         chunk_texts = [t for _, _, t in chunk]
-        classifications = binary_autolabel_service.classify_binary(
-            label_name=label.name,
-            label_description=label.description,
-            yes_examples=yes_examples,
-            no_examples=no_examples,
-            messages=chunk_texts,
-        )
-        return chunk, classifications
+        # Retry on transient errors (rate-limit, read/connect timeout). Other
+        # error classes fail-fast so genuine bugs (auth, malformed request,
+        # 500-class) surface immediately rather than after a long backoff.
+        last_exc: Optional[BaseException] = None
+        for attempt in range(PARALLEL_RETRY_MAX_ATTEMPTS):
+            try:
+                classifications = binary_autolabel_service.classify_binary(
+                    label_name=label_name,
+                    label_description=label_description,
+                    yes_examples=yes_examples,
+                    no_examples=no_examples,
+                    messages=chunk_texts,
+                )
+                return chunk, classifications
+            except Exception as e:
+                if not _is_transient_classify_error(e):
+                    raise
+                last_exc = e
+                if attempt == PARALLEL_RETRY_MAX_ATTEMPTS - 1:
+                    break
+                base = PARALLEL_RETRY_BACKOFF_SECONDS[
+                    min(attempt, len(PARALLEL_RETRY_BACKOFF_SECONDS) - 1)
+                ]
+                # ±25% jitter so worker threads don't all retry in lockstep.
+                wait = base * (0.75 + random.random() * 0.5)
+                kind = _classify_error_kind(e)
+                logger.info(
+                    "transient %s (attempt %d/%d), backing off %.1fs",
+                    kind if kind == "rate_limited" else "timeout",
+                    attempt + 1, PARALLEL_RETRY_MAX_ATTEMPTS, wait,
+                )
+                time.sleep(wait)
+        assert last_exc is not None  # only reachable after a transient chain
+        raise last_exc
 
     # Start from the cumulative count seeded by _do_classification so progress
     # reporting reflects total AI rows written, not just this run's portion.
@@ -3340,7 +3392,7 @@ def _classify_in_parallel(
                     value = cls.get("value", "no")
                     confidence = float(cls.get("confidence", 0.5))
                     db.add(LabelApplication(
-                        label_id=label.id,
+                        label_id=label_id,
                         chatlog_id=cid,
                         message_index=midx,
                         applied_by="ai",
@@ -3352,6 +3404,10 @@ def _classify_in_parallel(
                     else:
                         no_msgs.append(text)
                 completed += len(chunk)
+                # Refresh re-reads the row in the main thread, keeping the
+                # ORM instance consistent before we modify+commit it. Bypasses
+                # any expired-attribute weirdness from the prior commit.
+                db.refresh(label)
                 label.classified_count = completed
                 db.add(label)
                 db.commit()
@@ -3362,122 +3418,117 @@ def _classify_in_parallel(
     return yes_msgs, no_msgs
 
 
-def _classify_via_batch_api(
-    db: Session,
-    label: LabelDefinition,
-    pending: list,
-    yes_examples: list,
-    no_examples: list,
-) -> tuple[list[str], list[str]]:
-    """Batch API path: build a JSONL with one request per chunk, upload, submit a
-    batch job, poll until terminal, then download and parse the result file.
+# Aggregate-state ordering: lower = less-advanced. The poll loop reports the
+# *least-advanced* state across in-flight sub-batches so the UI honestly
+# reflects "are we still waiting for Google to start anything". Unknown states
+# fall through to a large sentinel so they don't accidentally outrank QUEUED.
+_BATCH_STATE_RANK = {
+    "JOB_STATE_UNSPECIFIED": 0,
+    "JOB_STATE_QUEUED": 1,
+    "JOB_STATE_PENDING": 2,
+    "JOB_STATE_UPDATING": 3,
+    "JOB_STATE_PAUSED": 3,
+    "JOB_STATE_RUNNING": 4,
+}
+_BATCH_TERMINAL_STATES = {
+    "JOB_STATE_SUCCEEDED",
+    "JOB_STATE_FAILED",
+    "JOB_STATE_CANCELLED",
+    "JOB_STATE_EXPIRED",
+}
 
-    Trade-off vs parallel sync: Google handles internal concurrency (much higher
-    throughput than 8 worker threads) at 50% cost, with a 24h SLA. Progress is
-    coarse — `classified_count` only advances at the end since the Batch API
-    surfaces job-level state, not per-request progress."""
-    from google.genai import types as genai_types
 
-    bas = binary_autolabel_service
-    chunks = [
-        pending[i:i + CLASSIFICATION_CHUNK_SIZE]
-        for i in range(0, len(pending), CLASSIFICATION_CHUNK_SIZE)
-    ]
+def _group_chunks_into_sub_batches(chunks, target_msgs):
+    """Group `chunks` so each sub-batch has approximately `target_msgs` messages.
+    Returns a list of sub-batches, each itself a list of chunks. For totals
+    ≤ target_msgs this yields exactly one sub-batch — keeping the N=1 path
+    identical to the pre-splitting behavior (single Gemini Batch job)."""
+    if not chunks:
+        return []
+    total = sum(len(c) for c in chunks)
+    n = max(1, -(-total // target_msgs))
+    target_per_sb = total / n
+    sub_batches: list[list] = []
+    cur: list = []
+    cur_msgs = 0
+    for chunk in chunks:
+        cur.append(chunk)
+        cur_msgs += len(chunk)
+        # Close out the current sub-batch once it hits the target, except keep
+        # everything left for the final sub-batch (avoids creating an n+1th
+        # tiny sub-batch from rounding).
+        if cur_msgs >= target_per_sb and len(sub_batches) < n - 1:
+            sub_batches.append(cur)
+            cur, cur_msgs = [], 0
+    if cur:
+        sub_batches.append(cur)
+    return sub_batches
 
-    # Build JSONL of batch requests. Key encodes the chunk index so we can map
-    # results back to the right pending tuples regardless of return order.
-    jsonl_path = None
-    uploaded_name = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
-        ) as f:
-            jsonl_path = f.name
-            for idx, chunk in enumerate(chunks):
-                chunk_texts = [t for _, _, t in chunk]
-                req = bas.build_classify_batch_request(
-                    key=f"chunk-{idx}",
-                    label_name=label.name,
-                    label_description=label.description,
-                    yes_examples=yes_examples,
-                    no_examples=no_examples,
-                    messages=chunk_texts,
-                )
-                f.write(json_mod.dumps(req) + "\n")
 
-        uploaded = bas.client.files.upload(
-            file=jsonl_path,
-            config=genai_types.UploadFileConfig(
-                display_name=f"binary-classify-label-{label.id}",
-                mime_type="jsonl",
-            ),
-        )
-        uploaded_name = uploaded.name
+def _aggregate_batch_state(jobs) -> str:
+    """The 'least-advanced' state across `jobs`. Empty list returns SUCCEEDED."""
+    if not jobs:
+        return "JOB_STATE_SUCCEEDED"
+    return min(
+        (j.state.name for j in jobs),
+        key=lambda s: _BATCH_STATE_RANK.get(s, 99),
+    )
 
-        job = bas.client.batches.create(
-            model=bas.CLASSIFY_MODEL,
-            src=uploaded.name,
-            config={"display_name": f"binary-classify-label-{label.id}"},
-        )
 
-        terminal = {
-            "JOB_STATE_SUCCEEDED",
-            "JOB_STATE_FAILED",
-            "JOB_STATE_CANCELLED",
-            "JOB_STATE_EXPIRED",
-        }
-        while job.state.name not in terminal:
-            time.sleep(BATCH_POLL_INTERVAL_SEC)
-            job = bas.client.batches.get(name=job.name)
+def _cleanup_sub_batch_entry(entry, bas) -> None:
+    """Delete a sub-batch's local tempfile and remote uploaded source. Best-effort;
+    swallows per-resource cleanup errors so one stuck delete doesn't mask the
+    real exception that triggered cleanup."""
+    if entry.get("jsonl_path"):
+        try:
+            os.unlink(entry["jsonl_path"])
+        except OSError:
+            pass
+        entry["jsonl_path"] = None
+    if entry.get("uploaded_name"):
+        try:
+            bas.client.files.delete(name=entry["uploaded_name"])
+        except Exception:
+            pass
+        entry["uploaded_name"] = None
 
-        if job.state.name != "JOB_STATE_SUCCEEDED":
-            err = getattr(job, "error", None)
-            raise RuntimeError(f"Batch job ended in {job.state.name}: {err}")
 
-        # Read results — Batch returns either a result file or inline responses.
-        results_by_key: dict[str, dict] = {}
-        dest = getattr(job, "dest", None)
-        result_file_name = getattr(dest, "file_name", None) if dest else None
-        if result_file_name:
-            content = bas.client.files.download(file=result_file_name)
-            text = content.decode("utf-8") if isinstance(content, (bytes, bytearray)) else content
-            for line in text.splitlines():
-                if not line.strip():
-                    continue
-                row = json_mod.loads(line)
-                key = row.get("key")
-                if key:
-                    results_by_key[key] = row
-        else:
-            inlined = getattr(dest, "inlined_responses", None) or []
-            for i, inline in enumerate(inlined):
-                key = getattr(inline, "key", None) or f"chunk-{i}"
-                results_by_key[key] = {
-                    "key": key,
-                    "response": getattr(inline, "response", None),
-                    "error": getattr(inline, "error", None),
-                }
-    finally:
-        if jsonl_path:
-            try:
-                os.unlink(jsonl_path)
-            except OSError:
-                pass
-        if uploaded_name:
-            try:
-                bas.client.files.delete(name=uploaded_name)
-            except Exception:
-                pass
+def _parse_and_write_sub_batch(db, label, job, entry, bas) -> tuple[list[str], list[str]]:
+    """Download a single sub-batch's results, parse, and write AI rows. Returns
+    the (yes_texts, no_texts) contribution for the summarizer.
+
+    Chunk keys are globally indexed (`chunk-{global_idx}`) across all
+    sub-batches so the parsing logic is uniform regardless of N."""
+    results_by_key: dict[str, dict] = {}
+    dest = getattr(job, "dest", None)
+    result_file_name = getattr(dest, "file_name", None) if dest else None
+    if result_file_name:
+        content = bas.client.files.download(file=result_file_name)
+        text_content = content.decode("utf-8") if isinstance(content, (bytes, bytearray)) else content
+        for line in text_content.splitlines():
+            if not line.strip():
+                continue
+            row = json_mod.loads(line)
+            key = row.get("key")
+            if key:
+                results_by_key[key] = row
+    else:
+        inlined = getattr(dest, "inlined_responses", None) or []
+        for i, inline in enumerate(inlined):
+            key = getattr(inline, "key", None) or f"chunk-{entry['start_chunk_idx'] + i}"
+            results_by_key[key] = {
+                "key": key,
+                "response": getattr(inline, "response", None),
+                "error": getattr(inline, "error", None),
+            }
 
     yes_msgs: list[str] = []
     no_msgs: list[str] = []
-    # Cumulative start — see same comment in _classify_in_parallel.
-    completed = label.classified_count or 0
-    for idx, chunk in enumerate(chunks):
-        row = results_by_key.get(f"chunk-{idx}")
+    for local_idx, chunk in enumerate(entry["chunks"]):
+        global_idx = entry["start_chunk_idx"] + local_idx
+        row = results_by_key.get(f"chunk-{global_idx}")
         response_obj = (row or {}).get("response")
         if response_obj is not None and not isinstance(response_obj, dict):
-            # SDK may return typed objects for inline responses; coerce to dict.
             response_obj = response_obj.to_json_dict() if hasattr(response_obj, "to_json_dict") else None
         classifications = bas.parse_classify_batch_response(response_obj, len(chunk))
         for (cid, midx, text), cls in zip(chunk, classifications):
@@ -3495,10 +3546,191 @@ def _classify_via_batch_api(
                 yes_msgs.append(text)
             else:
                 no_msgs.append(text)
-        completed += len(chunk)
-        label.classified_count = completed
+    return yes_msgs, no_msgs
+
+
+def _classify_via_batch_api(
+    db: Session,
+    label: LabelDefinition,
+    pending: list,
+    yes_examples: list,
+    no_examples: list,
+) -> tuple[list[str], list[str]]:
+    """Batch API path: split `pending` into N sub-batches (sized by
+    BATCH_SPLIT_TARGET_MESSAGES), submit each as its own Gemini Batch job in
+    parallel, then poll all of them in a single 15 s tick loop. Each sub-batch
+    commits its results + advances `classified_count` the moment it terminates
+    SUCCEEDED — giving the UI honest per-batch progress (the SDK exposes no
+    per-request progress within a single job).
+
+    N=1 for jobs ≤ BATCH_SPLIT_TARGET_MESSAGES, so the small-handoff path is
+    behaviorally unchanged from the pre-split version.
+
+    Trade-off vs parallel sync: keeps Google's 50% Batch API discount and 24h
+    SLA. Each sub-batch carries its own queue wait, but submissions are
+    parallel so total wall-clock is dominated by max(sub_batch_time), not
+    sum(sub_batch_time)."""
+    from google.genai import types as genai_types
+
+    bas = binary_autolabel_service
+    chunks = [
+        pending[i:i + CLASSIFICATION_CHUNK_SIZE]
+        for i in range(0, len(pending), CLASSIFICATION_CHUNK_SIZE)
+    ]
+    sub_batches = _group_chunks_into_sub_batches(chunks, BATCH_SPLIT_TARGET_MESSAGES)
+    n = len(sub_batches)
+
+    # Seed progress counters before any I/O so the UI never observes a
+    # half-initialized in-flight state. `batch_submitted_at` doubles as the
+    # historical "when did the whole handoff start" marker.
+    submitted_at = datetime.utcnow()
+    label.batch_submitted_at = submitted_at
+    label.batch_total_count = n
+    label.batch_completed_count = 0
+    db.add(label)
+    db.commit()
+
+    entries: list[dict] = []
+    yes_msgs: list[str] = []
+    no_msgs: list[str] = []
+    completed = label.classified_count or 0
+
+    try:
+        # ── Submission: build JSONL → upload → batches.create per sub-batch.
+        # Sequential because each step is fast (seconds) relative to the
+        # subsequent Google-side runtime (minutes-hours).
+        global_chunk_idx = 0
+        for sb_idx, sb_chunks in enumerate(sub_batches):
+            start_idx = global_chunk_idx
+            jsonl_path = None
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+            ) as f:
+                jsonl_path = f.name
+                for chunk in sb_chunks:
+                    chunk_texts = [t for _, _, t in chunk]
+                    req = bas.build_classify_batch_request(
+                        key=f"chunk-{global_chunk_idx}",
+                        label_name=label.name,
+                        label_description=label.description,
+                        yes_examples=yes_examples,
+                        no_examples=no_examples,
+                        messages=chunk_texts,
+                    )
+                    f.write(json_mod.dumps(req) + "\n")
+                    global_chunk_idx += 1
+            uploaded = bas.client.files.upload(
+                file=jsonl_path,
+                config=genai_types.UploadFileConfig(
+                    display_name=f"binary-classify-label-{label.id}-sb{sb_idx}",
+                    mime_type="jsonl",
+                ),
+            )
+            job = bas.client.batches.create(
+                model=bas.CLASSIFY_MODEL,
+                src=uploaded.name,
+                config={"display_name": f"binary-classify-label-{label.id}-sb{sb_idx}"},
+            )
+            entries.append({
+                "sb_idx": sb_idx,
+                "job": job,
+                "chunks": sb_chunks,
+                "start_chunk_idx": start_idx,
+                "message_count": sum(len(c) for c in sb_chunks),
+                "uploaded_name": uploaded.name,
+                "jsonl_path": jsonl_path,
+                "cleaned": False,
+            })
+
+        # ── Initial commit of submitted state. `batch_job_name` carries the
+        # first sub-batch's job name as a representative handle (the multi-job
+        # case is implied by batch_total_count > 1; we don't persist all names
+        # since the recovery-on-restart story is intentionally out of scope).
+        last_aggregate = _aggregate_batch_state([e["job"] for e in entries])
+        label.batch_job_name = entries[0]["job"].name if entries else None
+        label.batch_state = last_aggregate
+        label.batch_polled_at = datetime.utcnow()
         db.add(label)
         db.commit()
+        logger.info(
+            "batch submitted: label=%s n_sub_batches=%d total_msgs=%d initial_state=%s",
+            label.id, n, len(pending), last_aggregate,
+        )
+
+        # ── Poll loop: each tick walks all in-flight sub-batches. Any that
+        # have hit a terminal state are parsed immediately (so classified_count
+        # advances as soon as a sub-batch lands rather than waiting for all of
+        # them). Any non-SUCCEEDED terminal raises and aborts the whole run —
+        # already-committed AI rows from sibling sub-batches stay in the DB
+        # and the retry path skips them via the (label_id, chatlog_id,
+        # message_index) unique constraint.
+        in_flight = list(entries)
+        while in_flight:
+            time.sleep(BATCH_POLL_INTERVAL_SEC)
+            still_in_flight: list[dict] = []
+            for entry in in_flight:
+                refreshed = bas.client.batches.get(name=entry["job"].name)
+                entry["job"] = refreshed
+                if refreshed.state.name in _BATCH_TERMINAL_STATES:
+                    if refreshed.state.name != "JOB_STATE_SUCCEEDED":
+                        err = getattr(refreshed, "error", None)
+                        raise RuntimeError(
+                            f"Sub-batch {refreshed.name} ended in "
+                            f"{refreshed.state.name}: {err}"
+                        )
+                    sub_yes, sub_no = _parse_and_write_sub_batch(
+                        db, label, refreshed, entry, bas
+                    )
+                    yes_msgs.extend(sub_yes)
+                    no_msgs.extend(sub_no)
+                    completed += entry["message_count"]
+                    label.classified_count = completed
+                    label.batch_completed_count = (label.batch_completed_count or 0) + 1
+                    db.add(label)
+                    db.commit()
+                    logger.info(
+                        "sub-batch complete: label=%s job=%s (%d/%d)",
+                        label.id, refreshed.name,
+                        label.batch_completed_count, label.batch_total_count,
+                    )
+                    _cleanup_sub_batch_entry(entry, bas)
+                    entry["cleaned"] = True
+                else:
+                    still_in_flight.append(entry)
+            in_flight = still_in_flight
+            new_aggregate = _aggregate_batch_state([e["job"] for e in in_flight])
+            label.batch_state = new_aggregate
+            label.batch_polled_at = datetime.utcnow()
+            db.add(label)
+            db.commit()
+            if new_aggregate != last_aggregate:
+                logger.info(
+                    "batch aggregate state: label=%s %s -> %s",
+                    label.id, last_aggregate, new_aggregate,
+                )
+                last_aggregate = new_aggregate
+    finally:
+        # Catch-all cleanup: any sub-batch that didn't reach SUCCEEDED still
+        # has an uploaded source on Google's side and a local tempfile. The
+        # successful path already cleans each entry inline above (cleaned=True).
+        for entry in entries:
+            if not entry.get("cleaned"):
+                _cleanup_sub_batch_entry(entry, bas)
+
+    # All sub-batches succeeded → null the in-flight handles so the UI's
+    # `isBatchInFlight` branch turns off and `phase='handed_off'` renders the
+    # final summary cleanly. `batch_submitted_at` stays as historical record.
+    label.batch_job_name = None
+    label.batch_state = None
+    label.batch_polled_at = None
+    label.batch_total_count = None
+    label.batch_completed_count = None
+    db.add(label)
+    db.commit()
+    logger.info(
+        "all sub-batches complete: label=%s classified=%d sub_batches=%d",
+        label.id, completed, n,
+    )
 
     return yes_msgs, no_msgs
 
@@ -3514,6 +3746,25 @@ def _classify_error_kind(exc: BaseException) -> str:
     if "429" in text or "resource_exhausted" in text or "rate limit" in text or "quota" in text:
         return "rate_limited"
     return "error"
+
+
+def _is_transient_classify_error(exc: BaseException) -> bool:
+    """Whether the parallel chunk runner should retry instead of fail-fast.
+    Covers two transient classes that an in-progress run shouldn't tank on:
+
+    - Rate-limiting (429 / RESOURCE_EXHAUSTED) — the existing retry case.
+    - Network timeouts — read/connect timeouts from a hung TCP connection to
+      Google. Without retry these turn a single bad socket into a whole-run
+      failure (we hit this at 99.7% on label 21).
+
+    Genuine bugs (auth, malformed request, 500-class errors) fall through to
+    fail-fast so they surface immediately instead of after a long backoff."""
+    if _classify_error_kind(exc) == "rate_limited":
+        return True
+    text = (str(exc) or "").lower()
+    name = type(exc).__name__.lower()
+    timeout_signals = ("timeout", "timed out", "deadline exceeded", "readtimeout", "connecttimeout")
+    return any(sig in text or sig in name for sig in timeout_signals)
 
 
 def _classify_in_background(label_id: int, sample_size: Optional[int] = None) -> None:
@@ -3542,6 +3793,14 @@ def _classify_in_background(label_id: int, sample_size: Optional[int] = None) ->
                 "error": str(e) or e.__class__.__name__,
                 "error_kind": _classify_error_kind(e),
             })
+            # Clear in-flight batch handle so the failed-state UI doesn't render
+            # a stale "running" badge. `batch_submitted_at` is preserved for
+            # postmortems (e.g., to know how long the batch ran before failing).
+            label.batch_job_name = None
+            label.batch_state = None
+            label.batch_polled_at = None
+            label.batch_total_count = None
+            label.batch_completed_count = None
             db.add(label)
             db.commit()
 
@@ -3970,5 +4229,10 @@ def list_handoff_summaries(db: Session = Depends(get_session)):
             classification_total=label.classification_total,
             error=payload.get("error") if label.phase == "failed" else None,
             error_kind=payload.get("error_kind") if label.phase == "failed" else None,
+            batch_state=label.batch_state,
+            batch_submitted_at=label.batch_submitted_at,
+            batch_polled_at=label.batch_polled_at,
+            batch_total_count=label.batch_total_count,
+            batch_completed_count=label.batch_completed_count,
         ))
     return out

--- a/server/python/models.py
+++ b/server/python/models.py
@@ -25,6 +25,20 @@ class LabelDefinition(SQLModel, table=True):
     paired_label_id: Optional[int] = Field(
         default=None, foreign_key="labeldefinition.id", index=True
     )
+    # Batch API instrumentation: populated only while a Gemini Batch job is in
+    # flight for this label. The poll loop in _classify_via_batch_api writes
+    # `batch_state` + `batch_polled_at` on every tick; all three "live" fields
+    # are nulled out once the job terminates. `batch_submitted_at` is kept as a
+    # historical record for postmortems.
+    batch_job_name: Optional[str] = Field(default=None)
+    batch_state: Optional[str] = Field(default=None)
+    batch_submitted_at: Optional[datetime] = Field(default=None)
+    batch_polled_at: Optional[datetime] = Field(default=None)
+    # Multi-batch splitting (set when the batch path runs N > 1 sub-batches for
+    # large jobs so the UI can show "X of N batches done"). Both fields are
+    # nulled out at terminal alongside the other in-flight handles.
+    batch_total_count: Optional[int] = Field(default=None)
+    batch_completed_count: Optional[int] = Field(default=None)
 
 
 class LabelApplication(SQLModel, table=True):

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -389,6 +389,18 @@ class HandoffSummaryListItem(BaseModel):
     classification_total: Optional[int] = None
     error: Optional[str] = None
     error_kind: Optional[str] = None  # "rate_limited" | "error" | None
+    # Gemini Batch API instrumentation. `batch_state` is non-null only while a
+    # batch job is in flight; the UI uses its presence to switch from the
+    # `classified_count / classification_total` % bar to an indeterminate
+    # state-aware display. `batch_submitted_at` powers an elapsed-time label;
+    # `batch_polled_at` powers a liveness hint (stale = task may be dead).
+    # When work is split across multiple sub-batches, `batch_total_count` and
+    # `batch_completed_count` let the UI render "X of N batches done".
+    batch_state: Optional[str] = None
+    batch_submitted_at: Optional[datetime] = None
+    batch_polled_at: Optional[datetime] = None
+    batch_total_count: Optional[int] = None
+    batch_completed_count: Optional[int] = None
 
 
 class MergeAssignmentsRequest(BaseModel):

--- a/server/python/tests/test_handoff_flow.py
+++ b/server/python/tests/test_handoff_flow.py
@@ -1,5 +1,6 @@
 """Tests for handoff (now background-async), summary, refine, and review-queue endpoints."""
-from unittest.mock import patch
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 from sqlmodel import select
 
@@ -125,6 +126,145 @@ def test_classification_writes_ai_rows_and_summary(client, session):
     fresh = session.get(LabelDefinition, a["id"])
     assert fresh.phase == "handed_off"
     assert fresh.summary_json is not None
+
+
+def test_parallel_classify_retries_on_rate_limit_then_succeeds(client, session):
+    """The chunk runner retries Gemini 429 (RESOURCE_EXHAUSTED) errors with
+    exponential backoff. After self-throttling below the quota, the run
+    completes and AI rows are written normally."""
+    _seed(session, conversations=2, per_conv=3)
+    a = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{a['id']}/activate")
+    _decide(client, a["id"], 300, 0, "yes")
+    _decide(client, a["id"], 300, 1, "no")
+
+    # Fail twice with 429, then succeed. Counters are per-call so any of the
+    # parallel chunks share the same rate-limit emulation.
+    call_count = {"n": 0}
+
+    class _RateLimited(Exception):
+        code = 429
+
+    def flaky_classify(label_name, label_description, yes_examples, no_examples, messages):
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            raise _RateLimited("429 RESOURCE_EXHAUSTED: quota exceeded")
+        return [
+            {"index": i, "value": "yes" if i % 2 == 0 else "no", "confidence": 0.9}
+            for i in range(len(messages))
+        ]
+
+    def fake_summary(*args, **kwargs):
+        return {"included": [], "excluded": []}
+
+    label = session.get(LabelDefinition, a["id"])
+    with patch("binary_autolabel_service.classify_binary", side_effect=flaky_classify), \
+         patch("binary_autolabel_service.summarize_batch", side_effect=fake_summary), \
+         patch("main.time.sleep"):  # collapse backoff sleeps in tests
+        main._do_classification(session, label)
+
+    # Two 429s burned, then succeeded → AI rows landed normally.
+    assert call_count["n"] >= 3
+    ai_rows = session.exec(
+        select(LabelApplication).where(
+            LabelApplication.label_id == a["id"],
+            LabelApplication.applied_by == "ai",
+        )
+    ).all()
+    assert len(ai_rows) > 0
+
+
+def test_parallel_classify_gives_up_after_max_retries_on_rate_limit(client, session):
+    """If 429s keep coming past PARALLEL_RETRY_MAX_ATTEMPTS, the chunk runner
+    surfaces the 429 to the caller. The exception handler in
+    `_classify_in_background` then marks the label rate_limited."""
+    _seed(session, conversations=1, per_conv=2)
+    a = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{a['id']}/activate")
+    _decide(client, a["id"], 300, 0, "yes")
+
+    def always_429(*args, **kwargs):
+        raise Exception("429 RESOURCE_EXHAUSTED: quota exceeded")
+
+    label = session.get(LabelDefinition, a["id"])
+    with patch("binary_autolabel_service.classify_binary", side_effect=always_429), \
+         patch("main.time.sleep"):
+        import pytest as _pytest
+        with _pytest.raises(Exception, match="429"):
+            main._do_classification(session, label)
+
+
+def test_parallel_classify_retries_on_request_timeout(client, session):
+    """Hung connections (read/connect timeouts) are now treated as transient
+    and retried, matching the rate-limit retry path. This prevents a single
+    stuck socket from killing an otherwise-complete run (we hit exactly this
+    at 99.7% on a 17k-message handoff)."""
+    _seed(session, conversations=2, per_conv=3)
+    a = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{a['id']}/activate")
+    _decide(client, a["id"], 300, 0, "yes")
+    _decide(client, a["id"], 300, 1, "no")
+
+    # First two calls raise a timeout-flavored exception; third succeeds.
+    call_count = {"n": 0}
+
+    class _ReadTimeout(Exception):
+        pass
+
+    def flaky_classify(label_name, label_description, yes_examples, no_examples, messages):
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            raise _ReadTimeout("read timeout while waiting for Gemini response")
+        return [
+            {"index": i, "value": "no", "confidence": 0.5}
+            for i in range(len(messages))
+        ]
+
+    def fake_summary(*args, **kwargs):
+        return {"included": [], "excluded": []}
+
+    label = session.get(LabelDefinition, a["id"])
+    with patch("binary_autolabel_service.classify_binary", side_effect=flaky_classify), \
+         patch("binary_autolabel_service.summarize_batch", side_effect=fake_summary), \
+         patch("main.time.sleep"):
+        main._do_classification(session, label)
+
+    # Burned 2 timeouts then succeeded.
+    assert call_count["n"] >= 3
+    ai_rows = session.exec(
+        select(LabelApplication).where(
+            LabelApplication.label_id == a["id"],
+            LabelApplication.applied_by == "ai",
+        )
+    ).all()
+    assert len(ai_rows) > 0
+
+
+def test_parallel_classify_does_not_retry_non_rate_limit_errors(client, session):
+    """Non-429 errors (auth, 500, validation, etc.) should NOT be retried —
+    the chunk runner fails fast so genuine bugs surface immediately."""
+    _seed(session, conversations=1, per_conv=2)
+    a = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{a['id']}/activate")
+    _decide(client, a["id"], 300, 0, "yes")
+
+    call_count = {"n": 0}
+
+    def auth_error(*args, **kwargs):
+        call_count["n"] += 1
+        raise Exception("401 UNAUTHENTICATED: bad API key")
+
+    label = session.get(LabelDefinition, a["id"])
+    with patch("binary_autolabel_service.classify_binary", side_effect=auth_error), \
+         patch("main.time.sleep"):
+        import pytest as _pytest
+        with _pytest.raises(Exception, match="401"):
+            main._do_classification(session, label)
+    # No retry burned on non-429 errors. With PARALLEL_CONCURRENCY=3 we may
+    # have up to 3 chunks failing concurrently, but each chunk should fail
+    # on its first attempt — call_count == number of chunks attempted, not
+    # number of chunks × retry attempts.
+    assert call_count["n"] <= main.PARALLEL_CONCURRENCY
 
 
 def test_summary_endpoint_after_classification(client, session):
@@ -517,3 +657,380 @@ def test_failed_handoff_still_appears_with_error(client, session):
     assert len(failed) == 1
     assert failed[0]["phase"] == "failed"
     assert failed[0]["error"] == "Gemini quota exceeded"
+
+
+# ─── Batch API instrumentation ────────────────────────────────────────────
+
+
+def _make_fake_job(state_name, name="batches/test-job", dest_inlined=None):
+    """Build a MagicMock job mimicking the genai Batch API shape that
+    `_classify_via_batch_api` reads from."""
+    j = MagicMock()
+    j.name = name
+    j.state.name = state_name
+    j.error = None
+    if dest_inlined is not None:
+        j.dest.file_name = None
+        j.dest.inlined_responses = dest_inlined
+    else:
+        j.dest = None
+    return j
+
+
+def test_batch_state_persists_through_poll_loop_and_clears_on_success(session):
+    """The batch path writes `batch_state` + `batch_polled_at` on every poll
+    tick (so the UI can show real liveness) and nulls the in-flight fields
+    once the job terminates successfully. `batch_submitted_at` is kept as a
+    historical record."""
+    import binary_autolabel_service as bas
+
+    label = LabelDefinition(name="batch-test", mode="single", phase="classifying")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+
+    pending = [(1, i, f"msg {i}") for i in range(3)]
+    states_after_create = iter(["JOB_STATE_RUNNING", "JOB_STATE_SUCCEEDED"])
+    snapshots: list[str] = []
+
+    def fake_get(name=None):
+        # Snapshot what the function just committed before serving the next state.
+        session.refresh(label)
+        snapshots.append(label.batch_state)
+        return _make_fake_job(
+            next(states_after_create),
+            dest_inlined=[],  # parse_classify_batch_response is patched, so contents irrelevant
+        )
+
+    fake_client = MagicMock()
+    fake_client.files.upload.return_value = MagicMock(name="uploads/x")
+    fake_client.files.delete = MagicMock()
+    fake_client.batches.create.return_value = _make_fake_job("JOB_STATE_PENDING")
+    fake_client.batches.get.side_effect = fake_get
+
+    fake_classifications = [
+        {"index": i, "value": "yes", "confidence": 0.9} for i in range(len(pending))
+    ]
+
+    with patch.object(bas, "client", fake_client), \
+         patch("main.time.sleep"), \
+         patch.object(bas, "parse_classify_batch_response", return_value=fake_classifications):
+        main._classify_via_batch_api(session, label, pending, [], [])
+
+    session.refresh(label)
+    # In-flight handle was nulled after terminal completion.
+    assert label.batch_job_name is None
+    assert label.batch_state is None
+    assert label.batch_polled_at is None
+    assert label.batch_total_count is None
+    assert label.batch_completed_count is None
+    # Historical record survives.
+    assert label.batch_submitted_at is not None
+    # The loop committed at least one intermediate state between submit and
+    # success — snapshots[0] should be what was committed by `create()` (PENDING),
+    # snapshots[1] should be what was committed after the first `get()` (RUNNING).
+    assert snapshots[0] == "JOB_STATE_PENDING"
+    assert snapshots[1] == "JOB_STATE_RUNNING"
+    # And the post-batch result-write loop populated the row count.
+    assert label.classified_count == len(pending)
+
+
+def test_batch_state_cleared_when_background_task_raises(session, engine):
+    """When the background classification raises, the failure handler in
+    `_classify_in_background` clears the in-flight batch handle so the
+    failed-state UI doesn't render a stale 'running' badge.
+    `batch_submitted_at` is intentionally preserved for postmortems."""
+    label = LabelDefinition(
+        name="batch-fail",
+        mode="single",
+        phase="classifying",
+        batch_job_name="batches/inflight",
+        batch_state="JOB_STATE_RUNNING",
+        batch_submitted_at=datetime.utcnow(),
+        batch_polled_at=datetime.utcnow(),
+    )
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+    label_id = label.id
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("Gemini batch died")
+
+    # `_classify_in_background` opens its own Session(engine). Point it at the
+    # in-memory test engine so the cleanup commit lands in the test DB.
+    with patch.object(main, "engine", engine), \
+         patch("main._do_classification", side_effect=boom):
+        main._classify_in_background(label_id)
+
+    session.expire_all()
+    fresh = session.get(LabelDefinition, label_id)
+    assert fresh.phase == "failed"
+    assert fresh.batch_job_name is None
+    assert fresh.batch_state is None
+    assert fresh.batch_polled_at is None
+    # Historical record preserved.
+    assert fresh.batch_submitted_at is not None
+
+
+def test_handoff_summaries_includes_batch_fields(client, session):
+    """`/api/handoff-summaries` surfaces `batch_state`, `batch_submitted_at`,
+    and `batch_polled_at` so the SummariesPage can render the in-flight
+    state-aware display."""
+    label = LabelDefinition(
+        name="batch-flight",
+        mode="single",
+        phase="classifying",
+        classification_total=1234,
+        classified_count=0,
+        batch_job_name="batches/abc",
+        batch_state="JOB_STATE_RUNNING",
+        batch_submitted_at=datetime.utcnow(),
+        batch_polled_at=datetime.utcnow(),
+    )
+    session.add(label)
+    session.commit()
+
+    items = client.get("/api/handoff-summaries").json()
+    found = [it for it in items if it["label_name"] == "batch-flight"]
+    assert len(found) == 1
+    item = found[0]
+    assert item["batch_state"] == "JOB_STATE_RUNNING"
+    assert item["batch_submitted_at"] is not None
+    assert item["batch_polled_at"] is not None
+
+
+def test_handoff_summaries_omits_batch_fields_when_not_in_flight(client, session):
+    """A label that never used the batch path (or whose batch has terminated)
+    surfaces `batch_state` as None — the frontend uses presence-of-state to
+    decide whether to render the indeterminate UI."""
+    label = LabelDefinition(
+        name="no-batch", mode="single", phase="classifying",
+        classification_total=10, classified_count=3,
+    )
+    session.add(label)
+    session.commit()
+
+    items = client.get("/api/handoff-summaries").json()
+    found = [it for it in items if it["label_name"] == "no-batch"]
+    assert len(found) == 1
+    assert found[0]["batch_state"] is None
+    assert found[0]["batch_submitted_at"] is None
+    assert found[0]["batch_polled_at"] is None
+
+
+# ─── Multi-batch splitting ────────────────────────────────────────────────
+
+
+def _make_multi_batch_fakes(state_sequences):
+    """Build the standard mock client used by the multi-batch tests.
+    `state_sequences` maps job name -> list of states returned by successive
+    .get() calls on that job. Each .create() call returns a new PENDING job
+    named `batches/sb-{idx}` in order, matching the sb_idx assignment in
+    `_classify_via_batch_api`."""
+    create_count = {"n": 0}
+    upload_count = {"n": 0}
+
+    def fake_create(*, model=None, src=None, config=None):
+        idx = create_count["n"]
+        create_count["n"] += 1
+        return _make_fake_job("JOB_STATE_PENDING", name=f"batches/sb-{idx}")
+
+    state_iters = {name: iter(seq) for name, seq in state_sequences.items()}
+
+    def fake_get(name=None):
+        next_state = next(state_iters[name])
+        return _make_fake_job(
+            next_state,
+            name=name,
+            dest_inlined=[] if next_state == "JOB_STATE_SUCCEEDED" else None,
+        )
+
+    def fake_upload(*, file=None, config=None):
+        idx = upload_count["n"]
+        upload_count["n"] += 1
+        m = MagicMock()
+        m.name = f"uploads/file-{idx}"
+        return m
+
+    fake_client = MagicMock()
+    fake_client.files.upload.side_effect = fake_upload
+    fake_client.files.delete = MagicMock()
+    fake_client.batches.create.side_effect = fake_create
+    fake_client.batches.get.side_effect = fake_get
+    return fake_client, create_count, upload_count
+
+
+def test_multi_batch_path_advances_counts_as_sub_batches_land(session):
+    """When pending > BATCH_SPLIT_TARGET_MESSAGES, the batch path splits work
+    across N sub-batches; `classified_count` + `batch_completed_count` advance
+    as each one terminates SUCCEEDED rather than waiting for the whole job."""
+    import binary_autolabel_service as bas
+
+    label = LabelDefinition(name="multi-batch", mode="single", phase="classifying")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+
+    # 8000 pending msgs → 160 chunks of 50 → N=2 sub-batches (target 4000 each).
+    pending = [(1, i, f"msg {i}") for i in range(8000)]
+
+    fake_client, create_count, _ = _make_multi_batch_fakes({
+        # Tick 1: both still running. Tick 2: sb-0 succeeds, sb-1 still running.
+        # Tick 3: sb-1 succeeds.
+        "batches/sb-0": ["JOB_STATE_RUNNING", "JOB_STATE_SUCCEEDED"],
+        "batches/sb-1": ["JOB_STATE_RUNNING", "JOB_STATE_RUNNING", "JOB_STATE_SUCCEEDED"],
+    })
+
+    # Snapshot DB state BEFORE each tick (time.sleep is patched and runs first).
+    tick_snapshots: list[dict] = []
+
+    def fake_sleep(_seconds):
+        session.refresh(label)
+        tick_snapshots.append({
+            "classified_count": label.classified_count,
+            "batch_completed_count": label.batch_completed_count,
+            "batch_total_count": label.batch_total_count,
+            "batch_state": label.batch_state,
+        })
+
+    fake_classifications = lambda _resp, n: [
+        {"index": i, "value": "yes", "confidence": 0.9} for i in range(n)
+    ]
+
+    with patch.object(bas, "client", fake_client), \
+         patch("main.time.sleep", side_effect=fake_sleep), \
+         patch.object(bas, "parse_classify_batch_response", side_effect=fake_classifications):
+        main._classify_via_batch_api(session, label, pending, [], [])
+
+    session.refresh(label)
+    # Two sub-batches were created and both succeeded.
+    assert create_count["n"] == 2
+    assert label.classified_count == 8000
+    # All in-flight handles cleared after terminal.
+    assert label.batch_job_name is None
+    assert label.batch_state is None
+    assert label.batch_polled_at is None
+    assert label.batch_total_count is None
+    assert label.batch_completed_count is None
+    assert label.batch_submitted_at is not None
+
+    # Intermediate progress: classified_count is monotonically non-decreasing
+    # across ticks, and crosses 0 → ~4000 → 8000 as each sub-batch lands.
+    classified_series = [s["classified_count"] or 0 for s in tick_snapshots]
+    assert classified_series == sorted(classified_series)
+    # At least one tick observed partial progress (the first sub-batch landed
+    # while the second was still in flight). Sequence is roughly [0, 4000, ...].
+    assert any(0 < (s["classified_count"] or 0) < 8000 for s in tick_snapshots)
+    # batch_total_count is set immediately after submission, so every snapshot
+    # within the in-flight period reports it.
+    assert all(s["batch_total_count"] == 2 for s in tick_snapshots)
+    # At least one tick observed `batch_completed_count == 1` (between the
+    # first and second sub-batch landings). The final state of 2 lives only
+    # between the last poll and the post-loop cleanup, so we don't observe it
+    # in tick_snapshots — the after-loop `assert label.batch_completed_count
+    # is None` above already verifies the terminal cleanup.
+    assert any((s["batch_completed_count"] or 0) == 1 for s in tick_snapshots)
+
+
+def test_multi_batch_partial_failure_preserves_succeeded_sub_batch_rows(session):
+    """If one sub-batch hits a non-SUCCEEDED terminal, the batch function
+    raises. Already-committed AI rows from sibling sub-batches that succeeded
+    earlier stay in the DB so the retry path picks up from there via the
+    `(label_id, chatlog_id, message_index)` unique constraint."""
+    import binary_autolabel_service as bas
+
+    label = LabelDefinition(name="multi-partial-fail", mode="single", phase="classifying")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+
+    pending = [(1, i, f"msg {i}") for i in range(8000)]
+
+    fake_client, _, _ = _make_multi_batch_fakes({
+        # Tick 1: sb-0 succeeds, sb-1 still running.
+        # Tick 2: sb-1 fails.
+        "batches/sb-0": ["JOB_STATE_SUCCEEDED"],
+        "batches/sb-1": ["JOB_STATE_RUNNING", "JOB_STATE_FAILED"],
+    })
+
+    fake_classifications = lambda _resp, n: [
+        {"index": i, "value": "yes", "confidence": 0.9} for i in range(n)
+    ]
+
+    with patch.object(bas, "client", fake_client), \
+         patch("main.time.sleep"), \
+         patch.object(bas, "parse_classify_batch_response", side_effect=fake_classifications):
+        import pytest as _pytest
+        with _pytest.raises(RuntimeError, match="JOB_STATE_FAILED"):
+            main._classify_via_batch_api(session, label, pending, [], [])
+
+    # The successful sub-batch's AI rows are still in the DB.
+    ai_rows = session.exec(
+        select(LabelApplication).where(
+            LabelApplication.label_id == label.id,
+            LabelApplication.applied_by == "ai",
+        )
+    ).all()
+    assert len(ai_rows) > 0
+    # And the label's classified_count reflects the partial work.
+    session.refresh(label)
+    assert label.classified_count is not None and label.classified_count > 0
+
+
+def test_n_eq_1_path_when_pending_at_or_below_split_target(session):
+    """For pending ≤ BATCH_SPLIT_TARGET_MESSAGES the splitter produces a single
+    sub-batch (N=1), keeping the small-handoff path behaviorally identical to
+    the pre-split version. Exercises `_group_chunks_into_sub_batches` boundary."""
+    import binary_autolabel_service as bas
+
+    label = LabelDefinition(name="n1-path", mode="single", phase="classifying")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+
+    # Exactly at the target — should still be 1 sub-batch.
+    pending = [(1, i, f"msg {i}") for i in range(main.BATCH_SPLIT_TARGET_MESSAGES)]
+
+    fake_client, create_count, _ = _make_multi_batch_fakes({
+        "batches/sb-0": ["JOB_STATE_SUCCEEDED"],
+    })
+
+    fake_classifications = lambda _resp, n: [
+        {"index": i, "value": "yes", "confidence": 0.9} for i in range(n)
+    ]
+
+    with patch.object(bas, "client", fake_client), \
+         patch("main.time.sleep"), \
+         patch.object(bas, "parse_classify_batch_response", side_effect=fake_classifications):
+        main._classify_via_batch_api(session, label, pending, [], [])
+
+    # Single sub-batch was created.
+    assert create_count["n"] == 1
+    session.refresh(label)
+    assert label.classified_count == main.BATCH_SPLIT_TARGET_MESSAGES
+
+
+def test_handoff_summaries_surfaces_batch_count_fields(client, session):
+    """`/api/handoff-summaries` exposes `batch_total_count` and
+    `batch_completed_count` so the UI can render 'X of N batches done'."""
+    label = LabelDefinition(
+        name="batch-counts",
+        mode="single",
+        phase="classifying",
+        classification_total=17416,
+        classified_count=8000,
+        batch_state="JOB_STATE_RUNNING",
+        batch_submitted_at=datetime.utcnow(),
+        batch_polled_at=datetime.utcnow(),
+        batch_total_count=5,
+        batch_completed_count=2,
+    )
+    session.add(label)
+    session.commit()
+
+    items = client.get("/api/handoff-summaries").json()
+    found = [it for it in items if it["label_name"] == "batch-counts"]
+    assert len(found) == 1
+    assert found[0]["batch_total_count"] == 5
+    assert found[0]["batch_completed_count"] == 2

--- a/src/index.css
+++ b/src/index.css
@@ -251,9 +251,20 @@
   from { transform: scaleX(0); }
   to   { transform: scaleX(1); opacity: 0; }
 }
+/* Indeterminate progress strip used by SummariesPage while a Gemini Batch
+   job is in flight (no per-request progress is available from Google during
+   that window, so we sweep a narrow highlight across the bar instead). */
+@keyframes batchSweep {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}
+.batch-indeterminate-strip {
+  animation: batchSweep 1.6s linear infinite;
+}
 @media (prefers-reduced-motion: reduce) {
   .chart-card *,
-  [class*="rail-"] {
+  [class*="rail-"],
+  .batch-indeterminate-strip {
     animation-duration: 0ms !important;
     transition-duration: 0ms !important;
   }

--- a/src/pages/SummariesPage.tsx
+++ b/src/pages/SummariesPage.tsx
@@ -3,6 +3,44 @@ import { api } from '../services/api'
 import type { HandoffSummaryItem, SummaryPattern } from '../types'
 
 const RETRY_HOLD_MS = 1500
+// Gemini Batch job states we treat as "in flight" — the UI swaps the % bar
+// for an indeterminate state-aware display while we're in one of these.
+// JOB_STATE_SUCCEEDED is excluded so the brief window between batch-success
+// and phase='handed_off' falls through to the existing % bar (which is
+// already advancing per-chunk as results are parsed).
+const BATCH_FLIGHT_STATES = new Set(['JOB_STATE_PENDING', 'JOB_STATE_RUNNING'])
+// If we haven't seen a successful poll in this long, the in-process
+// BackgroundTask is most likely dead (e.g., killed by `uvicorn --reload`).
+const STALE_POLL_MS = 30_000
+
+function batchStateLabel(state: string): string {
+  if (state === 'JOB_STATE_PENDING') return 'Queued'
+  if (state === 'JOB_STATE_RUNNING') return 'Running'
+  // Unexpected pre-terminal states: surface raw so it's at least debuggable.
+  return state.replace(/^JOB_STATE_/, '').toLowerCase()
+}
+
+// Backend writes `datetime.utcnow()` (naive UTC) and Pydantic serializes it
+// without a timezone marker, e.g. "2026-05-13T19:51:42.646785". Per ECMA-262,
+// `Date.parse` interprets such strings as **local time**, which makes the
+// elapsed counter clamp to 0 in any non-UTC timezone. Force-interpret as UTC
+// by appending 'Z' when no offset is present.
+function parseUtcIso(iso: string): number {
+  const hasTz = /Z$|[+-]\d{2}:?\d{2}$/.test(iso)
+  return Date.parse(hasTz ? iso : iso + 'Z')
+}
+
+function formatElapsed(fromIso: string, nowMs: number): string {
+  const startMs = parseUtcIso(fromIso)
+  if (Number.isNaN(startMs)) return ''
+  const sec = Math.max(0, Math.floor((nowMs - startMs) / 1000))
+  if (sec < 60) return `${sec}s`
+  const m = Math.floor(sec / 60)
+  const s = sec % 60
+  if (m < 60) return `${m}m ${s}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
 
 export function SummariesPage() {
   const [summaries, setSummaries] = useState<HandoffSummaryItem[]>([])
@@ -113,6 +151,42 @@ function SummaryCard({ summary, open, onToggle, onRetry }: SummaryCardProps) {
   const isClassifying = summary.phase === 'classifying'
   const isFailed = summary.phase === 'failed'
   const isRateLimited = isFailed && summary.error_kind === 'rate_limited'
+  const isBatchInFlight =
+    isClassifying &&
+    summary.batch_state != null &&
+    BATCH_FLIGHT_STATES.has(summary.batch_state)
+  // Multi-batch handoffs advance `classified_count` by ~one-Nth each time a
+  // sub-batch lands. Once *any* sub-batch has landed (classified_count > 0
+  // while still in flight), the real % bar is more informative than the
+  // indeterminate strip. Before the first landing we keep the strip — there
+  // is genuinely nothing meaningful to point at yet.
+  const hasRealBatchProgress = isBatchInFlight && (summary.classified_count ?? 0) > 0
+  const hasBatchCounts =
+    summary.batch_total_count != null &&
+    summary.batch_total_count > 1 &&
+    summary.batch_completed_count != null
+
+  // 1s wall clock — only ticks while a batch is in flight, so other cards
+  // don't re-render needlessly. Drives the elapsed-time label + stale-poll
+  // hint. Backend writes `batch_polled_at` every 15s; the visible delta
+  // refreshes on this 1s tick.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!isBatchInFlight) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [isBatchInFlight])
+
+  const elapsed = summary.batch_submitted_at
+    ? formatElapsed(summary.batch_submitted_at, now)
+    : ''
+  const lastPollAgeMs = summary.batch_polled_at
+    ? now - parseUtcIso(summary.batch_polled_at)
+    : 0
+  const isStalePoll =
+    isBatchInFlight && summary.batch_polled_at != null && lastPollAgeMs > STALE_POLL_MS
+  const lastPollSec = Math.max(0, Math.floor(lastPollAgeMs / 1000))
+
   const progressPct =
     summary.classification_total && summary.classification_total > 0
       ? Math.round(
@@ -135,7 +209,21 @@ function SummaryCard({ summary, open, onToggle, onRetry }: SummaryCardProps) {
           <div className={`font-mono text-[10px] tracking-[0.16em] uppercase mb-1 flex items-center gap-2 ${
             isRateLimited ? 'text-ochre' : isFailed ? 'text-brick' : 'text-ochre'
           }`}>
-            {isClassifying ? (
+            {isBatchInFlight ? (
+              <>
+                <span className="relative inline-flex">
+                  <span className="absolute inline-flex w-1.5 h-1.5 rounded-full bg-ochre opacity-75 animate-ping" />
+                  <span className="relative inline-flex w-1.5 h-1.5 rounded-full bg-ochre" />
+                </span>
+                Classifying · Gemini batch · {batchStateLabel(summary.batch_state!)}
+                {hasBatchCounts && (
+                  <span className="text-faint" data-testid="batch-counts">
+                    {' · '}
+                    {summary.batch_completed_count} of {summary.batch_total_count} batches done
+                  </span>
+                )}
+              </>
+            ) : isClassifying ? (
               <>
                 <span className="relative inline-flex">
                   <span className="absolute inline-flex w-1.5 h-1.5 rounded-full bg-ochre opacity-75 animate-ping" />
@@ -176,8 +264,24 @@ function SummaryCard({ summary, open, onToggle, onRetry }: SummaryCardProps) {
               <span className="font-mono text-[10px] text-faint">{open ? '▾' : '▸'}</span>
             </>
           )}
-          {isClassifying && (
+          {isClassifying && !isBatchInFlight && (
             <span className="font-mono text-[12px] text-ochre">{progressPct}%</span>
+          )}
+          {hasRealBatchProgress && (
+            <span
+              className="font-mono text-[12px] text-ochre tabular-nums"
+              data-testid="batch-progress-pct"
+            >
+              {progressPct}%
+            </span>
+          )}
+          {isBatchInFlight && elapsed && (
+            <span
+              className="font-mono text-[11px] text-muted tabular-nums"
+              data-testid="batch-elapsed"
+            >
+              {elapsed}
+            </span>
           )}
           {isFailed && !isRateLimited && (
             <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-brick">
@@ -192,7 +296,62 @@ function SummaryCard({ summary, open, onToggle, onRetry }: SummaryCardProps) {
         </div>
       </button>
 
-      {isClassifying && (
+      {isClassifying && isBatchInFlight && (
+        <div className="px-6 pb-5" data-testid="batch-inflight-block">
+          {hasRealBatchProgress ? (
+            <div
+              className="h-[3px] bg-edge rounded-sm overflow-hidden"
+              role="progressbar"
+              aria-label="Gemini batch progress"
+              aria-valuenow={progressPct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div
+                className="h-full bg-ochre transition-[width] duration-500 ease-out"
+                style={{ width: `${progressPct}%` }}
+                data-testid="batch-real-bar"
+              />
+            </div>
+          ) : (
+            <div
+              className="h-[3px] bg-edge rounded-sm overflow-hidden relative"
+              role="progressbar"
+              aria-label="Gemini batch in progress"
+              aria-busy="true"
+            >
+              <div className="absolute top-0 left-0 h-full w-[30%] bg-ochre batch-indeterminate-strip" />
+            </div>
+          )}
+          <div className="mt-2 font-serif text-[13px] text-muted leading-[1.5]">
+            {hasBatchCounts ? (
+              <>
+                Gemini is working through {summary.batch_total_count} sub-batches
+                in parallel — the bar advances each time one lands. You can keep
+                labeling other things in the meantime.
+              </>
+            ) : (
+              <>
+                This label was routed to the Gemini Batch API (the cheaper path
+                used for jobs &gt; 500 messages). Google reports job-level state
+                only, so there's no per-message progress to show until the
+                batch completes — feel free to keep labeling other messages in
+                the meantime.
+              </>
+            )}
+          </div>
+          {isStalePoll && (
+            <div
+              className="mt-2 font-mono text-[10px] tracking-[0.16em] uppercase text-ochre"
+              data-testid="batch-stale-hint"
+            >
+              Last update {lastPollSec}s ago — task may have stalled
+            </div>
+          )}
+        </div>
+      )}
+
+      {isClassifying && !isBatchInFlight && (
         <div className="px-6 pb-5">
           <div className="h-[3px] bg-edge rounded-sm overflow-hidden">
             <div
@@ -202,7 +361,7 @@ function SummaryCard({ summary, open, onToggle, onRetry }: SummaryCardProps) {
           </div>
           <div className="mt-2 font-serif text-[13px] text-muted leading-[1.5]">
             Gemini is working through the remaining unlabeled messages. The summary will
-            appear here when it's done — feel free to keep labeling other things.
+            appear here when it's done — feel free to keep labeling other messages.
           </div>
         </div>
       )}

--- a/src/tests/SummariesPage.test.tsx
+++ b/src/tests/SummariesPage.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { SummariesPage } from '../pages/SummariesPage'
+import type { HandoffSummaryItem } from '../types'
+
+const inflight: HandoffSummaryItem = {
+  label_id: 1,
+  label_name: 'validation',
+  description: 'Asking whether their answer is correct',
+  phase: 'classifying',
+  yes_count: 0,
+  no_count: 0,
+  review_count: 0,
+  review_threshold: 0.7,
+  included: [],
+  excluded: [],
+  classified_count: 0,
+  classification_total: 17416,
+  error: null,
+  error_kind: null,
+  batch_state: 'JOB_STATE_RUNNING',
+  batch_submitted_at: new Date(Date.now() - 65_000).toISOString(),
+  batch_polled_at: new Date(Date.now() - 5_000).toISOString(),
+  batch_total_count: null,
+  batch_completed_count: null,
+}
+
+const inflightStale: HandoffSummaryItem = {
+  ...inflight,
+  label_id: 2,
+  label_name: 'stale-task',
+  batch_polled_at: new Date(Date.now() - 90_000).toISOString(),
+}
+
+const parallel: HandoffSummaryItem = {
+  label_id: 3,
+  label_name: 'small-job',
+  description: null,
+  phase: 'classifying',
+  yes_count: 0,
+  no_count: 0,
+  review_count: 0,
+  review_threshold: 0.7,
+  included: [],
+  excluded: [],
+  classified_count: 12,
+  classification_total: 50,
+  error: null,
+  error_kind: null,
+  batch_state: null,
+  batch_submitted_at: null,
+  batch_polled_at: null,
+  batch_total_count: null,
+  batch_completed_count: null,
+}
+
+// Multi-batch handoff (N=5), first sub-batch landed → 1 of 5 done, real 23% bar.
+const multiBatchPartial: HandoffSummaryItem = {
+  ...inflight,
+  label_id: 4,
+  label_name: 'multi-validation',
+  classified_count: 4000,
+  classification_total: 17416,
+  batch_total_count: 5,
+  batch_completed_count: 1,
+}
+
+// Multi-batch handoff (N=5), nothing landed yet → indeterminate strip.
+const multiBatchPreLand: HandoffSummaryItem = {
+  ...inflight,
+  label_id: 5,
+  label_name: 'multi-validation-pre',
+  classified_count: 0,
+  classification_total: 17416,
+  batch_total_count: 5,
+  batch_completed_count: 0,
+}
+
+const { mockListHandoffSummaries } = vi.hoisted(() => ({
+  mockListHandoffSummaries: vi.fn(),
+}))
+
+vi.mock('../services/api', () => ({
+  api: {
+    listHandoffSummaries: mockListHandoffSummaries,
+    retryHandoffSingleLabel: vi.fn(),
+  },
+}))
+
+beforeEach(() => {
+  mockListHandoffSummaries.mockReset()
+})
+
+test('renders the batch-in-flight UI (state + elapsed) for a batch job', async () => {
+  mockListHandoffSummaries.mockResolvedValue([inflight])
+  render(<SummariesPage />)
+
+  await waitFor(() => {
+    expect(screen.getByText(/Classifying · Gemini batch · Running/i)).toBeInTheDocument()
+  })
+
+  // Indeterminate UI present
+  expect(screen.getByTestId('batch-inflight-block')).toBeInTheDocument()
+  expect(
+    screen.getByRole('progressbar', { name: /Gemini batch in progress/i }),
+  ).toBeInTheDocument()
+
+  // The misleading "0%" label is suppressed in the in-flight path.
+  expect(screen.queryByText('0%')).not.toBeInTheDocument()
+  // The misleading "0 of 17416" badge text is suppressed too.
+  expect(screen.queryByText(/0 of 17416/)).not.toBeInTheDocument()
+
+  // Elapsed time chip is present (1m 5s from our seed).
+  const elapsed = screen.getByTestId('batch-elapsed')
+  expect(elapsed.textContent ?? '').toMatch(/m\s+\d+s/)
+})
+
+test('shows a stale-poll hint when the backend has not polled recently', async () => {
+  mockListHandoffSummaries.mockResolvedValue([inflightStale])
+  render(<SummariesPage />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('batch-stale-hint')).toBeInTheDocument()
+  })
+  expect(screen.getByTestId('batch-stale-hint').textContent ?? '').toMatch(
+    /may have stalled/i,
+  )
+})
+
+test('parallel-path classifying still renders the % bar (no batch UI)', async () => {
+  mockListHandoffSummaries.mockResolvedValue([parallel])
+  render(<SummariesPage />)
+
+  await waitFor(() => {
+    expect(screen.getByText('24%')).toBeInTheDocument()
+  })
+
+  // No batch UI rendered.
+  expect(screen.queryByTestId('batch-inflight-block')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('batch-elapsed')).not.toBeInTheDocument()
+})
+
+test('multi-batch handoff: real % bar + "X of N batches" once first sub-batch lands', async () => {
+  mockListHandoffSummaries.mockResolvedValue([multiBatchPartial])
+  render(<SummariesPage />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('batch-counts')).toBeInTheDocument()
+  })
+
+  // "1 of 5 batches done" is wired up.
+  expect(screen.getByTestId('batch-counts').textContent ?? '').toMatch(/1 of 5 batches done/)
+  // Real % bar is rendered (not the indeterminate strip).
+  expect(screen.getByTestId('batch-real-bar')).toBeInTheDocument()
+  // Real % chip is also surfaced next to the elapsed-time chip.
+  const pctChip = screen.getByTestId('batch-progress-pct')
+  expect(pctChip.textContent ?? '').toMatch(/23%/)
+  // Elapsed time is still shown — useful even with a real bar.
+  expect(screen.getByTestId('batch-elapsed')).toBeInTheDocument()
+})
+
+test('multi-batch handoff: indeterminate strip before any sub-batch lands', async () => {
+  mockListHandoffSummaries.mockResolvedValue([multiBatchPreLand])
+  render(<SummariesPage />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('batch-counts')).toBeInTheDocument()
+  })
+
+  // "0 of 5 batches done" is shown to convey scope before anything lands.
+  expect(screen.getByTestId('batch-counts').textContent ?? '').toMatch(/0 of 5 batches done/)
+  // No real % bar yet — indeterminate strip path.
+  expect(screen.queryByTestId('batch-real-bar')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('batch-progress-pct')).not.toBeInTheDocument()
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -366,6 +366,16 @@ export interface HandoffSummaryItem {
   classification_total: number | null
   error: string | null
   error_kind: 'rate_limited' | 'error' | null
+  // Gemini Batch API instrumentation — non-null only while a batch job is in
+  // flight. When `batch_state` is set, the UI shows a state-aware display.
+  // For multi-batch handoffs, `batch_total_count` / `batch_completed_count`
+  // drive the "X of N batches done" text and let the real % bar take over
+  // as soon as the first sub-batch lands.
+  batch_state: string | null
+  batch_submitted_at: string | null
+  batch_polled_at: string | null
+  batch_total_count: number | null
+  batch_completed_count: number | null
 }
 
 export interface AssistNeighbor {


### PR DESCRIPTION
## Summary
- Splits large handoffs into N parallel Gemini Batch sub-batches (~4k msgs each) so `classified_count` advances per-sub-batch instead of jumping from 0 → done.
- Adds Batch API instrumentation on `LabelDefinition` (`batch_state`, `batch_submitted_at`, `batch_polled_at`, `batch_total_count`, `batch_completed_count`) and surfaces it in `SummariesPage` as a state-aware in-flight display (indeterminate sweep, elapsed counter, stale-poll hint).
- Reliability hardening uncovered by a 17k-message run: 120s per-request timeout on the genai client, parallel concurrency 8 → 3, jittered retry loop on rate-limit/timeout, snapshot of label fields before spawning workers (SQLAlchemy thread-safety).

## Notes for reviewers
- `BATCH_THRESHOLD` is **temporarily** bumped to 100k to route label-21 through the parallel path while Google's Batch queue recovers — flagged in code, should revert to 500 once that handoff completes.
- The frontend parses naive-UTC backend timestamps as UTC by appending `Z` (fixes elapsed counter clamping to 0 outside UTC).
- N=1 path in `_classify_via_batch_api` is behaviorally unchanged for small handoffs.

## Test Plan
- [x] `cd server/python && uv run pytest` — 236 passed
- [x] `npm test` — 74 passed (incl. new `SummariesPage.test.tsx`)
- [ ] Manual: kick off a small (≤4k msg) handoff → should still go through a single Batch job, % bar identical to before.
- [ ] Manual: kick off a large (>4k msg) handoff → confirm "X of N batches done" text appears, % bar advances per-sub-batch.
- [ ] Manual: simulate a stalled BackgroundTask (kill uvicorn worker mid-run) → confirm "last polled Ns ago" hint surfaces after 30s.