### PR TITLE
Bundle decide/undo/skip with readiness; cache thread fetch; tidy

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -23,6 +23,21 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
+# 0) Free ports we're about to bind (kubectl 5432, uvicorn 8000, vite 5173)
+free_port() {
+  local port="$1"
+  local pids
+  pids=$(lsof -ti:"$port" 2>/dev/null || true)
+  if [[ -n "$pids" ]]; then
+    echo -e "\033[33m[dev     ]\033[0m Freeing port $port (killing: $(echo $pids | tr '\n' ' '))"
+    kill -9 $pids 2>/dev/null || true
+  fi
+}
+
+for port in 5432 8000 5173; do
+  free_port "$port"
+done
+
 # 1) kubectl port-forward (auto-reconnect on drop)
 (
   while true; do

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -36,7 +36,7 @@ from schemas import (
     RecalibrationItemResponse, SaveRecalibrationRequest, SaveRecalibrationResponse, RecalibrationStatsResponse,
     CreateSingleLabelRequest, QueueLabelRequest, DecideRequest,
     SkipConversationRequest, SkipConversationResponse,
-    SingleLabelResponse, FocusedMessageResponse, ReadinessResponse,
+    SingleLabelResponse, FocusedMessageResponse, ReadinessResponse, DecideResponse,
     SummaryResponse, SummaryPattern, HandoffResponse,
     ReviewItemResponse, ReviewRequest,
     CreateAssignmentRequest, AssignmentResponse, UnmappedCountResponse,
@@ -3357,7 +3357,17 @@ def get_assist(
     )
 
 
-@app.post("/api/single-labels/{label_id}/decide", response_model=Optional[FocusedMessageResponse])
+def _decide_response(
+    db: Session, label_id: int, assignment_id: Optional[int] = None
+) -> DecideResponse:
+    """Build the combined next-message + readiness payload for the /run hot path."""
+    payload = queue_service.next_message_for_label(db, label_id, assignment_id)
+    nxt = FocusedMessageResponse(**payload) if payload else None
+    readiness = ReadinessResponse(**decision_service.compute_readiness(db, label_id))
+    return DecideResponse(next=nxt, readiness=readiness)
+
+
+@app.post("/api/single-labels/{label_id}/decide", response_model=DecideResponse)
 def post_decide(
     label_id: int,
     req: DecideRequest,
@@ -3383,15 +3393,12 @@ def post_decide(
         message_index=req.message_index,
         value=req.value,
     )
-    payload = queue_service.next_message_for_label(db, label_id, assignment_id)
-    if not payload:
-        return None
-    return FocusedMessageResponse(**payload)
+    return _decide_response(db, label_id, assignment_id)
 
 
 @app.post(
     "/api/single-labels/{label_id}/skip-conversation",
-    response_model=Optional[FocusedMessageResponse],
+    response_model=DecideResponse,
 )
 def post_skip_conversation(
     label_id: int,
@@ -3401,7 +3408,7 @@ def post_skip_conversation(
     """Skip every still-undecided student message in `chatlog_id` for this label so
     the queue jumps to the next conversation. Already-decided messages are untouched.
     Returns the next focused message (next conversation in the per-label walk order)
-    or None when nothing remains."""
+    or None when nothing remains, plus refreshed readiness."""
     label = db.get(LabelDefinition, label_id)
     if not label:
         raise HTTPException(status_code=404, detail=f"No label with id={label_id}")
@@ -3411,22 +3418,20 @@ def post_skip_conversation(
             detail=f"Label {label_id} ({label.name!r}) is mode={label.mode!r}, not 'single'",
         )
     decision_service.skip_conversation(db, label_id, req.chatlog_id)
-    payload = queue_service.next_message_for_label(db, label_id)
-    if not payload:
-        return None
-    return FocusedMessageResponse(**payload)
+    return _decide_response(db, label_id)
 
 
-@app.post("/api/single-labels/{label_id}/undo", response_model=Optional[FocusedMessageResponse])
-def post_undo(label_id: int, db: Session = Depends(get_session)):
+@app.post("/api/single-labels/{label_id}/undo", response_model=DecideResponse)
+def post_undo(
+    label_id: int,
+    assignment_id: Optional[int] = None,
+    db: Session = Depends(get_session),
+):
     label = db.get(LabelDefinition, label_id)
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="Single-label not found")
     decision_service.undo_last_decision(db, label_id)
-    payload = queue_service.next_message_for_label(db, label_id)
-    if not payload:
-        return None
-    return FocusedMessageResponse(**payload)
+    return _decide_response(db, label_id, assignment_id)
 
 
 @app.get("/api/single-labels/{label_id}/readiness", response_model=ReadinessResponse)
@@ -4540,6 +4545,7 @@ def list_handoff_summaries(db: Session = Depends(get_session)):
     labels = db.exec(
         select(LabelDefinition)
         .where(LabelDefinition.mode == "single")
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
         .where(LabelDefinition.phase.in_(  # type: ignore[attr-defined]
             ["classifying", "handed_off", "reviewing", "complete", "failed"]
         ))

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -2,6 +2,8 @@
 that needs a decision for the active label."""
 import logging
 import hashlib
+import threading
+from collections import OrderedDict
 from typing import Optional
 
 from sqlalchemy import text as sql_text
@@ -11,6 +13,19 @@ from database import ext_engine
 from models import LabelApplication, MessageCache
 
 logger = logging.getLogger(__name__)
+
+# Conversation threads in `events` are immutable once ingested, so a per-process
+# cache keyed by chatlog_id removes redundant Postgres roundtrips during /run
+# (the instructor stays in one conversation across several decide clicks).
+_THREAD_CACHE_MAX = 512
+_thread_cache: "OrderedDict[int, list[dict]]" = OrderedDict()
+_thread_cache_lock = threading.Lock()
+
+
+def _clear_thread_cache() -> None:
+    """Test hook: drop all cached threads."""
+    with _thread_cache_lock:
+        _thread_cache.clear()
 
 
 def _shuffle_key(label_id: int, chatlog_id: int) -> int:
@@ -222,30 +237,46 @@ def _build_focus_payload(
 def _fetch_full_thread(chatlog_id: int) -> list[dict]:
     """Pull the entire conversation (every student question + tutor response) from
     the external Postgres events table, in chronological order. Each entry includes
-    a `student_index` for student turns so we can locate the focused message."""
+    a `student_index` for student turns so we can locate the focused message.
+
+    Cached per-process by chatlog_id. Empty results (Postgres unreachable, etc.)
+    are NOT cached so a transient failure doesn't poison the cache.
+    """
+    with _thread_cache_lock:
+        cached = _thread_cache.get(chatlog_id)
+        if cached is not None:
+            _thread_cache.move_to_end(chatlog_id)
+            return cached
+
+    result = _fetch_full_thread_uncached(chatlog_id)
+    if not result:
+        return result
+
+    with _thread_cache_lock:
+        _thread_cache[chatlog_id] = result
+        _thread_cache.move_to_end(chatlog_id)
+        while len(_thread_cache) > _THREAD_CACHE_MAX:
+            _thread_cache.popitem(last=False)
+    return result
+
+
+def _fetch_full_thread_uncached(chatlog_id: int) -> list[dict]:
+    # chatlog_id is the MIN(events.id) of its conversation by construction
+    # (see ingest paths in main.py). So resolving conversation_id is a single-row
+    # PK lookup — much cheaper than the old GROUP BY/HAVING scan, which was
+    # painful per-decide because /run hits this function on every cycle.
     sql = """
-    WITH conv AS (
-        SELECT id, event_type, payload, created_at
-        FROM events
-        WHERE event_type IN ('tutor_query', 'tutor_response')
-          AND payload->>'conversation_id' = (
-              SELECT payload->>'conversation_id'
-              FROM events
-              WHERE id = (
-                  SELECT MIN(id)
-                  FROM events
-                  WHERE event_type IN ('tutor_query','tutor_response')
-                    AND payload->>'conversation_id' IS NOT NULL
-                  GROUP BY payload->>'conversation_id'
-                  HAVING MIN(id) = :chatlog_id
-              )
-          )
-        ORDER BY id ASC
-    )
     SELECT event_type,
            payload->>'question' AS question,
            payload->>'response' AS response
-    FROM conv
+    FROM events
+    WHERE event_type IN ('tutor_query', 'tutor_response')
+      AND payload->>'conversation_id' = (
+          SELECT payload->>'conversation_id'
+          FROM events
+          WHERE id = :chatlog_id
+      )
+    ORDER BY id ASC
     """
     try:
         with ext_engine.connect() as conn:

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -295,6 +295,14 @@ class ReadinessResponse(BaseModel):
     hint: Optional[str]
 
 
+class DecideResponse(BaseModel):
+    """Combined response for decide/undo/skip-conversation: the next focused
+    message (or None if nothing left) plus refreshed readiness. Bundling these
+    saves the /run UI a separate getReadiness round-trip per cycle."""
+    next: Optional[FocusedMessageResponse]
+    readiness: ReadinessResponse
+
+
 class SummaryPattern(BaseModel):
     excerpt: str
     frequency: str  # "common" | "moderate" | "rare"

--- a/server/python/tests/test_handoff_flow.py
+++ b/server/python/tests/test_handoff_flow.py
@@ -370,6 +370,28 @@ def test_classifying_label_appears_in_summaries(client, session):
     assert any(item["label_name"] == "help" and item["phase"] == "classifying" for item in items)
 
 
+def test_archived_label_excluded_from_summaries(client, session):
+    """Regression: DELETE /api/single-labels/{id} soft-archives the label by
+    setting `archived_at`. /api/handoff-summaries must filter those out so the
+    UI's LabelRail reflects the deletion."""
+    _seed(session)
+    a = client.post("/api/single-labels", json={"name": "test"}).json()
+    client.post(f"/api/single-labels/{a['id']}/activate")
+    client.post(f"/api/single-labels/{a['id']}/handoff")
+
+    # Sanity: appears before delete.
+    pre = client.get("/api/handoff-summaries").json()
+    assert any(it["label_name"] == "test" for it in pre)
+
+    r = client.delete(f"/api/single-labels/{a['id']}")
+    assert r.status_code == 200
+
+    post = client.get("/api/handoff-summaries").json()
+    assert not any(it["label_name"] == "test" for it in post), (
+        "archived label leaked into /api/handoff-summaries"
+    )
+
+
 def test_two_sequential_handoffs_both_appear_in_summaries(client, session):
     """Regression: hand off two different active labels back-to-back. Both should
     appear on /api/handoff-summaries — not silently disappear."""

--- a/server/python/tests/test_single_label_routes.py
+++ b/server/python/tests/test_single_label_routes.py
@@ -248,8 +248,9 @@ def test_skip_conversation_endpoint_jumps_to_next_conversation(client, session):
     )
     assert r.status_code == 200
     body = r.json()
-    assert body is not None
-    assert body["chatlog_id"] != starting_cid
+    assert body["next"] is not None
+    assert body["next"]["chatlog_id"] != starting_cid
+    assert "readiness" in body
 
     # The skipped conversation now has 3 skip rows for the active label
     skips = session.exec(
@@ -260,6 +261,40 @@ def test_skip_conversation_endpoint_jumps_to_next_conversation(client, session):
     ).all()
     assert len(skips) == 3
     assert all(r.value == "skip" for r in skips)
+
+
+def test_fetch_full_thread_cache_hits_avoid_second_call(monkeypatch):
+    """Second call for the same chatlog_id should reuse cache without re-invoking the uncached fetcher."""
+    queue_service._clear_thread_cache()
+    calls: list[int] = []
+
+    def fake(chatlog_id):
+        calls.append(chatlog_id)
+        return [{"message_index": 0, "role": "student", "text": "hi", "student_index": 0}]
+
+    monkeypatch.setattr(queue_service, "_fetch_full_thread_uncached", fake)
+    a = queue_service._fetch_full_thread(7777)
+    b = queue_service._fetch_full_thread(7777)
+    assert calls == [7777]
+    assert a is b
+
+
+def test_fetch_full_thread_empty_result_is_not_cached(monkeypatch):
+    """A transient empty result must not poison the cache."""
+    queue_service._clear_thread_cache()
+    results = [[], [{"message_index": 0, "role": "student", "text": "ok", "student_index": 0}]]
+    calls: list[int] = []
+
+    def fake(chatlog_id):
+        calls.append(chatlog_id)
+        return results.pop(0)
+
+    monkeypatch.setattr(queue_service, "_fetch_full_thread_uncached", fake)
+    first = queue_service._fetch_full_thread(8888)
+    second = queue_service._fetch_full_thread(8888)
+    assert first == []
+    assert second and second[0]["text"] == "ok"
+    assert calls == [8888, 8888]
 
 
 def test_next_focused_fallback_includes_tutor_from_cache(client, session, monkeypatch):

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,7 +6,7 @@ import type {
   ConceptCandidate, EmbedStatus, ConversationMessage, AnalysisSummary, TemporalAnalysis,
   LabelExample, SplitAutoLabelRequest, ApplyBatchRequest, ConciseResponse,
   RecalibrationItem, RecalibrationStats, SaveRecalibrationRequest, SaveRecalibrationResponse,
-  SingleLabel, FocusedMessage, ReadinessState, DecisionValue,
+  SingleLabel, FocusedMessage, ReadinessState, DecideResult, DecisionValue,
   SingleLabelSummary, HandoffResponse, ReviewItem,
   AssignmentMapping, UnmappedCount, InferAssignmentsResult, HandoffSummaryItem,
   AssistResponse,
@@ -317,20 +317,25 @@ export const api = {
     id: number,
     body: { chatlog_id: number; message_index: number; value: DecisionValue },
     assignmentId?: number,
-  ): Promise<FocusedMessage | null> =>
-    USE_MOCK ? Promise.resolve(mockFocusedMessage)
-             : req(
-                 `/api/single-labels/${id}/decide${assignmentId ? `?assignment_id=${assignmentId}` : ''}`,
-                 { method: 'POST', ...json(body) }
-               ),
-
-  undoLastDecision: (id: number): Promise<FocusedMessage | null> =>
-    USE_MOCK ? Promise.resolve(mockFocusedMessage)
-             : req(`/api/single-labels/${id}/undo`, { method: 'POST' }),
-
-  skipConversation: (id: number, chatlogId: number): Promise<FocusedMessage | null> =>
+  ): Promise<DecideResult> =>
     USE_MOCK
-      ? Promise.resolve(mockFocusedMessage)
+      ? Promise.resolve({ next: mockFocusedMessage, readiness: mockReadiness })
+      : req(
+          `/api/single-labels/${id}/decide${assignmentId ? `?assignment_id=${assignmentId}` : ''}`,
+          { method: 'POST', ...json(body) }
+        ),
+
+  undoLastDecision: (id: number, assignmentId?: number): Promise<DecideResult> =>
+    USE_MOCK
+      ? Promise.resolve({ next: mockFocusedMessage, readiness: mockReadiness })
+      : req(
+          `/api/single-labels/${id}/undo${assignmentId ? `?assignment_id=${assignmentId}` : ''}`,
+          { method: 'POST' }
+        ),
+
+  skipConversation: (id: number, chatlogId: number): Promise<DecideResult> =>
+    USE_MOCK
+      ? Promise.resolve({ next: mockFocusedMessage, readiness: mockReadiness })
       : req(`/api/single-labels/${id}/skip-conversation`, {
           method: 'POST',
           ...json({ chatlog_id: chatlogId }),
@@ -549,7 +554,7 @@ export const api = {
     })
              : req(
                  `/api/single-labels/${id}/applications/${chatlog_id}?message_index=${message_index}`,
-                 { method: 'PATCH', body: JSON.stringify({ verdict }) },
+                 { method: 'PATCH', ...json({ verdict }) },
                ),
 
   upsertSingleLabelNote: (
@@ -561,7 +566,7 @@ export const api = {
     USE_MOCK ? Promise.resolve({ ok: true as const })
              : req(
                  `/api/single-labels/${id}/applications/${chatlog_id}/note?message_index=${message_index}`,
-                 { method: 'PUT', body: JSON.stringify({ text }) },
+                 { method: 'PUT', ...json({ text }) },
                ),
 
   patchSingleLabel: (
@@ -574,7 +579,7 @@ export const api = {
       review_threshold: patch.review_threshold ?? 0.75, agreement_vs_gold: null,
       confidence_histogram: [],
     })
-             : req(`/api/single-labels/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
+             : req(`/api/single-labels/${id}`, { method: 'PATCH', ...json(patch) }),
 
   // ─── Handoff summaries ───
   listHandoffSummaries: (): Promise<HandoffSummaryItem[]> =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -298,6 +298,13 @@ export interface ReadinessState {
   hint: string | null
 }
 
+/** Combined response from decide/undo/skip-conversation: avoids a separate
+ *  getReadiness round-trip per cycle. */
+export interface DecideResult {
+  next: FocusedMessage | null
+  readiness: ReadinessState
+}
+
 export interface SummaryPattern {
   excerpt: string
   frequency: string


### PR DESCRIPTION
> Stacked on **#47** (summaries-revamp-phase-1). Review after that merges, or set base to \`main\` once merged.

## Summary

Three orthogonal improvements to the \`/run\` hot path, plus a tiny dev-loop ergonomics fix and one summaries regression fix.

**API — decide/undo/skip-conversation bundle next + readiness.** New \`DecideResponse { next, readiness }\` payload (replaces \`Optional[FocusedMessageResponse]\` on three endpoints). The \`/run\` UI no longer round-trips \`getReadiness\` per cycle. \`undo\` now accepts \`assignment_id\` so assignment-scoped runs stay scoped after an undo. Frontend (\`api.ts\` + \`DecideResult\` type) wired through.

**queue_service — cache _fetch_full_thread.** Per-process LRU (cap 512) keyed by \`chatlog_id\`. \`events\` rows are immutable post-ingest and the instructor stays in one conversation across several decide clicks, so this kills redundant Postgres roundtrips. Empty results are NOT cached so a transient Postgres failure doesn't poison the cache. Also drops the GROUP BY/HAVING subquery in the SQL — \`chatlog_id\` is \`MIN(events.id)\` by construction, so resolving conversation_id is now a single-row PK lookup.

**list_handoff_summaries — filter archived.** \`DELETE /api/single-labels/{id}\` soft-archives by setting \`archived_at\`; the handoff-summaries query was leaking archived labels into the \`LabelRail\`. Regression test added.

**bin/dev — free ports 5432/8000/5173 at startup.** Stale processes from a previous session no longer silently keep the new dev server from binding.

## Test plan

- [x] \`cd server/python && uv run pytest tests/test_handoff_flow.py tests/test_single_label_routes.py\` (50 passed)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: \`/run\` round-trip a decide, then an undo, then a skip-conversation; readiness updates without a separate fetch in network panel
- [ ] Manual: delete a handed-off single-label, confirm it disappears from the LabelRail on \`/summaries\`