### PR TITLE
Context-aware (pair-text) embeddings for concept induction + assist

### DIFF
--- a/docs/superpowers/plans/2026-05-15-context-aware-embeddings.md
+++ b/docs/superpowers/plans/2026-05-15-context-aware-embeddings.md
@@ -1,0 +1,765 @@
+# Context-Aware Embeddings — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace bare-student-text embeddings in `concept_service.py` and the assist-flank lookup with conversation-pair embeddings ("Tutor: ...\nStudent: ...") so meaning depends on context, not surface form.
+
+**Architecture:** `embed_messages` builds pair text from each message dict's optional `context_before`, sends that to Gemini's embedding API (unchanged), and stores under a bumped `model_version = "gemini-embedding-001:pair-v1"`. The single caller in `main.py` adds the context field to its message dicts; the cluster-naming prompt shows Gemini the pair format; `assist_service._build_cache` adds a one-line filter so old + new vectors are never mixed. `MessageCache.context_before` already exists (`models.py:135`) — no schema changes.
+
+**Tech Stack:** Python 3, FastAPI, SQLModel, pytest, Gemini API (`gemini-embedding-001` for embeddings, `gemini-2.0-flash` for cluster naming), scikit-learn KMeans.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-context-aware-embeddings-design.md`
+
+**User preference:** This codebase user reviews and commits changes themselves. Tasks end with a "stop for user review" step instead of `git commit`. Group related task output before stopping so the user can review and commit at a natural breakpoint.
+
+---
+
+## File Structure
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `server/python/concept_service.py` | Split `EMBED_MODEL` into `EMBED_API_MODEL` (call signature) + `EMBED_MODEL` (cache key); new `_build_pair_text` helper; `embed_messages` uses helper; `_build_discovery_prompt` shows pair format. |
+| `server/python/main.py` | Single message-dict assembly at line 2043-2047 adds `context_before` field. |
+| `server/python/assist_service.py` | `_build_cache` filters by `model_version == EMBED_MODEL`. |
+| `server/python/tests/test_concept_service.py` | New tests for pair-text helper, pair-format embedding call, cache-key bump, and pair-format in discovery prompt. Existing tests left intact (they exercise the no-context fallback). |
+| `server/python/tests/test_assist_service.py` | New test verifying the model_version filter excludes stale-key vectors. |
+
+### Unchanged
+- `server/python/models.py` — `MessageCache.context_before` already exists.
+- `server/python/database.py` — no migration needed.
+- All frontend code.
+
+### New
+- None.
+
+---
+
+## Task 1: `_build_pair_text` helper
+
+**Files:**
+- Modify: `server/python/concept_service.py` (add the helper at module scope, just above `def embed_messages`)
+- Modify: `server/python/tests/test_concept_service.py` (add unit tests for the helper)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/python/tests/test_concept_service.py`:
+
+```python
+def test_pair_text_with_context():
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": "Did that solve it?",
+    })
+    assert out == "Tutor: Did that solve it?\nStudent: yes"
+
+
+def test_pair_text_without_context():
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": None,
+    })
+    assert out == "[Conversation start]\nStudent: yes"
+
+
+def test_pair_text_treats_empty_context_as_missing():
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": "",
+    })
+    assert out == "[Conversation start]\nStudent: yes"
+
+
+def test_pair_text_truncates_long_context():
+    from concept_service import _build_pair_text, CONTEXT_CHAR_LIMIT
+    long_ctx = "A" * 800 + "tail-marker"
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": long_ctx,
+    })
+    # Truncation keeps the LAST CONTEXT_CHAR_LIMIT chars (where the prompt usually lives).
+    assert "tail-marker" in out
+    assert out.startswith("Tutor: ")
+    # The Tutor segment should be exactly CONTEXT_CHAR_LIMIT chars.
+    tutor_line = out.split("\n")[0]  # "Tutor: <ctx>"
+    assert len(tutor_line) - len("Tutor: ") == CONTEXT_CHAR_LIMIT
+
+
+def test_pair_text_handles_missing_context_key():
+    """If the caller dict lacks `context_before` entirely (legacy path), fall back gracefully."""
+    from concept_service import _build_pair_text
+    out = _build_pair_text({"message_text": "hello"})
+    assert out == "[Conversation start]\nStudent: hello"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd server/python && uv run pytest tests/test_concept_service.py::test_pair_text_with_context tests/test_concept_service.py::test_pair_text_without_context tests/test_concept_service.py::test_pair_text_treats_empty_context_as_missing tests/test_concept_service.py::test_pair_text_truncates_long_context tests/test_concept_service.py::test_pair_text_handles_missing_context_key -v
+```
+
+Expected: 5 tests FAIL with `ImportError: cannot import name '_build_pair_text' from 'concept_service'` (and `CONTEXT_CHAR_LIMIT`).
+
+- [ ] **Step 3: Implement the helper**
+
+In `server/python/concept_service.py`, add this immediately after the existing `EMBED_BATCH_SIZE = 100` constant (and before the `def embed_messages` declaration):
+
+```python
+CONTEXT_CHAR_LIMIT = 500
+
+
+def _build_pair_text(msg: Dict[str, Any]) -> str:
+    """Build the text that gets embedded for one student message.
+
+    Pair format:
+        Tutor: <last CONTEXT_CHAR_LIMIT chars of preceding tutor turn>
+        Student: <message_text>
+
+    When there is no preceding tutor turn (first student message in a conversation,
+    or context not provided by the caller), fall back to a consistent prefix that
+    keeps the embedding distribution roughly aligned with the pair format:
+
+        [Conversation start]
+        Student: <message_text>
+    """
+    student = msg["message_text"]
+    ctx = msg.get("context_before")
+    if not ctx:
+        return f"[Conversation start]\nStudent: {student}"
+    truncated = ctx[-CONTEXT_CHAR_LIMIT:] if len(ctx) > CONTEXT_CHAR_LIMIT else ctx
+    return f"Tutor: {truncated}\nStudent: {student}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cd server/python && uv run pytest tests/test_concept_service.py -v
+```
+
+Expected: All 5 new tests PASS plus the 3 existing concept_service tests still PASS (8 total).
+
+- [ ] **Step 5: Stop for user review**
+
+Surface: "Task 1 done — `_build_pair_text` helper added with 5 unit tests, existing concept_service tests still pass. Continue?"
+
+---
+
+## Task 2: Wire `embed_messages` to use the helper + bump cache key
+
+**Files:**
+- Modify: `server/python/concept_service.py` — split `EMBED_MODEL` into two constants; route `embed_messages` through `_build_pair_text`; ensure cached rows under the OLD key are not consulted under the NEW key.
+- Modify: `server/python/tests/test_concept_service.py` — new tests for the pair-format embedding call, the new cache key, and old-key-not-reused.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/python/tests/test_concept_service.py`:
+
+```python
+@patch("concept_service.client")
+def test_embed_messages_sends_pair_text_to_api(mock_client, session):
+    """The string passed to the embedding API must be the pair format, not the bare student text."""
+    mock_client.models.embed_content.side_effect = (
+        lambda **kwargs: _fake_embed_result(kwargs["contents"])
+    )
+
+    from concept_service import embed_messages
+
+    messages = [
+        {
+            "chatlog_id": 1,
+            "message_index": 0,
+            "message_text": "yes",
+            "context_before": "Did that solve it?",
+        },
+    ]
+    embed_messages(messages, session)
+
+    # The API was called once. Inspect the contents argument.
+    call = mock_client.models.embed_content.call_args
+    assert call is not None
+    contents = call.kwargs["contents"]
+    assert contents == ["Tutor: Did that solve it?\nStudent: yes"]
+
+
+@patch("concept_service.client")
+def test_embed_messages_uses_new_model_version_as_cache_key(mock_client, session):
+    """Cached MessageEmbedding rows must use the bumped model_version (not the raw API model)."""
+    mock_client.models.embed_content.side_effect = (
+        lambda **kwargs: _fake_embed_result(kwargs["contents"])
+    )
+
+    from concept_service import embed_messages, EMBED_MODEL
+
+    messages = [
+        {"chatlog_id": 1, "message_index": 0, "message_text": "hi", "context_before": "Hello."},
+    ]
+    embed_messages(messages, session)
+
+    cached = session.exec(select(MessageEmbedding)).all()
+    assert len(cached) == 1
+    assert cached[0].model_version == EMBED_MODEL
+    assert EMBED_MODEL == "gemini-embedding-001:pair-v1"
+
+
+@patch("concept_service.client")
+def test_embed_messages_does_not_reuse_old_key_cache(mock_client, session):
+    """A pre-existing row stored under the OLD model_version must NOT short-circuit the new flow."""
+    mock_client.models.embed_content.side_effect = (
+        lambda **kwargs: _fake_embed_result(kwargs["contents"])
+    )
+
+    # Pre-seed a stale-key row.
+    session.add(MessageEmbedding(
+        chatlog_id=1,
+        message_index=0,
+        embedding=np.zeros(3072, dtype=np.float32).tobytes(),
+        model_version="gemini-embedding-001",  # old key
+    ))
+    session.commit()
+
+    from concept_service import embed_messages, EMBED_MODEL
+
+    messages = [
+        {"chatlog_id": 1, "message_index": 0, "message_text": "hi", "context_before": "Hello."},
+    ]
+    embed_messages(messages, session)
+
+    # API was called (cache miss under new key).
+    assert mock_client.models.embed_content.called
+
+    # We now have two rows: the stale-key row (preserved) and a new-key row.
+    rows = session.exec(select(MessageEmbedding)).all()
+    versions = sorted(r.model_version for r in rows)
+    assert versions == ["gemini-embedding-001", EMBED_MODEL]
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```
+cd server/python && uv run pytest tests/test_concept_service.py::test_embed_messages_sends_pair_text_to_api tests/test_concept_service.py::test_embed_messages_uses_new_model_version_as_cache_key tests/test_concept_service.py::test_embed_messages_does_not_reuse_old_key_cache -v
+```
+
+Expected: 3 tests FAIL — either ImportError on `EMBED_MODEL` (still the old string), or assertion failure on the contents being bare text.
+
+- [ ] **Step 3: Update `EMBED_MODEL` constants in `server/python/concept_service.py`**
+
+Find (around line 15):
+
+```python
+EMBED_MODEL = "gemini-embedding-001"
+EMBED_DIM = 3072
+EMBED_BATCH_SIZE = 100  # Gemini API limit per call
+```
+
+Replace with:
+
+```python
+EMBED_API_MODEL = "gemini-embedding-001"  # passed to the Gemini API
+EMBED_MODEL = "gemini-embedding-001:pair-v1"  # stored as MessageEmbedding.model_version (cache key)
+EMBED_DIM = 3072
+EMBED_BATCH_SIZE = 100  # Gemini API limit per call
+```
+
+- [ ] **Step 4: Route `embed_messages` through the new helper + use the new API constant**
+
+In `server/python/concept_service.py`, find the body of `embed_messages` (around line 20). Locate this block:
+
+```python
+        result = client.models.embed_content(
+            model=EMBED_MODEL,
+            contents=texts,
+        )
+```
+
+Replace with:
+
+```python
+        result = client.models.embed_content(
+            model=EMBED_API_MODEL,
+            contents=texts,
+        )
+```
+
+And find this block earlier in the function:
+
+```python
+        texts = [messages[i]["message_text"] for i in batch_idx]
+```
+
+Replace with:
+
+```python
+        texts = [_build_pair_text(messages[i]) for i in batch_idx]
+```
+
+The cache write block (around line 62) already stores `model_version=EMBED_MODEL` — that line stays as-is, and now correctly stores the bumped key.
+
+- [ ] **Step 5: Find and update the other `EMBED_MODEL` use inside the function (cache lookup)**
+
+Find this block in `embed_messages` (around line 33-38):
+
+```python
+        cached = db.exec(
+            select(MessageEmbedding).where(
+                MessageEmbedding.chatlog_id == msg["chatlog_id"],
+                MessageEmbedding.message_index == msg["message_index"],
+                MessageEmbedding.model_version == EMBED_MODEL,
+            )
+        ).first()
+```
+
+This is already correct — `EMBED_MODEL` is now the new pair-v1 string, so the lookup will correctly miss the old-key rows. No change needed; just verify by re-reading.
+
+- [ ] **Step 6: Find and update other call sites of the embedding API in this file**
+
+Two other places in `concept_service.py` call `client.models.embed_content` with `EMBED_MODEL`:
+
+Around line 193 (in `_deduplicate_concepts`):
+
+```python
+    result = client.models.embed_content(model=EMBED_MODEL, contents=texts)
+```
+
+Around line 281 (in `discover_concepts`, embedding label texts):
+
+```python
+        label_embed_result = client.models.embed_content(
+            model=EMBED_MODEL,
+            contents=label_texts,
+        )
+```
+
+Both of these embed concept/label strings, not student messages — they do not interact with the `MessageEmbedding` cache. But they pass `model=EMBED_MODEL` to the Gemini API, which after Step 3 is the cache-key string `"gemini-embedding-001:pair-v1"` — NOT a valid Gemini model name. **Both must be updated** to use `EMBED_API_MODEL`:
+
+```python
+    result = client.models.embed_content(model=EMBED_API_MODEL, contents=texts)
+```
+
+and
+
+```python
+        label_embed_result = client.models.embed_content(
+            model=EMBED_API_MODEL,
+            contents=label_texts,
+        )
+```
+
+- [ ] **Step 7: Run the full concept_service test suite to verify everything still passes**
+
+```
+cd server/python && uv run pytest tests/test_concept_service.py -v
+```
+
+Expected: All tests pass (existing 3 + 5 helper tests from Task 1 + 3 new wiring tests = 11 total).
+
+- [ ] **Step 8: Stop for user review**
+
+Surface: "Task 2 done — `embed_messages` builds pair text, cache key bumped to `gemini-embedding-001:pair-v1`, three other API call sites in the same file updated to use the renamed `EMBED_API_MODEL`. 11 tests in test_concept_service.py all pass. Continue?"
+
+---
+
+## Task 3: Update `_build_discovery_prompt` to show pair format
+
+**Files:**
+- Modify: `server/python/concept_service.py` — change the sample-rendering loop inside `_build_discovery_prompt` to show context-aware lines.
+- Modify: `server/python/tests/test_concept_service.py` — new test for the prompt content.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_concept_service.py`:
+
+```python
+def test_discovery_prompt_includes_tutor_context_when_present():
+    from concept_service import _build_discovery_prompt
+
+    samples_by_cluster = {
+        0: [
+            {
+                "message_text": "yes",
+                "context_before": "Did that solve it?",
+            },
+            {
+                "message_text": "?",
+                "context_before": "What would go in the blank to make this statement true?",
+            },
+        ],
+    }
+    prompt = _build_discovery_prompt(samples_by_cluster, existing_labels=[], rejected_names=[])
+
+    # When context is present, the prompt shows BOTH tutor and student turns.
+    assert "Tutor asked:" in prompt
+    assert "Student replied:" in prompt
+    assert "Did that solve it?" in prompt
+    assert "What would go in the blank to make this statement true?" in prompt
+
+
+def test_discovery_prompt_handles_missing_context():
+    from concept_service import _build_discovery_prompt
+
+    samples_by_cluster = {
+        0: [
+            {"message_text": "hello", "context_before": None},
+        ],
+    }
+    prompt = _build_discovery_prompt(samples_by_cluster, existing_labels=[], rejected_names=[])
+
+    # When no context, the prompt marks this as the start of the conversation.
+    assert "(start of conversation)" in prompt
+    assert "hello" in prompt
+    # The "Tutor asked:" prefix must NOT appear for this sample.
+    # (There may be other samples in other clusters that legitimately have it, but here there's just one sample.)
+    assert "Tutor asked:" not in prompt
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd server/python && uv run pytest tests/test_concept_service.py::test_discovery_prompt_includes_tutor_context_when_present tests/test_concept_service.py::test_discovery_prompt_handles_missing_context -v
+```
+
+Expected: 2 tests FAIL — the current prompt only shows bare student text.
+
+- [ ] **Step 3: Update `_build_discovery_prompt`**
+
+In `server/python/concept_service.py`, find the sample-rendering loop (around line 152-157):
+
+```python
+    for cluster_id, samples in samples_by_cluster.items():
+        parts.append(f"### Cluster {cluster_id}")
+        for s in samples:
+            text = s["message_text"][:300]
+            parts.append(f'- "{text}"')
+        parts.append("")
+```
+
+Replace with:
+
+```python
+    for cluster_id, samples in samples_by_cluster.items():
+        parts.append(f"### Cluster {cluster_id}")
+        for s in samples:
+            text = s["message_text"][:300]
+            ctx = (s.get("context_before") or "").strip()
+            if ctx:
+                # Show last 200 chars of tutor context (where the prompt usually is)
+                # to keep the discovery prompt size manageable across N×K samples.
+                ctx_short = (ctx[-200:] if len(ctx) > 200 else ctx).replace("\n", " ")
+                parts.append(f'- Tutor asked: "{ctx_short}"')
+                parts.append(f'  Student replied: "{text}"')
+            else:
+                parts.append(f'- (start of conversation) Student: "{text}"')
+        parts.append("")
+```
+
+- [ ] **Step 4: Run the prompt tests to verify they pass**
+
+```
+cd server/python && uv run pytest tests/test_concept_service.py -v
+```
+
+Expected: All 13 tests in test_concept_service.py pass (the 11 from Task 1+2 + the 2 new ones).
+
+- [ ] **Step 5: Stop for user review**
+
+Surface: "Task 3 done — `_build_discovery_prompt` shows tutor context when present and a (start of conversation) marker otherwise. 13 tests pass. Continue?"
+
+---
+
+## Task 4: Update `discover_concepts` caller in `main.py` to include `context_before`
+
+**Files:**
+- Modify: `server/python/main.py` — add `context_before` field to the message dicts assembled at line 2043-2047.
+
+There is no test added in this task — the change is a single field added to a dict literal, and the upstream behavior is verified by Task 2's test of `embed_messages`. If the user wants integration coverage, the existing `test_discover_concepts_returns_candidates` test in `test_concept_service.py` already passes the new field path through (with `context_before=None` via `.get()`), so the integration is implicitly covered.
+
+- [ ] **Step 1: Locate the caller**
+
+Open `server/python/main.py` and find the block around line 2040-2047 (inside the `_discover_run` background task):
+
+```python
+            all_messages = []
+            for mc in db.exec(select(MessageCache)).all():
+                key = (mc.chatlog_id, mc.message_index)
+                if key not in labeled_keys:
+                    all_messages.append({
+                        "chatlog_id": mc.chatlog_id,
+                        "message_index": mc.message_index,
+                        "message_text": mc.message_text,
+                    })
+```
+
+- [ ] **Step 2: Add `context_before` to the dict**
+
+Replace the inner block with:
+
+```python
+            all_messages = []
+            for mc in db.exec(select(MessageCache)).all():
+                key = (mc.chatlog_id, mc.message_index)
+                if key not in labeled_keys:
+                    all_messages.append({
+                        "chatlog_id": mc.chatlog_id,
+                        "message_index": mc.message_index,
+                        "message_text": mc.message_text,
+                        "context_before": mc.context_before,
+                    })
+```
+
+That is the only change. `MessageCache.context_before` is `Optional[str]` and already populated at startup.
+
+- [ ] **Step 3: Run the full backend test suite to confirm nothing breaks**
+
+```
+cd server/python && uv run pytest -v
+```
+
+Expected: All tests pass (the existing main.py tests do not exercise the discovery background task directly; the field addition is benign).
+
+- [ ] **Step 4: Stop for user review**
+
+Surface: "Task 4 done — `main.py:2043` now passes `context_before` into the discover_concepts message dicts. Full backend test suite passes. Continue?"
+
+---
+
+## Task 5: Add `model_version` filter in `assist_service._build_cache`
+
+**Files:**
+- Modify: `server/python/assist_service.py` — import `EMBED_MODEL` from `concept_service`; add `.where(MessageEmbedding.model_version == EMBED_MODEL)` to the `_build_cache` query.
+- Modify: `server/python/tests/test_assist_service.py` — new test verifying old-key rows are excluded.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_assist_service.py`:
+
+```python
+def test_build_cache_filters_by_current_model_version(session):
+    """When MessageEmbedding contains rows from both the old (bare-text) and new
+    (pair-format) model_versions, _build_cache must load ONLY the new ones.
+    Otherwise the assist matrix mixes vectors of incompatible semantics."""
+    from concept_service import EMBED_MODEL
+    from assist_service import _build_cache
+
+    # Pre-seed two rows: one OLD-key, one NEW-key, both at the same (chatlog_id, message_index).
+    session.add(MessageEmbedding(
+        chatlog_id=42,
+        message_index=0,
+        embedding=_emb([1.0, 0.0]),
+        model_version="gemini-embedding-001",  # OLD
+    ))
+    session.add(MessageEmbedding(
+        chatlog_id=42,
+        message_index=0,
+        embedding=_emb([0.0, 1.0]),
+        model_version=EMBED_MODEL,  # NEW
+    ))
+    # Add a second NEW-key row at a different key so the matrix has > 1 vector.
+    session.add(MessageEmbedding(
+        chatlog_id=99,
+        message_index=0,
+        embedding=_emb([1.0, 1.0]),
+        model_version=EMBED_MODEL,
+    ))
+    session.commit()
+
+    cache = _build_cache(session, fingerprint=(0, 0, 0))
+
+    # Only the NEW-key vectors should be loaded.
+    assert cache["matrix"] is not None
+    assert cache["matrix"].shape[0] == 2  # two NEW rows, not three
+    keys = set(cache["keys_idx"].keys())
+    assert keys == {(42, 0), (99, 0)}
+
+    # Verify (42, 0)'s vector is the NEW one ([0, 1] normalized), not the OLD one ([1, 0]).
+    idx = cache["keys_idx"][(42, 0)]
+    vec = cache["matrix"][idx]
+    # Normalized [0, 1] is just [0, 1]. Normalized [1, 0] is [1, 0]. So vec[1] should be ~1.0.
+    assert vec[1] > 0.99
+    assert vec[0] < 0.01
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+cd server/python && uv run pytest tests/test_assist_service.py::test_build_cache_filters_by_current_model_version -v
+```
+
+Expected: FAIL — current `_build_cache` loads ALL rows regardless of `model_version`, so the matrix has 3 vectors and (42, 0) might point to either the OLD or NEW one depending on insertion order.
+
+- [ ] **Step 3: Add the import and the filter to `_build_cache`**
+
+In `server/python/assist_service.py`, near the existing imports at the top of the file, add:
+
+```python
+from concept_service import EMBED_MODEL
+```
+
+Find `_build_cache` (around line 18-25):
+
+```python
+def _build_cache(db: Session, fingerprint: tuple[int, int, int]) -> dict:
+    rows = db.exec(
+        select(
+            MessageEmbedding.chatlog_id,
+            MessageEmbedding.message_index,
+            MessageEmbedding.embedding,
+        )
+    ).all()
+```
+
+Replace with:
+
+```python
+def _build_cache(db: Session, fingerprint: tuple[int, int, int]) -> dict:
+    rows = db.exec(
+        select(
+            MessageEmbedding.chatlog_id,
+            MessageEmbedding.message_index,
+            MessageEmbedding.embedding,
+        )
+        .where(MessageEmbedding.model_version == EMBED_MODEL)
+    ).all()
+```
+
+- [ ] **Step 4: Update the fingerprint query to match (so cache invalidation is consistent)**
+
+Find `_embedding_fingerprint` (around line 40-50 in `assist_service.py`):
+
+```python
+def _embedding_fingerprint(db: Session) -> tuple[int, int, int]:
+    """A cheap signal that detects inserts, deletes, and in-place re-embeds.
+    (count, max_id, sum_id) — pure-count was insufficient because re-embedding
+    an existing (chatlog_id, message_index) does not change the row count, but
+    does change which rows we are now serving."""
+    row = db.exec(
+        select(
+            func.count(MessageEmbedding.id),
+            func.coalesce(func.max(MessageEmbedding.id), 0),
+            func.coalesce(func.sum(MessageEmbedding.id), 0),
+```
+
+After the `select(...)` call, add a `.where(MessageEmbedding.model_version == EMBED_MODEL)` to the chain so the fingerprint reflects ONLY the new-key rows. The exact location depends on the surrounding `).one()`. Read the function fully, then add the `.where(...)` on the existing query (it likely has a `.first()` or `.one()` at the end; insert the `.where()` before it).
+
+The full updated function should look like:
+
+```python
+def _embedding_fingerprint(db: Session) -> tuple[int, int, int]:
+    """A cheap signal that detects inserts, deletes, and in-place re-embeds.
+    (count, max_id, sum_id) — pure-count was insufficient because re-embedding
+    an existing (chatlog_id, message_index) does not change the row count, but
+    does change which rows we are now serving."""
+    row = db.exec(
+        select(
+            func.count(MessageEmbedding.id),
+            func.coalesce(func.max(MessageEmbedding.id), 0),
+            func.coalesce(func.sum(MessageEmbedding.id), 0),
+        )
+        .where(MessageEmbedding.model_version == EMBED_MODEL)
+    ).one()
+    return (int(row[0]), int(row[1]), int(row[2]))
+```
+
+(If the existing function body differs from what's shown above, preserve the existing logic and add only the `.where(...)` call.)
+
+- [ ] **Step 5: Run the assist_service test suite to verify everything passes**
+
+```
+cd server/python && uv run pytest tests/test_assist_service.py -v
+```
+
+Expected: All existing assist_service tests pass AND the new filter test passes.
+
+**Watch for**: the existing test `test_nearest_neighbors_returns_top_k_by_cosine` and friends seed `MessageEmbedding` rows WITHOUT specifying `model_version` — meaning they use the default value from `models.py:150` which is `"gemini-embedding-001"` (the OLD key). After Step 3, those rows will be filtered out and the existing tests will FAIL.
+
+If they fail, the fix is to update `_seed_message` (in test_assist_service.py around line 26-37) to explicitly set `model_version=EMBED_MODEL`:
+
+```python
+def _seed_message(session, chatlog_id, message_index, text, vec):
+    from concept_service import EMBED_MODEL
+    session.add(MessageCache(
+        chatlog_id=chatlog_id,
+        message_index=message_index,
+        message_text=text,
+    ))
+    session.add(MessageEmbedding(
+        chatlog_id=chatlog_id,
+        message_index=message_index,
+        embedding=_emb(vec),
+        model_version=EMBED_MODEL,
+    ))
+    session.commit()
+```
+
+After updating the seeder, re-run the suite; all assist tests should pass.
+
+- [ ] **Step 6: Run the full backend test suite to confirm no regressions**
+
+```
+cd server/python && uv run pytest -v
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Stop for user review**
+
+Surface: "Task 5 done — `assist_service._build_cache` and `_embedding_fingerprint` filter by `model_version == EMBED_MODEL`, test seeder updated, all backend tests pass. Continue to final smoke?"
+
+---
+
+## Task 6: End-to-end manual smoke (user action — cannot dispatch)
+
+This task is manual and cannot be performed by a subagent.
+
+- [ ] **Step 1: Start the stack**
+
+```
+npm run dev:all
+```
+
+- [ ] **Step 2: Trigger concept discovery via the existing UI path**
+
+In single-label or multi-label mode, find the Discover affordance (`src/components/queue/DiscoverSection.tsx` or related; the trigger is via the `/api/concepts/discover` endpoint).
+
+- [ ] **Step 3: Verify cluster names reflect context**
+
+After discovery completes:
+- Compare cluster names to what you got before (recall the screenshot showing `validation` clusters mixing surface-form `?` and `yes` responses).
+- Names should describe semantically meaningful patterns ("students asking for clarification on fill-in-the-blank prompts") rather than surface forms ("short responses").
+- Open a cluster's messages and confirm they actually share a pedagogical pattern, not just a surface form.
+
+- [ ] **Step 4: Verify the assist flank on /run**
+
+Walk to a label run (`/run`) where a focused short-text message appears (`?`, `yes`, `ok`).
+- Confirm the "your closest prior decisions" sidebar surfaces priors that are context-similar (priors that were responses to similar tutor prompts), not just bare-text similar.
+- Specifically test the scenario from the spec's motivating screenshot: a `?` response to a fill-in-the-blank tutor prompt should surface confusion-like priors, NOT validation-shaped priors like "did i do this right".
+
+- [ ] **Step 5: If A doesn't work — escalate to C**
+
+Apply the criteria from `docs/superpowers/specs/2026-05-15-context-aware-embeddings-design.md` §10:
+- `validation` clusters still mix `?` with `did i do this right`?
+- Assist neighbors for known-confusion `?` still return validation priors with > 0.7 cosine?
+- Instructor feels clusters/flank are still noisy?
+
+If any of these are true, the next move is option **C (LLM-summarized context)**. That requires a new spec, not a fix to this one. Surface to me with what you observed and we'll write the C spec.
+
+- [ ] **Step 6: Final state**
+
+If A worked: commit PRs 1–5 (Tasks 1–5) at your preferred granularity. The full extraction is done.
+
+If A didn't work: keep the working tree, surface to me, and we move to spec C with concrete evidence of where A fell short.
+
+---
+
+## Definition of done
+
+- [ ] `_build_pair_text` helper exists in `concept_service.py` with 5 unit tests passing.
+- [ ] `embed_messages` produces vectors from pair text (or the no-context fallback) and stores them with `model_version = "gemini-embedding-001:pair-v1"`.
+- [ ] `_build_discovery_prompt` shows Gemini the pair format for cluster naming.
+- [ ] `main.py:2043` passes `context_before` into the discovery message dicts.
+- [ ] `assist_service._build_cache` and `_embedding_fingerprint` filter by the new `model_version`.
+- [ ] All backend tests pass.
+- [ ] Manual smoke (Task 6) confirms cluster names and assist neighbors are context-aware.
+- [ ] Spec §10 escalation criteria checked; if A doesn't deliver, surface to write spec C.

--- a/docs/superpowers/specs/2026-05-15-context-aware-embeddings-design.md
+++ b/docs/superpowers/specs/2026-05-15-context-aware-embeddings-design.md
@@ -1,0 +1,287 @@
+# Context-aware embeddings — design spec
+
+**Date:** 2026-05-15
+**Branch:** to be created from `main` or `summaries-revamp` when implementation starts
+**Owner:** @m1nce
+**Status:** Draft — pending user approval
+
+---
+
+## 1. Motivation
+
+`server/python/concept_service.py:51` embeds the bare student message text:
+
+```python
+texts = [messages[i]["message_text"] for i in batch_idx]
+```
+
+For messages whose meaning is **entirely defined by what they're responding to** — `"?"`, `"yes"`, `"ok"`, `"i think 4"`, `"did i"` — this produces vectors that collapse together regardless of label. A `"?"` that means "confusion at a fill-in-the-blank prompt" embeds identically to a `"?"` that means "I don't understand your explanation, please rephrase" and a `"?"` that means "wait, are you asking me?". Two consequences:
+
+1. **`/run` assist-flank misleads.** The "your closest prior decisions" sidebar (powered by cosine NN over `MessageEmbedding` via `assist_service.py`) for a focused `"?"` surfaces priors like `"did i do this right"` and `"how does my code look now?"` — all marked YES for the `validation` label — because they're all "short student messages" by embedding similarity. The instructor sees three prior YESes and is implicitly nudged toward YES, but the focused `"?"` is *not* validation in context (the prior tutor turn was a content question, not a self-check prompt).
+
+2. **`/summaries` concept clusters mix labels.** `discover_concepts` (concept_service.py:209) clusters bare-text embeddings, so clusters group by surface form ("all `?`s", "all short affirmations") rather than by pedagogically meaningful pattern. Cluster names produced by `_build_discovery_prompt` reflect that surface grouping.
+
+Both surfaces share the same `MessageEmbedding` cache. Fixing the embedding strategy fixes both.
+
+---
+
+## 2. Approach
+
+Replace bare-text embedding with **conversation-pair embedding**: each student message is embedded together with its immediately-preceding tutor turn, prefixed by speaker labels to give the embedding model role structure.
+
+**Embedded text format** (the string passed to Gemini's `embed_content`):
+
+```
+Tutor: {context_before truncated to last 500 chars}
+Student: {message_text}
+```
+
+When `context_before` is absent (first student turn in a conversation, or missing in cache), embed the student message alone with a `[Conversation start]\nStudent: {message_text}` prefix so the format is still consistent.
+
+This is option **A** from the brainstorming discussion. Options B (windowed multi-turn) and D (per-label context recipe) are out of scope. Option **C (LLM-summarized context)** is documented in §10 as the next escalation if A's clusters still mix labels in measurable ways.
+
+---
+
+## 3. Scope
+
+**In scope:**
+- Modify `embed_messages` (concept_service.py) to accept context and build the pair text.
+- Bump the embedding cache version so stale single-message vectors are not reused.
+- Update `discover_concepts` to fetch `context_before` from `MessageCache` and pass it in.
+- Update `_build_discovery_prompt` so the cluster-naming prompt shows Gemini the pair format too.
+- Tests: `test_concept_service.py` updated to cover the new pair format and cache key.
+
+**In scope (continued):**
+- A one-line filter addition in `assist_service.py:21` to scope the loaded matrix to the new `model_version`, so old + new vectors are never mixed in the same cosine matrix during the transition. This is consistency-of-cache, not a redesign of ranking logic.
+
+**Out of scope (deliberate):**
+- `binary_autolabel_service.py` — the classifier reads textual prompts, not embeddings, so its fix is separate (a related-but-distinct spec).
+- Re-embedding live production cache as a backfill job — the new cache key will simply re-embed on demand. A separate one-shot script can be added later if eager re-embed is wanted.
+- `MessageCache` schema changes — `context_before` already exists at `main.py:97-101` and is populated at cache build time.
+- Multi-turn context windows (option B) — single previous tutor turn is the v1 commitment.
+- Per-label context recipes (option D).
+- Changing how the assist sidebar ranks or displays neighbors — only the filter on which vectors get loaded changes; the ranking algorithm is untouched.
+
+---
+
+## 4. Where the context comes from
+
+`MessageCache.context_before` (defined in `models.py:135`) is populated at cache-build time by the SQL at `main.py:97-101`:
+
+```sql
+(SELECT e2.payload->>'response' FROM events e2
+ WHERE e2.payload->>'conversation_id' = s.conv_id
+   AND e2.event_type = 'tutor_response' AND e2.id < s.id
+ ORDER BY e2.id DESC LIMIT 1) AS context_before
+```
+
+So the immediately-preceding tutor turn is already available in local SQLite for every cached student message. No external DB query is needed at embed time. **`embed_messages` does not need to fetch context itself** — the caller (`discover_concepts`) reads it from `MessageCache` and passes it in alongside `message_text`.
+
+---
+
+## 5. API changes
+
+### `embed_messages` (concept_service.py)
+
+**Before:**
+```python
+def embed_messages(messages: List[Dict[str, Any]], db: Session) -> np.ndarray:
+    # ...
+    texts = [messages[i]["message_text"] for i in batch_idx]
+```
+
+Each message dict required keys: `chatlog_id`, `message_index`, `message_text`.
+
+**After:**
+```python
+def embed_messages(messages: List[Dict[str, Any]], db: Session) -> np.ndarray:
+    # ...
+    texts = [_build_pair_text(messages[i]) for i in batch_idx]
+```
+
+Each message dict requires keys: `chatlog_id`, `message_index`, `message_text`. New optional key: `context_before: Optional[str]`. If absent or `None`, treated as "first turn".
+
+### New private helper
+
+```python
+CONTEXT_CHAR_LIMIT = 500  # last 500 chars of tutor context — the question the student is responding to
+
+def _build_pair_text(msg: Dict[str, Any]) -> str:
+    """Build the text that gets embedded for one student message.
+
+    Format:
+        Tutor: <last 500 chars of preceding tutor turn>
+        Student: <message_text>
+
+    If no preceding tutor turn exists (first student message in a conversation),
+    fall back to:
+        [Conversation start]
+        Student: <message_text>
+    """
+    student = msg["message_text"]
+    ctx = msg.get("context_before")
+    if not ctx:
+        return f"[Conversation start]\nStudent: {student}"
+    truncated = ctx[-CONTEXT_CHAR_LIMIT:] if len(ctx) > CONTEXT_CHAR_LIMIT else ctx
+    return f"Tutor: {truncated}\nStudent: {student}"
+```
+
+`CONTEXT_CHAR_LIMIT = 500` is chosen so the tutor context fits in a few sentences (~80-100 words) — enough for the actual question or prompt without diluting the student's signal. The last N chars (not first N) is correct because the question is usually at the end of a tutor turn.
+
+### Cache invalidation
+
+Bump the `EMBED_MODEL` constant:
+
+```python
+EMBED_MODEL = "gemini-embedding-001:pair-v1"
+```
+
+The actual model called via `client.models.embed_content` stays `"gemini-embedding-001"`:
+
+```python
+EMBED_API_MODEL = "gemini-embedding-001"  # what Gemini accepts
+EMBED_MODEL = "gemini-embedding-001:pair-v1"  # what we store as model_version (cache key)
+# ...
+result = client.models.embed_content(model=EMBED_API_MODEL, contents=texts)
+```
+
+This way, old cached rows (where `model_version = "gemini-embedding-001"`) remain untouched on disk but are never matched by the new lookup. New rows are written under the new model_version. On-disk size grows during the transition; a cleanup query can drop the old rows once the new ones are warm:
+
+```sql
+DELETE FROM messageembedding WHERE model_version = 'gemini-embedding-001';
+```
+
+This deletion is **not** part of v1 — leaving the old rows is safe and allows rollback by reverting `EMBED_MODEL` if A doesn't pan out.
+
+### `discover_concepts` caller update
+
+`discover_concepts` is invoked from `main.py:1906` and similar sites (`grep -n "discover_concepts" server/python/`). Wherever the caller builds the `messages: List[Dict]` list, it should join `MessageCache.context_before` into each dict.
+
+If the caller already queries `MessageCache` for `message_text`, adding `MessageCache.context_before` to the SELECT is a one-line change. If the caller assembles the dict from a different source, it should look up `MessageCache.context_before` by `(chatlog_id, message_index)` before calling.
+
+### `_build_discovery_prompt` update
+
+The function (`concept_service.py:129`) currently shows Gemini bare student-text samples (line 154-156):
+
+```python
+for s in samples:
+    text = s["message_text"][:300]
+    parts.append(f'- "{text}"')
+```
+
+Update to show the pair format so Gemini sees the context when naming clusters:
+
+```python
+for s in samples:
+    ctx = (s.get("context_before") or "").strip()
+    if ctx:
+        ctx_short = (ctx[-200:] if len(ctx) > 200 else ctx).replace("\n", " ")
+        text = s["message_text"][:300]
+        parts.append(f"- Tutor asked: \"{ctx_short}\"")
+        parts.append(f"  Student replied: \"{text}\"")
+    else:
+        text = s["message_text"][:300]
+        parts.append(f'- (start of conversation) Student: "{text}"')
+```
+
+Limit context to last 200 chars in the prompt (shorter than the embedding limit) to keep the prompt size manageable across N samples × K clusters.
+
+---
+
+## 6. Behavior on edge cases
+
+| Case | Handling |
+|------|----------|
+| First student turn in a conversation (no `context_before`) | Fall back to `[Conversation start]\nStudent: {text}` format. Same key shape, no special path downstream. |
+| `context_before` exists but is empty string | Treated as missing (`not ctx` is true). Same fallback path. |
+| Very long tutor turn (e.g., a multi-paragraph explanation) | Truncated to last 500 chars before pair text is built. Loses early context but preserves the immediate prompt the student is responding to. |
+| Very long student turn (rare; usually short) | No truncation. Gemini embeds up to 8K tokens; even a 2K-char student response is well within budget. |
+| Multiple `tutor_response` events between two student turns | `MessageCache.context_before` already picks the most recent one (`ORDER BY id DESC LIMIT 1` in the SQL). No change needed. |
+| `MessageCache` row missing entirely | Caller treats this as "no context available" and falls back. Should not happen during normal operation since cache is built at startup. |
+
+---
+
+## 7. Testing
+
+### Unit tests (`server/python/tests/test_concept_service.py`)
+
+1. **`test_pair_text_with_context`**: `_build_pair_text({"message_text": "yes", "context_before": "Did that solve it?"})` returns `"Tutor: Did that solve it?\nStudent: yes"`.
+2. **`test_pair_text_without_context`**: same with `context_before=None` returns `"[Conversation start]\nStudent: yes"`.
+3. **`test_pair_text_truncates_long_context`**: tutor context of 2000 chars is truncated to last 500.
+4. **`test_embed_messages_uses_pair_text`**: mock `client.models.embed_content`, call `embed_messages` with a message dict that has `context_before`, assert the `contents` arg to `embed_content` is `["Tutor: ...\nStudent: ..."]`, not the bare text.
+5. **`test_cache_key_uses_new_model_version`**: after embedding, the `MessageEmbedding` row's `model_version` is `"gemini-embedding-001:pair-v1"`.
+6. **`test_old_cached_embedding_not_reused`**: pre-seed `MessageEmbedding` with `model_version="gemini-embedding-001"` (old key). Call `embed_messages` — must call `embed_content` (cache miss under new key) and write a new row.
+
+### Spot-check (not automated — manual verification by user)
+
+After implementation, run `discover_concepts` on the live data. Compare:
+- Cluster names before vs after (qualitative — do they describe semantically meaningful patterns now?).
+- A handful of known-bare-text examples (`?`, `yes`, `ok`) — their assist-flank nearest neighbors should now reflect context-aware similarity.
+
+This is the empirical signal for "did A work". §10 below describes what "didn't work" looks like.
+
+---
+
+## 8. Migration / rollout
+
+1. Land the code change (cache key bump means existing on-disk vectors are not consulted).
+2. First request to `discover_concepts` or the assist-flank rebuild path will re-embed messages under the new key. With a typical sample size (a few hundred messages), this completes in seconds to a minute and costs a fraction of a cent.
+3. (Optional, deferred) Drop the old rows: `DELETE FROM messageembedding WHERE model_version = 'gemini-embedding-001';`
+4. Rollback path: revert `EMBED_MODEL` to `"gemini-embedding-001"`. The old rows are still on disk and lookups hit them again.
+
+---
+
+## 9. Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Tutor context overwhelms student signal (long tutor turn, short student turn) | 500-char trailing truncation. If still problematic, escalate to **C** (LLM-summarized context, §10). |
+| Cache double-storage during transition | Acceptable for v1. Deletion of old rows is a one-line SQL when desired. |
+| `_build_discovery_prompt` token budget exceeded for many clusters × many samples | Context limited to 200 chars in the prompt (shorter than the embedding limit of 500). For 8 clusters × 5 samples × ~200 chars context + 300 chars student, total is ~5K chars ≈ 1.3K tokens for cluster bodies. Well within budget. |
+| Behavioral surprise in `/run` assist flank during the first session post-deploy | The neighbors will change — that's the point. Worth noting in a release-notes line for the instructor. Not a correctness issue. |
+| Future caller of `embed_messages` forgets to pass `context_before` | `context_before` is optional and falls back gracefully. No crash, just degraded similarity for that caller. Acceptable. |
+
+---
+
+## 10. Escalation path: option C
+
+If after deploying A, clusters and assist-flank neighbors are still measurably wrong on the labels that motivated this change (`validation`, `cooperation`), escalate to **option C: LLM-summarized context**.
+
+**Criteria for "A didn't work"** (any one is sufficient):
+- The `validation` clusters from `discover_concepts` still group `"?"`s from confusion contexts with `"did i do this right"`s — measurable by spot-check on a 20-message sample.
+- Assist-flank neighbors for a known-confusion `"?"` still return validation-shaped priors with > 0.7 cosine — measurable by manual probe.
+- Instructor reports the flank/clusters feel similarly noisy to before.
+
+**Option C sketch** (for context; not a spec):
+- Before embedding, ask Gemini-Flash to produce a one-sentence "what is the student doing here, in context" summary that synthesizes the surrounding turns.
+- Embed the summary instead of the pair text.
+- Cost: one extra Gemini call per message (cached the same way), ~$0.0001 per call at current rates.
+- Risk: Gemini hallucinations in the summary propagate to embedding space.
+
+C is documented here so the path forward is clear. It is NOT implemented in v1.
+
+---
+
+## 11. File map
+
+### Modified
+- `server/python/concept_service.py` — new `_build_pair_text` helper; `embed_messages` uses it; `EMBED_MODEL` renamed and split (`EMBED_API_MODEL` + `EMBED_MODEL`); `discover_concepts` passes `context_before` into the message dicts when assembling them; `_build_discovery_prompt` shows pair format.
+- Caller(s) of `discover_concepts` in `main.py` — include `MessageCache.context_before` when assembling the message list passed to the function.
+- `server/python/tests/test_concept_service.py` — new tests (§7), existing tests updated where they assert on the embedded text format.
+
+### Modified (cross-module, one-line addition)
+- `server/python/assist_service.py:19-25` — `_build_cache` currently selects all `MessageEmbedding` rows with no filter. Add a `.where(MessageEmbedding.model_version == EMBED_MODEL)` to ensure the cosine matrix only contains vectors built under the new pair-v1 strategy. Import `EMBED_MODEL` from `concept_service` (or define a shared constant). Without this filter, the assist matrix would mix old bare-text vectors with new pair vectors after rollout, producing incoherent neighbor results until the old rows are deleted.
+
+### New
+- None — no new files, no schema changes.
+
+---
+
+## 12. Success criteria
+
+1. `embed_messages` produces vectors built from `"Tutor: ...\nStudent: ..."` (or the no-context fallback) pair text.
+2. `MessageEmbedding` rows produced after the change have `model_version = "gemini-embedding-001:pair-v1"`.
+3. `discover_concepts` end-to-end runs without error using the new pipeline on a small live sample.
+4. Cluster names produced for a labeled sample (e.g., `validation`) describe meaningful patterns rather than surface forms — qualitative judgment by the user during manual spot-check.
+5. The `/run` assist flank for a focused `"?"` returns context-similar priors (priors that were also short responses to fill-in-the-blank or content questions), not the highest-cosine bare-text matches.
+6. Test suite green; `npx tsc --noEmit` unchanged (this is a Python-only change).

--- a/server/python/assist_service.py
+++ b/server/python/assist_service.py
@@ -9,6 +9,7 @@ import numpy as np
 from sqlalchemy import func
 from sqlmodel import Session, select
 
+from concept_service import EMBED_MODEL
 from models import LabelApplication, MessageCache, MessageEmbedding
 
 
@@ -22,6 +23,7 @@ def _build_cache(db: Session, fingerprint: tuple[int, int, int]) -> dict:
             MessageEmbedding.message_index,
             MessageEmbedding.embedding,
         )
+        .where(MessageEmbedding.model_version == EMBED_MODEL)
     ).all()
     if not rows:
         return {"matrix": None, "keys_idx": {}, "fingerprint": fingerprint}
@@ -48,6 +50,7 @@ def _embedding_fingerprint(db: Session) -> tuple[int, int, int]:
             func.coalesce(func.max(MessageEmbedding.id), 0),
             func.coalesce(func.sum(MessageEmbedding.id), 0),
         )
+        .where(MessageEmbedding.model_version == EMBED_MODEL)
     ).one()
     return (int(row[0]), int(row[1]), int(row[2]))
 

--- a/server/python/concept_service.py
+++ b/server/python/concept_service.py
@@ -12,18 +12,46 @@ from models import MessageEmbedding, ConceptCandidate, LabelDefinition
 
 client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
 
-EMBED_MODEL = "gemini-embedding-001"
+EMBED_API_MODEL = "gemini-embedding-001"  # passed to the Gemini API
+EMBED_MODEL = "gemini-embedding-001:pair-v1"  # stored as MessageEmbedding.model_version (cache key)
 EMBED_DIM = 3072
 EMBED_BATCH_SIZE = 100  # Gemini API limit per call
+CONTEXT_CHAR_LIMIT = 500
+
+
+def _build_pair_text(msg: Dict[str, Any]) -> str:
+    """Build the text that gets embedded for one student message.
+
+    Pair format:
+        Tutor: <last CONTEXT_CHAR_LIMIT chars of preceding tutor turn>
+        Student: <message_text>
+
+    When there is no preceding tutor turn (first student message in a conversation,
+    or context not provided by the caller), fall back to a consistent prefix that
+    keeps the embedding distribution roughly aligned with the pair format:
+
+        [Conversation start]
+        Student: <message_text>
+    """
+    student = msg["message_text"]
+    ctx = msg.get("context_before")
+    if not ctx or not ctx.strip():
+        return f"[Conversation start]\nStudent: {student}"
+    truncated = ctx[-CONTEXT_CHAR_LIMIT:] if len(ctx) > CONTEXT_CHAR_LIMIT else ctx
+    return f"Tutor: {truncated}\nStudent: {student}"
 
 
 def embed_messages(
     messages: List[Dict[str, Any]], db: Session
 ) -> np.ndarray:
-    """Embed messages, using cached embeddings where available.
+    """Embed messages using context-aware pair text, caching results by model_version.
 
     Each message dict must have: chatlog_id, message_index, message_text.
-    Returns numpy array of shape (len(messages), 768).
+    Optional key ``context_before`` (str | None) — the preceding tutor turn.
+    When present it is prepended as ``Tutor: …\\nStudent: …``; when absent the
+    fallback ``[Conversation start]\\nStudent: …`` is used.
+
+    Returns numpy array of shape (len(messages), EMBED_DIM).
     """
     vectors = np.zeros((len(messages), EMBED_DIM), dtype=np.float32)
     uncached_indices: List[int] = []
@@ -48,10 +76,10 @@ def embed_messages(
     # Embed uncached in batches
     for batch_start in range(0, len(uncached_indices), EMBED_BATCH_SIZE):
         batch_idx = uncached_indices[batch_start : batch_start + EMBED_BATCH_SIZE]
-        texts = [messages[i]["message_text"] for i in batch_idx]
+        texts = [_build_pair_text(messages[i]) for i in batch_idx]
 
         result = client.models.embed_content(
-            model=EMBED_MODEL,
+            model=EMBED_API_MODEL,
             contents=texts,
         )
 
@@ -153,7 +181,15 @@ def _build_discovery_prompt(
         parts.append(f"### Cluster {cluster_id}")
         for s in samples:
             text = s["message_text"][:300]
-            parts.append(f'- "{text}"')
+            ctx = (s.get("context_before") or "").strip()
+            if ctx:
+                # Show last 200 chars of tutor context (where the prompt usually is)
+                # to keep the discovery prompt size manageable across N×K samples.
+                ctx_short = (ctx[-200:] if len(ctx) > 200 else ctx).replace("\n", " ")
+                parts.append(f'- Tutor asked: "{ctx_short}"')
+                parts.append(f'  Student replied: "{text}"')
+            else:
+                parts.append(f'- (start of conversation) Student: "{text}"')
         parts.append("")
 
     parts.append(
@@ -190,7 +226,7 @@ def _deduplicate_concepts(
         return concepts
 
     texts = [f"{c['name']}: {c['description']}" for c in concepts]
-    result = client.models.embed_content(model=EMBED_MODEL, contents=texts)
+    result = client.models.embed_content(model=EMBED_API_MODEL, contents=texts)
     vectors = np.array([e.values for e in result.embeddings], dtype=np.float32)
 
     norms = np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9
@@ -279,7 +315,7 @@ def discover_concepts(
     if existing:
         label_texts = [f"{ld['name']}: {ld['description']}" for ld in existing]
         label_embed_result = client.models.embed_content(
-            model=EMBED_MODEL,
+            model=EMBED_API_MODEL,
             contents=label_texts,
         )
         label_vectors = np.array(

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2040,6 +2040,7 @@ def _run_discover():
                         "chatlog_id": mc.chatlog_id,
                         "message_index": mc.message_index,
                         "message_text": mc.message_text,
+                        "context_before": mc.context_before,
                     })
 
             if not all_messages:

--- a/server/python/tests/test_assist_endpoint.py
+++ b/server/python/tests/test_assist_endpoint.py
@@ -1,6 +1,7 @@
 """Integration tests for GET /api/single-labels/{id}/assist."""
 import numpy as np
 
+from concept_service import EMBED_MODEL
 from models import LabelApplication, LabelDefinition, MessageCache, MessageEmbedding
 
 
@@ -21,11 +22,11 @@ def test_assist_endpoint_returns_nearest_labeled_neighbors(client, session):
     # Focused message + two labeled candidates with controlled embeddings.
     # Cosine ranks by closeness to focused vector.
     session.add(MessageCache(chatlog_id=200, message_index=0, message_text="focus"))
-    session.add(MessageEmbedding(chatlog_id=200, message_index=0, embedding=_emb([1.0, 0.0])))
+    session.add(MessageEmbedding(chatlog_id=200, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
     session.add(MessageCache(chatlog_id=100, message_index=0, message_text="i'm stuck on q3"))
-    session.add(MessageEmbedding(chatlog_id=100, message_index=0, embedding=_emb([0.95, 0.31])))
+    session.add(MessageEmbedding(chatlog_id=100, message_index=0, embedding=_emb([0.95, 0.31]), model_version=EMBED_MODEL))
     session.add(MessageCache(chatlog_id=101, message_index=0, message_text="what is variance"))
-    session.add(MessageEmbedding(chatlog_id=101, message_index=0, embedding=_emb([0.31, 0.95])))
+    session.add(MessageEmbedding(chatlog_id=101, message_index=0, embedding=_emb([0.31, 0.95]), model_version=EMBED_MODEL))
     session.add(LabelApplication(
         label_id=label.id, chatlog_id=100, message_index=0,
         applied_by="human", confidence=1.0, value="yes",
@@ -64,7 +65,7 @@ def test_assist_endpoint_returns_empty_when_focus_has_no_embedding(client, sessi
 def test_assist_endpoint_returns_empty_when_no_labeled_neighbors(client, session):
     label = _seed_label(session)
     session.add(MessageCache(chatlog_id=200, message_index=0, message_text="focus"))
-    session.add(MessageEmbedding(chatlog_id=200, message_index=0, embedding=_emb([1.0, 0.0])))
+    session.add(MessageEmbedding(chatlog_id=200, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
     session.commit()
     r = client.get(
         f"/api/single-labels/{label.id}/assist",
@@ -79,7 +80,7 @@ def test_assist_endpoint_excludes_focused_message_from_its_own_neighbors(client,
     must not appear in its own neighbor list."""
     label = _seed_label(session)
     session.add(MessageCache(chatlog_id=200, message_index=0, message_text="focus"))
-    session.add(MessageEmbedding(chatlog_id=200, message_index=0, embedding=_emb([1.0, 0.0])))
+    session.add(MessageEmbedding(chatlog_id=200, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
     session.add(LabelApplication(
         label_id=label.id, chatlog_id=200, message_index=0,
         applied_by="human", confidence=1.0, value="yes",

--- a/server/python/tests/test_assist_service.py
+++ b/server/python/tests/test_assist_service.py
@@ -24,6 +24,7 @@ def _seed_label(session, name="L"):
 
 
 def _seed_message(session, chatlog_id, message_index, text, vec):
+    from concept_service import EMBED_MODEL
     session.add(MessageCache(
         chatlog_id=chatlog_id,
         message_index=message_index,
@@ -33,6 +34,7 @@ def _seed_message(session, chatlog_id, message_index, text, vec):
         chatlog_id=chatlog_id,
         message_index=message_index,
         embedding=_emb(vec),
+        model_version=EMBED_MODEL,
     ))
     session.commit()
 
@@ -134,3 +136,48 @@ def test_nearest_neighbors_excludes_skips(session):
     # The skipped message would have been the top similarity, but must be excluded.
     assert len(out) == 1
     assert out[0]["chatlog_id"] == 201
+
+
+def test_build_cache_filters_by_current_model_version(session):
+    """When MessageEmbedding contains rows from both the old (bare-text) and new
+    (pair-format) model_versions, _build_cache must load ONLY the new ones.
+    Otherwise the assist matrix mixes vectors of incompatible semantics."""
+    from concept_service import EMBED_MODEL
+    from assist_service import _build_cache
+
+    # Pre-seed two rows: one OLD-key, one NEW-key, both at the same (chatlog_id, message_index).
+    session.add(MessageEmbedding(
+        chatlog_id=42,
+        message_index=0,
+        embedding=_emb([1.0, 0.0]),
+        model_version="gemini-embedding-001",  # OLD
+    ))
+    session.add(MessageEmbedding(
+        chatlog_id=42,
+        message_index=0,
+        embedding=_emb([0.0, 1.0]),
+        model_version=EMBED_MODEL,  # NEW
+    ))
+    # Add a second NEW-key row at a different key so the matrix has > 1 vector.
+    session.add(MessageEmbedding(
+        chatlog_id=99,
+        message_index=0,
+        embedding=_emb([1.0, 1.0]),
+        model_version=EMBED_MODEL,
+    ))
+    session.commit()
+
+    cache = _build_cache(session, fingerprint=(0, 0, 0))
+
+    # Only the NEW-key vectors should be loaded.
+    assert cache["matrix"] is not None
+    assert cache["matrix"].shape[0] == 2  # two NEW rows, not three
+    keys = set(cache["keys_idx"].keys())
+    assert keys == {(42, 0), (99, 0)}
+
+    # Verify (42, 0)'s vector is the NEW one ([0, 1] normalized), not the OLD one ([1, 0]).
+    idx = cache["keys_idx"][(42, 0)]
+    vec = cache["matrix"][idx]
+    # Normalized [0, 1] is just [0, 1]. Normalized [1, 0] is [1, 0]. So vec[1] should be ~1.0.
+    assert vec[1] > 0.99
+    assert vec[0] < 0.01

--- a/server/python/tests/test_concept_service.py
+++ b/server/python/tests/test_concept_service.py
@@ -115,3 +115,182 @@ def test_deduplicate_concepts_filters_similar(mock_client):
     assert len(result) == 2
     assert result[0]["name"] == "code review"
     assert result[1]["name"] == "frustrated"
+
+
+def test_pair_text_with_context():
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": "Did that solve it?",
+    })
+    assert out == "Tutor: Did that solve it?\nStudent: yes"
+
+
+def test_pair_text_without_context():
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": None,
+    })
+    assert out == "[Conversation start]\nStudent: yes"
+
+
+def test_pair_text_treats_empty_context_as_missing():
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": "",
+    })
+    assert out == "[Conversation start]\nStudent: yes"
+
+
+def test_pair_text_truncates_long_context():
+    from concept_service import _build_pair_text, CONTEXT_CHAR_LIMIT
+    long_ctx = "A" * 800 + "tail-marker"
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": long_ctx,
+    })
+    # Truncation keeps the LAST CONTEXT_CHAR_LIMIT chars (where the prompt usually lives).
+    assert "tail-marker" in out
+    assert out.startswith("Tutor: ")
+    # The Tutor segment should be exactly CONTEXT_CHAR_LIMIT chars.
+    tutor_line = out.split("\n")[0]  # "Tutor: <ctx>"
+    assert len(tutor_line) - len("Tutor: ") == CONTEXT_CHAR_LIMIT
+
+
+def test_pair_text_handles_missing_context_key():
+    """If the caller dict lacks `context_before` entirely (legacy path), fall back gracefully."""
+    from concept_service import _build_pair_text
+    out = _build_pair_text({"message_text": "hello"})
+    assert out == "[Conversation start]\nStudent: hello"
+
+
+def test_pair_text_treats_whitespace_only_context_as_missing():
+    """Whitespace-only context (spaces, newlines, tabs) should be treated as missing."""
+    from concept_service import _build_pair_text
+    out = _build_pair_text({
+        "message_text": "yes",
+        "context_before": "   \n  ",
+    })
+    assert out == "[Conversation start]\nStudent: yes"
+
+
+@patch("concept_service.client")
+def test_embed_messages_sends_pair_text_to_api(mock_client, session):
+    """The string passed to the embedding API must be the pair format, not the bare student text."""
+    mock_client.models.embed_content.side_effect = (
+        lambda **kwargs: _fake_embed_result(kwargs["contents"])
+    )
+
+    from concept_service import embed_messages
+
+    messages = [
+        {
+            "chatlog_id": 1,
+            "message_index": 0,
+            "message_text": "yes",
+            "context_before": "Did that solve it?",
+        },
+    ]
+    embed_messages(messages, session)
+
+    # The API was called once. Inspect the contents argument.
+    call = mock_client.models.embed_content.call_args
+    assert call is not None
+    contents = call.kwargs["contents"]
+    assert contents == ["Tutor: Did that solve it?\nStudent: yes"]
+
+
+@patch("concept_service.client")
+def test_embed_messages_uses_new_model_version_as_cache_key(mock_client, session):
+    """Cached MessageEmbedding rows must use the bumped model_version (not the raw API model)."""
+    mock_client.models.embed_content.side_effect = (
+        lambda **kwargs: _fake_embed_result(kwargs["contents"])
+    )
+
+    from concept_service import embed_messages, EMBED_MODEL
+
+    messages = [
+        {"chatlog_id": 1, "message_index": 0, "message_text": "hi", "context_before": "Hello."},
+    ]
+    embed_messages(messages, session)
+
+    cached = session.exec(select(MessageEmbedding)).all()
+    assert len(cached) == 1
+    assert cached[0].model_version == EMBED_MODEL
+    assert EMBED_MODEL == "gemini-embedding-001:pair-v1"
+
+
+@patch("concept_service.client")
+def test_embed_messages_does_not_reuse_old_key_cache(mock_client, session):
+    """A pre-existing row stored under the OLD model_version must NOT short-circuit the new flow."""
+    mock_client.models.embed_content.side_effect = (
+        lambda **kwargs: _fake_embed_result(kwargs["contents"])
+    )
+
+    # Pre-seed a stale-key row.
+    session.add(MessageEmbedding(
+        chatlog_id=1,
+        message_index=0,
+        embedding=np.zeros(3072, dtype=np.float32).tobytes(),
+        model_version="gemini-embedding-001",  # old key
+    ))
+    session.commit()
+
+    from concept_service import embed_messages, EMBED_MODEL
+
+    messages = [
+        {"chatlog_id": 1, "message_index": 0, "message_text": "hi", "context_before": "Hello."},
+    ]
+    embed_messages(messages, session)
+
+    # API was called (cache miss under new key).
+    assert mock_client.models.embed_content.called
+
+    # We now have two rows: the stale-key row (preserved) and a new-key row.
+    rows = session.exec(select(MessageEmbedding)).all()
+    versions = sorted(r.model_version for r in rows)
+    assert versions == ["gemini-embedding-001", EMBED_MODEL]
+
+
+def test_discovery_prompt_includes_tutor_context_when_present():
+    from concept_service import _build_discovery_prompt
+
+    samples_by_cluster = {
+        0: [
+            {
+                "message_text": "yes",
+                "context_before": "Did that solve it?",
+            },
+            {
+                "message_text": "?",
+                "context_before": "What would go in the blank to make this statement true?",
+            },
+        ],
+    }
+    prompt = _build_discovery_prompt(samples_by_cluster, existing_labels=[], rejected_names=[])
+
+    # When context is present, the prompt shows BOTH tutor and student turns.
+    assert "Tutor asked:" in prompt
+    assert "Student replied:" in prompt
+    assert "Did that solve it?" in prompt
+    assert "What would go in the blank to make this statement true?" in prompt
+
+
+def test_discovery_prompt_handles_missing_context():
+    from concept_service import _build_discovery_prompt
+
+    samples_by_cluster = {
+        0: [
+            {"message_text": "hello", "context_before": None},
+        ],
+    }
+    prompt = _build_discovery_prompt(samples_by_cluster, existing_labels=[], rejected_names=[])
+
+    # When no context, the prompt marks this as the start of the conversation.
+    assert "(start of conversation)" in prompt
+    assert "hello" in prompt
+    # The "Tutor asked:" prefix must NOT appear for this sample.
+    # (There may be other samples in other clusters that legitimately have it, but here there's just one sample.)
+    assert "Tutor asked:" not in prompt


### PR DESCRIPTION
## Summary

- Replace bare-student-text embeddings in `concept_service.py` with `Tutor: …\nStudent: …` pair text so meaning depends on the preceding tutor turn, not surface form. Falls back to `[Conversation start]\nStudent: …` when no prior tutor turn exists.
- Bump the cache key to `model_version = "gemini-embedding-001:pair-v1"` and split `EMBED_API_MODEL` (call signature) from `EMBED_MODEL` (cache key); old + new vectors are never mixed.
- `assist_service._build_cache` and `_embedding_fingerprint` filter by the current `EMBED_MODEL` so stale rows from the previous embedding scheme stay invisible.
- `_run_discover` passes `mc.context_before` (already on `MessageCache`) through to the embedding pipeline; `_build_discovery_prompt` shows Gemini the pair format when context is present.

No schema migration — `MessageCache.context_before` already exists.

## Test plan

- [x] `cd server/python && uv run pytest tests/test_concept_service.py tests/test_assist_service.py tests/test_assist_endpoint.py` (26 passed locally)
- [ ] After merge: spot-check that re-running concept induction produces semantically grouped clusters (e.g., bare \"yes\" answers cluster by the tutor question they're responding to)

## Plan / spec

- `docs/superpowers/plans/2026-05-15-context-aware-embeddings.md`
- `docs/superpowers/specs/2026-05-15-context-aware-embeddings-design.md`