### PR TITLE
Hybrid explore sampling and fix /run thread order

### DIFF
--- a/server/python/database.py
+++ b/server/python/database.py
@@ -91,6 +91,8 @@ def _migrate_label_definition(conn, inspect, text):
         conn.execute(text(
             "ALTER TABLE labeldefinition ADD COLUMN review_threshold FLOAT NOT NULL DEFAULT 0.7"
         ))
+    if "hybrid_explore_fraction" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN hybrid_explore_fraction FLOAT"))
 
 
 def _migrate_label_application(conn, inspect, text):
@@ -150,6 +152,17 @@ def _cleanup_polluted_multi_label_rows(conn, text):
         print(f"[chatsight] cleanup: removed {n} stale value-bearing rows from multi-mode labels")
 
 
+def _migrate_conversation_cursor(conn, inspect, text):
+    cols = [c["name"] for c in inspect(conn).get_columns("conversationcursor")]
+    if "last_message_index" not in cols:
+        conn.execute(
+            text(
+                "ALTER TABLE conversationcursor "
+                "ADD COLUMN last_message_index INTEGER NOT NULL DEFAULT 0"
+            )
+        )
+
+
 def create_db_and_tables():
     SQLModel.metadata.create_all(engine)
     with engine.connect() as conn:
@@ -158,6 +171,7 @@ def create_db_and_tables():
         _migrate_label_application(conn, inspect, text)
         _migrate_labeling_session(conn, inspect, text)
         _migrate_message_cache(conn, inspect, text)
+        _migrate_conversation_cursor(conn, inspect, text)
         _cleanup_polluted_multi_label_rows(conn, text)
         # Indexes
         conn.execute(text(

--- a/server/python/decision_service.py
+++ b/server/python/decision_service.py
@@ -86,6 +86,7 @@ def record_decision(
             ConversationCursor(
                 label_id=label_id,
                 chatlog_id=chatlog_id,
+                last_message_index=message_index,
                 last_message_index_decided=message_index,
             )
         )
@@ -225,6 +226,7 @@ def skip_conversation(session: Session, label_id: int, chatlog_id: int) -> int:
             session.add(ConversationCursor(
                 label_id=label_id,
                 chatlog_id=chatlog_id,
+                last_message_index=last_idx,
                 last_message_index_decided=last_idx,
             ))
     session.commit()

--- a/server/python/explore_service.py
+++ b/server/python/explore_service.py
@@ -1,0 +1,820 @@
+"""Explore sampling: student-message-centric novelty for hybrid queue.
+
+Prioritizes rare, specific student help requests over long threads of generic
+\"help\" / \"question 1.2\" spam and over copy-pasted assignment prompts, errors,
+or code dumps (long but not distinctive). Tutor turns are excluded from
+conversation similarity; embeddings compare student messages only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from collections import Counter
+from datetime import datetime
+from typing import Any, Optional
+
+import numpy as np
+from google import genai
+from google.genai import types
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+import assist_service
+import binary_autolabel_service
+from concept_service import EMBED_API_MODEL, EMBED_MODEL
+from database import engine
+from models import (
+    ConversationProfile,
+    LabelApplication,
+    LabelDefinition,
+    LabelExploreGradebook,
+    MessageCache,
+    MessageEmbedding,
+)
+
+logger = logging.getLogger(__name__)
+
+_client: genai.Client | None = None
+_warm_lock = threading.Lock()
+
+
+def _gemini_available() -> bool:
+    return bool(os.environ.get("GEMINI_API_KEY", "").strip())
+
+
+def _client_get() -> genai.Client:
+    global _client
+    if _client is None:
+        _client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    return _client
+
+
+def _normalize(vec: np.ndarray) -> Optional[np.ndarray]:
+    n = float(np.linalg.norm(vec))
+    if n <= 0.0:
+        return None
+    return (vec / n).astype(np.float32)
+
+
+def _cosine(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.clip(np.dot(a, b), -1.0, 1.0))
+
+
+def human_label_count(session: Session, label_id: int) -> int:
+    return int(
+        session.exec(
+            select(func.count())
+            .select_from(LabelApplication)
+            .where(
+                LabelApplication.label_id == label_id,
+                LabelApplication.applied_by == "human",
+                LabelApplication.value.in_(["yes", "no"]),  # noqa: comparator
+            )
+        ).one()
+    )
+
+
+def labeled_chatlog_ids(session: Session, label_id: int) -> set[int]:
+    rows = session.exec(
+        select(LabelApplication.chatlog_id)
+        .where(
+            LabelApplication.label_id == label_id,
+            LabelApplication.applied_by == "human",
+            LabelApplication.value.in_(["yes", "no"]),  # noqa: comparator
+        )
+        .distinct()
+    ).all()
+    return set(rows)
+
+
+_GENERIC_HELP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*help\s*[!?.]*\s*$", re.I),
+    re.compile(r"^\s*(can you )?help( me)?( with this)?\s*[!?.]*\s*$", re.I),
+    re.compile(r"^\s*i\s*['']?m\s+stuck\s*[!?.]*\s*$", re.I),
+    re.compile(r"^\s*i\s+don\s*['']?t\s+get\s+it\s*[!?.]*\s*$", re.I),
+    re.compile(
+        r"^\s*(question|q|problem|part|exercise)\s*[#:]?\s*[\d.]+\s*[!?.]*\s*$",
+        re.I,
+    ),
+    re.compile(r"^\s*what\s+do\s+i\s+do\s*[!?.]*\s*$", re.I),
+    re.compile(r"^\s*how\s+do\s+i\s+(do|solve)\s+(this|it)\s*[!?.]*\s*$", re.I),
+)
+
+_SPECIFIC_SIGNALS: tuple[str, ...] = (
+    "example",
+    "groupby",
+    "merge",
+    "why does",
+    "why is",
+    "how do i use",
+    "in the context of",
+    "this line",
+    "my code",
+    "dataframe",
+    "plot",
+    "function",
+)
+
+# Homework prompts / specs students paste wholesale (not original questions).
+_PASTE_BODY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"traceback \(most recent call last\)", re.I),
+    re.compile(r"```"),
+    re.compile(r"^\s*\d+[\.)]\s+\S", re.M),
+    re.compile(
+        r"\b(write a function|using the (following )?dataset|you should submit|"
+        r"your task is to|complete the following|fill in the blank)\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(read the (following )?prompt|answer the questions below|"
+        r"show your work for)\b",
+        re.I,
+    ),
+)
+
+_PASTE_HEADER_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"^\s*(question|problem|part|exercise|lab|homework|hw)\s*[#:.]?\s*[\w\d.]",
+        re.I | re.M,
+    ),
+)
+
+
+def _first_person_density(text: str) -> float:
+    """Share of words that look like the student speaking in their own voice."""
+    words = re.findall(r"[a-zA-Z']+", text.lower())
+    if not words:
+        return 0.0
+    first_person = sum(
+        1 for w in words if w in ("i", "i'm", "im", "my", "me", "we", "our", "i've", "i'd")
+    )
+    return first_person / len(words)
+
+
+def student_message_copy_paste_likelihood(text: str) -> float:
+    """Likelihood the student message is pasted spec/code/error, not an original ask."""
+    t = (text or "").strip()
+    if not t:
+        return 0.0
+    score = 0.0
+    lower = t.lower()
+    n = len(t)
+
+    for pat in _PASTE_BODY_PATTERNS:
+        if pat.search(t):
+            score = max(score, 0.75)
+
+    for pat in _PASTE_HEADER_PATTERNS:
+        if pat.search(t):
+            score = max(score, 0.7)
+
+    # Long blocks with almost no student voice → pasted instructions.
+    if n >= 180:
+        fp = _first_person_density(t)
+        if fp < 0.012:
+            score = max(score, 0.88)
+        elif fp < 0.025 and n >= 350:
+            score = max(score, 0.8)
+        elif n >= 600 and fp < 0.04:
+            score = max(score, 0.75)
+
+    # Many lines / bullets like an assignment handout.
+    lines = [ln.strip() for ln in t.splitlines() if ln.strip()]
+    if n >= 250 and len(lines) >= 6:
+        numbered = sum(1 for ln in lines if re.match(r"^\d+[\.)]\s", ln))
+        if numbered >= 3 or len(lines) >= 10:
+            score = max(score, 0.72)
+
+    # Repeated identical lines (paste spam within one message).
+    if len(lines) >= 3:
+        top = Counter(lines).most_common(1)[0][1]
+        if top >= 3:
+            score = max(score, 0.65)
+
+    # Error dumps without a short student question wrapped around them.
+    if "traceback" in lower and n > 200 and _first_person_density(t) < 0.02:
+        score = max(score, 0.9)
+
+    return min(1.0, score)
+
+
+def student_help_genericness(text: str) -> float:
+    """How generic / repetitive a student help message is, in [0, 1]."""
+    t = (text or "").strip()
+    if not t:
+        return 1.0
+    paste = student_message_copy_paste_likelihood(t)
+    if paste >= 0.7:
+        return max(0.88, paste)
+
+    if len(t) <= 12:
+        return 0.92
+    for pat in _GENERIC_HELP_PATTERNS:
+        if pat.match(t):
+            return 0.9
+    lower = t.lower()
+    if len(t) < 35 and t.count("?") == 0 and not any(s in lower for s in _SPECIFIC_SIGNALS):
+        return max(0.72, paste)
+    if any(s in lower for s in _SPECIFIC_SIGNALS):
+        base = max(0.0, 0.35 - len(t) / 1200.0)
+        return max(base, paste * 0.85)
+    # Longer original questions — don't treat length alone as specific.
+    base = max(0.0, min(1.0, 0.65 - len(t) / 500.0))
+    return max(base, paste * 0.9)
+
+
+def student_help_specificity(
+    text: str,
+    *,
+    corpus_rarity: Optional[float] = None,
+) -> float:
+    """Specific, original student ask — down-ranks paste and corpus-common long text."""
+    t = (text or "").strip()
+    generic = student_help_genericness(t)
+    paste = student_message_copy_paste_likelihood(t)
+    spec = (1.0 - generic) * (1.0 - paste)
+    # Same long text pasted by many students → common in embeddings, not novel.
+    if corpus_rarity is not None and len(t) >= 120 and corpus_rarity < 0.3:
+        spec *= max(0.15, corpus_rarity / 0.3)
+    return max(0.0, min(1.0, spec))
+
+
+def conversation_centroid(session: Session, chatlog_id: int) -> Optional[np.ndarray]:
+    """Unit-normalized mean of **student** message embeddings in a conversation."""
+    rows = session.exec(
+        select(MessageEmbedding.embedding)
+        .join(
+            MessageCache,
+            (MessageCache.chatlog_id == MessageEmbedding.chatlog_id)
+            & (MessageCache.message_index == MessageEmbedding.message_index),
+        )
+        .where(
+            MessageEmbedding.chatlog_id == chatlog_id,
+            MessageEmbedding.model_version == EMBED_MODEL,
+        )
+    ).all()
+    if not rows:
+        return None
+    vecs = []
+    for row in rows:
+        emb_bytes = row[0] if isinstance(row, (tuple, list)) else row
+        v = _normalize(np.frombuffer(emb_bytes, dtype=np.float32))
+        if v is not None:
+            vecs.append(v)
+    if not vecs:
+        return None
+    mean = np.mean(np.stack(vecs), axis=0)
+    return _normalize(mean)
+
+
+def conversation_spam_penalty(student_texts: list[str]) -> float:
+    """Penalize generic pings and copy-paste spam threads, in [0, 1]."""
+    if not student_texts:
+        return 0.0
+    paste = [student_message_copy_paste_likelihood(t) for t in student_texts]
+    avg_paste = sum(paste) / len(paste)
+    if avg_paste >= 0.75 and len(student_texts) >= 1:
+        return min(1.0, 0.5 + 0.15 * len(student_texts))
+    if len(student_texts) < 2:
+        return 0.0
+    generic = [student_help_genericness(t) for t in student_texts]
+    avg = sum(generic) / len(generic)
+    if avg < 0.6:
+        return max(0.0, avg_paste - 0.4)
+    # Many short generic messages in one chat (e.g. repeated "help").
+    if len(student_texts) >= 3 and avg >= 0.75:
+        return min(1.0, 0.45 + 0.12 * (len(student_texts) - 2))
+    if len(student_texts) >= 2 and avg >= 0.85:
+        return 0.55
+    return max(0.0, avg - 0.5, avg_paste - 0.35)
+
+
+def _corpus_rarity_max_refs() -> int:
+    try:
+        return max(50, int(os.environ.get("CHATSIGHT_CORPUS_RARITY_MAX_REFS", "512")))
+    except (TypeError, ValueError):
+        return 512
+
+
+def student_message_corpus_rarity(
+    session: Session, chatlog_id: int, message_index: int
+) -> Optional[float]:
+    """1 − max cosine sim of this student message to a subsample of the corpus."""
+    cache = assist_service._get_cache(session)
+    matrix = cache.get("matrix")
+    keys_idx = cache.get("keys_idx") or {}
+    if matrix is None:
+        return None
+    idx = keys_idx.get((chatlog_id, message_index))
+    if idx is None:
+        return None
+    focused = matrix[idx]
+    n = matrix.shape[0]
+    max_refs = min(n, _corpus_rarity_max_refs())
+    if n <= max_refs:
+        sims = matrix @ focused
+        sims = sims.copy()
+        sims[idx] = -1.0
+        max_sim = float(np.max(sims))
+    else:
+        # Deterministic subsample — fast on large corpora (avoids blocking /next).
+        seed = (chatlog_id * 1_000_003) ^ (message_index * 9176) ^ n
+        rng = np.random.default_rng(seed & 0xFFFFFFFF)
+        sample_idx = rng.choice(n, size=max_refs, replace=False)
+        sample_idx = sample_idx[sample_idx != idx]
+        if sample_idx.size == 0:
+            return None
+        max_sim = float(np.max(matrix[sample_idx] @ focused))
+    if max_sim < 0.0:
+        return None
+    return 1.0 - max(0.0, min(1.0, max_sim))
+
+
+def explore_candidate_priority(
+    session: Session,
+    chatlog_id: int,
+    pending_text: str,
+    pending_index: int,
+    student_texts: list[str],
+    *,
+    use_corpus_rarity: bool = False,
+) -> float:
+    """Rank explore shortlist: specific student help, not raw length (fast by default)."""
+    rarity: Optional[float] = None
+    if use_corpus_rarity:
+        rarity = student_message_corpus_rarity(session, chatlog_id, pending_index)
+    spec = student_help_specificity(pending_text, corpus_rarity=rarity)
+    if rarity is None:
+        rarity = spec
+    spam = conversation_spam_penalty(student_texts)
+    return (0.45 * spec + 0.55 * rarity) * (1.0 - spam)
+
+
+def explore_score_pool_cap() -> int:
+    try:
+        return max(10, int(os.environ.get("CHATSIGHT_EXPLORE_SCORE_POOL_CAP", "60")))
+    except (TypeError, ValueError):
+        return 60
+
+
+def labeled_student_centroids(
+    session: Session, label_id: int
+) -> dict[int, np.ndarray]:
+    """Student-message centroids for each conversation with a human label."""
+    out: dict[int, np.ndarray] = {}
+    for cid in labeled_chatlog_ids(session, label_id):
+        cent = conversation_centroid(session, cid)
+        if cent is not None:
+            out[cid] = cent
+    return out
+
+
+def conversation_novelty(
+    session: Session,
+    label_id: int,
+    chatlog_id: int,
+    labeled_centroids: Optional[dict[int, np.ndarray]] = None,
+) -> Optional[float]:
+    """1 − max cosine similarity to student centroids of other labeled conversations."""
+    cand = conversation_centroid(session, chatlog_id)
+    if cand is None:
+        return None
+    if labeled_centroids is None:
+        labeled_centroids = labeled_student_centroids(session, label_id)
+    max_sim = 0.0
+    found = False
+    for cid, cent in labeled_centroids.items():
+        if cid == chatlog_id:
+            continue
+        found = True
+        max_sim = max(max_sim, _cosine(cand, cent))
+    if not found:
+        return None
+    return 1.0 - max_sim
+
+
+def _profile_vector(profile: ConversationProfile) -> Optional[np.ndarray]:
+    return _normalize(np.frombuffer(profile.summary_embedding, dtype=np.float32))
+
+
+def labeled_theme_vectors(
+    session: Session, label_id: int
+) -> dict[int, np.ndarray]:
+    """Cached summary embeddings for labeled conversations (one query)."""
+    labeled = labeled_chatlog_ids(session, label_id)
+    if not labeled:
+        return {}
+    rows = session.exec(
+        select(ConversationProfile).where(
+            ConversationProfile.label_id == label_id,
+            ConversationProfile.chatlog_id.in_(labeled),  # noqa: comparator
+        )
+    ).all()
+    out: dict[int, np.ndarray] = {}
+    for prof in rows:
+        vec = _profile_vector(prof)
+        if vec is not None:
+            out[prof.chatlog_id] = vec
+    return out
+
+
+def theme_novelty(
+    session: Session,
+    label_id: int,
+    chatlog_id: int,
+    labeled_vectors: Optional[dict[int, np.ndarray]] = None,
+) -> Optional[float]:
+    """1 − max similarity of this chat's summary to labeled conversation summaries."""
+    if labeled_vectors is None:
+        labeled_vectors = labeled_theme_vectors(session, label_id)
+    vec = labeled_vectors.get(chatlog_id)
+    if vec is None:
+        prof = session.get(ConversationProfile, (label_id, chatlog_id))
+        if prof is None:
+            return None
+        vec = _profile_vector(prof)
+        if vec is None:
+            return None
+    max_sim = 0.0
+    found = False
+    for cid, ovec in labeled_vectors.items():
+        if cid == chatlog_id:
+            continue
+        found = True
+        max_sim = max(max_sim, _cosine(vec, ovec))
+    if not found:
+        return None
+    return 1.0 - max_sim
+
+
+def get_gradebook(session: Session, label_id: int) -> Optional[dict[str, Any]]:
+    row = session.get(LabelExploreGradebook, label_id)
+    if not row:
+        return None
+    try:
+        return json.loads(row.gradebook_json)
+    except json.JSONDecodeError:
+        return None
+
+
+def ensure_gradebook(session: Session, label_id: int) -> Optional[dict[str, Any]]:
+    """Build or refresh label gradebook from human yes/no samples (Layer B)."""
+    if not _gemini_available():
+        return get_gradebook(session, label_id)
+
+    count = human_label_count(session, label_id)
+    if count < 3:
+        return get_gradebook(session, label_id)
+
+    existing = session.get(LabelExploreGradebook, label_id)
+    if existing and (count - existing.human_label_count) < 5:
+        return json.loads(existing.gradebook_json)
+
+    label = session.get(LabelDefinition, label_id)
+    if not label:
+        return None
+
+    yes_texts: list[str] = []
+    no_texts: list[str] = []
+    apps = session.exec(
+        select(
+            LabelApplication.value,
+            MessageCache.message_text,
+        )
+        .join(
+            MessageCache,
+            (MessageCache.chatlog_id == LabelApplication.chatlog_id)
+            & (MessageCache.message_index == LabelApplication.message_index),
+        )
+        .where(
+            LabelApplication.label_id == label_id,
+            LabelApplication.applied_by == "human",
+            LabelApplication.value.in_(["yes", "no"]),  # noqa: comparator
+        )
+    ).all()
+    for value, text in apps:
+        if value == "yes":
+            yes_texts.append(text)
+        elif value == "no":
+            no_texts.append(text)
+
+    try:
+        patterns = binary_autolabel_service.summarize_batch(
+            label.name,
+            label.description,
+            yes_texts,
+            no_texts,
+        )
+    except Exception as exc:
+        logger.warning("gradebook summarize_batch failed label_id=%s: %s", label_id, exc)
+        return get_gradebook(session, label_id)
+
+    gb = {
+        "included": patterns.get("included", []),
+        "excluded": patterns.get("excluded", []),
+    }
+    now = datetime.utcnow()
+    if existing:
+        existing.gradebook_json = json.dumps(gb)
+        existing.human_label_count = count
+        existing.updated_at = now
+        session.add(existing)
+    else:
+        session.add(
+            LabelExploreGradebook(
+                label_id=label_id,
+                gradebook_json=json.dumps(gb),
+                human_label_count=count,
+                updated_at=now,
+            )
+        )
+    session.commit()
+    return gb
+
+
+_SUMMARY_TOOL = types.Tool(
+    function_declarations=[
+        types.FunctionDeclaration(
+            name="summarize_conversation",
+            description="One-line theme summary for a student-AI tutoring conversation.",
+            parameters=types.Schema(
+                type=types.Type.OBJECT,
+                properties={
+                    "one_liner": types.Schema(
+                        type=types.Type.STRING,
+                        description="Single sentence: what this conversation is mainly about.",
+                    ),
+                    "theme_tags": types.Schema(
+                        type=types.Type.ARRAY,
+                        items=types.Schema(type=types.Type.STRING),
+                        description="3-5 short theme tags.",
+                    ),
+                },
+                required=["one_liner", "theme_tags"],
+            ),
+        )
+    ]
+)
+
+_SUMMARY_CONFIG = types.GenerateContentConfig(
+    system_instruction=(
+        "Summarize ONLY what the student is asking for in their own words — "
+        "ignore how the AI tutor responded. Do NOT treat copy-pasted homework "
+        "prompts, lab instructions, long error tracebacks, or code blocks as "
+        "distinctive themes; flag those as pasted content if they dominate. "
+        "Distinguish generic pings (\"help\", \"question 1.2\") from specific "
+        "original help requests (e.g. wanting an example of groupby in context). "
+        "Keep one_liner under 200 characters; theme_tags are 2-4 words each."
+    ),
+    temperature=0.2,
+    tools=[_SUMMARY_TOOL],
+    tool_config=types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["summarize_conversation"],
+        )
+    ),
+)
+
+
+def _summarize_conversation_gemini(
+    label_name: str,
+    label_description: Optional[str],
+    notebook: Optional[str],
+    student_texts: list[str],
+    gradebook: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    parts = [f"Label: {label_name}"]
+    if label_description:
+        parts.append(f"Description: {label_description}")
+    if notebook:
+        parts.append(f"Notebook: {notebook}")
+    if gradebook:
+        inc = gradebook.get("included") or []
+        exc = gradebook.get("excluded") or []
+        if inc:
+            parts.append("Themes already labeled YES (patterns): " + ", ".join(str(x) for x in inc[:8]))
+        if exc:
+            parts.append("Themes already labeled NO (patterns): " + ", ".join(str(x) for x in exc[:8]))
+    parts.append("\nStudent messages (in order):")
+    for i, t in enumerate(student_texts[:12]):
+        parts.append(f"{i + 1}. {t[:500]}")
+    response = _client_get().models.generate_content(
+        model="gemini-2.0-flash",
+        contents="\n".join(parts),
+        config=_SUMMARY_CONFIG,
+    )
+    for part in response.candidates[0].content.parts:
+        if part.function_call and part.function_call.name == "summarize_conversation":
+            args = part.function_call.args or {}
+            return {
+                "one_liner": str(args.get("one_liner", "")).strip(),
+                "theme_tags": list(args.get("theme_tags", [])),
+            }
+    return {"one_liner": "", "theme_tags": []}
+
+
+def _embed_summary_text(text: str) -> Optional[np.ndarray]:
+    if not text.strip():
+        return None
+    try:
+        result = _client_get().models.embed_content(
+            model=EMBED_API_MODEL,
+            contents=[text],
+        )
+        vec = np.array(result.embeddings[0].values, dtype=np.float32)
+        return _normalize(vec)
+    except Exception as exc:
+        logger.warning("summary embed failed: %s", exc)
+        return None
+
+
+def ensure_conversation_profile(
+    session: Session,
+    label_id: int,
+    chatlog_id: int,
+    student_texts: list[str],
+    notebook: Optional[str],
+) -> Optional[ConversationProfile]:
+    """Create or refresh cached conversation summary + embedding (Layer B)."""
+    if not _gemini_available() or not student_texts:
+        return session.get(ConversationProfile, (label_id, chatlog_id))
+
+    count = human_label_count(session, label_id)
+    existing = session.get(ConversationProfile, (label_id, chatlog_id))
+    if existing and (count - existing.human_label_count_at_build) < 5:
+        return existing
+
+    label = session.get(LabelDefinition, label_id)
+    if not label:
+        return existing
+
+    gradebook = ensure_gradebook(session, label_id)
+    try:
+        summary = _summarize_conversation_gemini(
+            label.name,
+            label.description,
+            notebook,
+            student_texts,
+            gradebook,
+        )
+    except Exception as exc:
+        logger.warning(
+            "conversation summarize failed label=%s chat=%s: %s",
+            label_id,
+            chatlog_id,
+            exc,
+        )
+        return existing
+
+    one_liner = summary.get("one_liner") or ""
+    if not one_liner:
+        return existing
+    # Embed student-help theme only (not tutor context).
+    student_blurb = "Student help: " + one_liner
+    vec = _embed_summary_text(student_blurb)
+    if vec is None:
+        return existing
+
+    now = datetime.utcnow()
+    tags_json = json.dumps(summary.get("theme_tags", []))
+    if existing:
+        existing.one_liner = one_liner
+        existing.theme_tags_json = tags_json
+        existing.summary_embedding = vec.tobytes()
+        existing.human_label_count_at_build = count
+        existing.updated_at = now
+        session.add(existing)
+    else:
+        existing = ConversationProfile(
+            label_id=label_id,
+            chatlog_id=chatlog_id,
+            one_liner=one_liner,
+            theme_tags_json=tags_json,
+            summary_embedding=vec.tobytes(),
+            human_label_count_at_build=count,
+            updated_at=now,
+        )
+        session.add(existing)
+    session.commit()
+    session.refresh(existing)
+    return existing
+
+
+def _student_texts_for_chatlog(
+    conv: dict[int, list[tuple[int, str, Optional[str]]]], chatlog_id: int
+) -> list[str]:
+    msgs = conv.get(chatlog_id, [])
+    return [text for _midx, text, _nb in sorted(msgs, key=lambda t: t[0])]
+
+
+def warm_explore_candidates(
+    label_id: int,
+    chatlog_ids: list[int],
+    conv: dict[int, list[tuple[int, str, Optional[str]]]],
+    notebooks: dict[int, Optional[str]],
+) -> None:
+    """Background: gradebook + conversation profiles for explore shortlist."""
+    if not _gemini_available() or not chatlog_ids:
+        return
+    ids = list(chatlog_ids)
+
+    def _run() -> None:
+        try:
+            with Session(engine) as session:
+                with _warm_lock:
+                    ensure_gradebook(session, label_id)
+                for cid in ids:
+                    texts = _student_texts_for_chatlog(conv, cid)
+                    if not texts:
+                        continue
+                    with _warm_lock:
+                        ensure_conversation_profile(
+                            session,
+                            label_id,
+                            cid,
+                            texts,
+                            notebooks.get(cid),
+                        )
+                labeled = labeled_chatlog_ids(session, label_id)
+            for cid in labeled:
+                if cid in ids:
+                    continue
+                texts = _student_texts_for_chatlog(conv, cid)
+                if not texts:
+                    continue
+                try:
+                    with Session(engine) as session:
+                        with _warm_lock:
+                            ensure_conversation_profile(
+                                session,
+                                label_id,
+                                cid,
+                                texts,
+                                notebooks.get(cid),
+                            )
+                except Exception as exc:
+                    logger.warning("warm labeled profile %s failed: %s", cid, exc)
+        except Exception as exc:
+            logger.warning("warm_explore_candidates failed: %s", exc)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def explore_score_weights() -> dict[str, float]:
+    """Normalized weights for utility blend; missing components are renormalized."""
+    def _f(key: str, default: float) -> float:
+        try:
+            return max(0.0, float(os.environ.get(key, str(default))))
+        except (TypeError, ValueError):
+            return default
+
+    return {
+        "uncertainty": _f("CHATSIGHT_EXPLORE_UNC_WEIGHT", "0.28"),
+        "message_novelty": _f("CHATSIGHT_EXPLORE_MSG_NOV_WEIGHT", "0.12"),
+        "conversation_novelty": _f("CHATSIGHT_EXPLORE_CONV_NOV_WEIGHT", "0.15"),
+        "theme_novelty": _f("CHATSIGHT_EXPLORE_THEME_NOV_WEIGHT", "0.15"),
+        "student_specificity": _f("CHATSIGHT_EXPLORE_SPEC_WEIGHT", "0.15"),
+        "student_rarity": _f("CHATSIGHT_EXPLORE_RARITY_WEIGHT", "0.15"),
+    }
+
+
+def blended_explore_utility(
+    uncertainty: Optional[float],
+    message_novelty: Optional[float],
+    conversation_novelty: Optional[float],
+    theme_novelty: Optional[float],
+    student_specificity: Optional[float],
+    student_rarity: Optional[float],
+    spam_penalty: float = 0.0,
+) -> float:
+    weights = explore_score_weights()
+    parts: list[tuple[float, float]] = []
+    if uncertainty is not None:
+        parts.append((uncertainty, weights["uncertainty"]))
+    if message_novelty is not None:
+        parts.append((message_novelty, weights["message_novelty"]))
+    if conversation_novelty is not None:
+        parts.append((conversation_novelty, weights["conversation_novelty"]))
+    if theme_novelty is not None:
+        parts.append((theme_novelty, weights["theme_novelty"]))
+    if student_specificity is not None:
+        parts.append((student_specificity, weights["student_specificity"]))
+    if student_rarity is not None:
+        parts.append((student_rarity, weights["student_rarity"]))
+    if not parts:
+        base = student_specificity if student_specificity is not None else 0.0
+    else:
+        wsum = sum(w for _, w in parts)
+        base = sum(v * w for v, w in parts) / wsum if wsum > 0.0 else 0.0
+    try:
+        spam_w = float(os.environ.get("CHATSIGHT_EXPLORE_SPAM_PENALTY", "0.85"))
+    except (TypeError, ValueError):
+        spam_w = 0.85
+    spam_w = max(0.0, min(1.0, spam_w))
+    return base * (1.0 - spam_w * max(0.0, min(1.0, spam_penalty)))
+
+

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2915,6 +2915,12 @@ def get_sample():
 # Single-label binary flow
 # ─────────────────────────────────────────────────────────────────────────────
 
+def _effective_hybrid_explore_fraction(label: LabelDefinition) -> float:
+    if label.hybrid_explore_fraction is not None:
+        return max(0.0, min(1.0, label.hybrid_explore_fraction))
+    return queue_service.default_hybrid_explore_fraction()
+
+
 def _label_to_response(db: Session, label: LabelDefinition) -> SingleLabelResponse:
     yes, no, skip, walked = decision_service.label_counts(db, label.id)
     total_convs = db.exec(select(MessageCache.chatlog_id).distinct()).all()
@@ -2931,6 +2937,8 @@ def _label_to_response(db: Session, label: LabelDefinition) -> SingleLabelRespon
         skip_count=skip,
         conversations_walked=walked,
         total_conversations=len(total_convs),
+        hybrid_explore_fraction=label.hybrid_explore_fraction,
+        hybrid_explore_effective=_effective_hybrid_explore_fraction(label),
     )
 
 
@@ -3323,7 +3331,13 @@ def get_next_focused(
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="Single-label not found")
 
-    payload = queue_service.next_message_for_label(db, label_id, assignment_id)
+    assist_service.rebuild_cache_if_stale(db, label_id)
+    payload = queue_service.next_message_for_label(
+        db,
+        label_id,
+        assignment_id,
+        explore_fraction=_effective_hybrid_explore_fraction(label),
+    )
     if not payload:
         return None
     return FocusedMessageResponse(**payload)
@@ -3362,7 +3376,15 @@ def _decide_response(
     db: Session, label_id: int, assignment_id: Optional[int] = None
 ) -> DecideResponse:
     """Build the combined next-message + readiness payload for the /run hot path."""
-    payload = queue_service.next_message_for_label(db, label_id, assignment_id)
+    label = db.get(LabelDefinition, label_id)
+    explore = _effective_hybrid_explore_fraction(label) if label else None
+    assist_service.rebuild_cache_if_stale(db, label_id)
+    payload = queue_service.next_message_for_label(
+        db,
+        label_id,
+        assignment_id,
+        explore_fraction=explore,
+    )
     nxt = FocusedMessageResponse(**payload) if payload else None
     readiness = ReadinessResponse(**decision_service.compute_readiness(db, label_id))
     return DecideResponse(next=nxt, readiness=readiness)
@@ -4413,6 +4435,11 @@ def patch_single_label(
         if not (0.0 <= body.review_threshold <= 1.0):
             raise HTTPException(status_code=422, detail="review_threshold must be in [0, 1]")
         label.review_threshold = body.review_threshold
+    if "hybrid_explore_fraction" in body.model_dump(exclude_unset=True):
+        v = body.hybrid_explore_fraction
+        if v is not None and not (0.0 <= v <= 1.0):
+            raise HTTPException(status_code=422, detail="hybrid_explore_fraction must be in [0, 1]")
+        label.hybrid_explore_fraction = v
 
     db.add(label)
     db.commit()

--- a/server/python/models.py
+++ b/server/python/models.py
@@ -43,6 +43,9 @@ class LabelDefinition(SQLModel, table=True):
     # this confidence land in the "Review" bucket. Configurable per-label via the
     # Settings tab; default 0.7 matches the implicit threshold the legacy code used.
     review_threshold: float = Field(default=0.7)
+    # Hybrid queue: fraction [0,1] of picks that bias toward richer conversations;
+    # None → use CHATSIGHT_HYBRID_EXPLORE_FRACTION env (default 0.35).
+    hybrid_explore_fraction: Optional[float] = Field(default=None)
 
 
 class LabelApplication(SQLModel, table=True):
@@ -104,6 +107,7 @@ class ConversationCursor(SQLModel, table=True):
     """Tracks resume position per (label_id, chatlog_id) for the single-label flow."""
     label_id: int = Field(foreign_key="labeldefinition.id", primary_key=True)
     chatlog_id: int = Field(primary_key=True)
+    last_message_index: int = Field(default=0)
     last_message_index_decided: int
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -161,6 +165,25 @@ class RecalibrationEvent(SQLModel, table=True):
     matched: bool                  # True if original_label_ids == relabel_ids
     session_id: Optional[int] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class LabelExploreGradebook(SQLModel, table=True):
+    """Cached yes/no pattern summary for explore theme scoring (per label)."""
+    label_id: int = Field(primary_key=True, foreign_key="labeldefinition.id")
+    gradebook_json: str
+    human_label_count: int = Field(default=0)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ConversationProfile(SQLModel, table=True):
+    """Cached AI one-liner + embedding for a conversation under a label."""
+    label_id: int = Field(primary_key=True, foreign_key="labeldefinition.id")
+    chatlog_id: int = Field(primary_key=True)
+    one_liner: str
+    theme_tags_json: Optional[str] = Field(default=None)
+    summary_embedding: bytes
+    human_label_count_at_build: int = Field(default=0)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
 
 
 class ConceptCandidate(SQLModel, table=True):

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -1,16 +1,21 @@
 """Queue logic for the single-label flow: pick the next conversation + message
 that needs a decision for the active label."""
-import logging
 import hashlib
+import logging
+import math
+import os
+import random
 import threading
 from collections import OrderedDict
-from typing import Optional
+from typing import Optional, Tuple
 
 from sqlalchemy import text as sql_text
 from sqlmodel import Session, select
 
+import assist_service
+import explore_service
 from database import ext_engine
-from models import LabelApplication, MessageCache
+from models import ConversationProfile, LabelApplication, MessageCache
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +33,166 @@ def _clear_thread_cache() -> None:
         _thread_cache.clear()
 
 
+def neighbor_uncertainty_novelty(
+    session: Session,
+    label_id: int,
+    chatlog_id: int,
+    message_index: int,
+) -> Optional[Tuple[float, float]]:
+    """From live embedding k-NN (same source as /assist), return (uncertainty, novelty) in [0,1]."""
+    neighbors = assist_service.nearest_neighbors(
+        session, label_id, chatlog_id, message_index, k=5
+    )
+    if not neighbors:
+        return None
+
+    yes_sum = 0.0
+    no_sum = 0.0
+    max_sim = None
+    for n in neighbors:
+        sim = float(n.get("similarity", 0.0))
+        max_sim = sim if max_sim is None else max(max_sim, sim)
+        v = n.get("value")
+        if v == "yes":
+            yes_sum += max(sim, 0.0)
+        elif v == "no":
+            no_sum += max(sim, 0.0)
+
+    denom = yes_sum + no_sum
+    if denom <= 0.0:
+        return None
+
+    p_yes = yes_sum / denom
+    eps = 1e-12
+    p_yes = max(eps, min(1.0 - eps, p_yes))
+    entropy = -p_yes * math.log(p_yes) - (1.0 - p_yes) * math.log(1.0 - p_yes)
+    uncertainty = entropy / math.log(2.0)
+
+    max_sim = float(max_sim if max_sim is not None else 0.0)
+    max_sim = max(0.0, min(1.0, max_sim))
+    novelty = 1.0 - max_sim
+    return uncertainty, novelty
+
+
+def build_sampling_meta(
+    session: Session,
+    label_id: int,
+    chatlog_id: int,
+    message_index: int,
+    conversation_student_messages: int,
+    sampling_pick: str,
+) -> dict:
+    """Human-readable sampling diagnostics for the RUN UI."""
+    if sampling_pick == "baseline":
+        sampling_pick = "round_robin"
+    unc_nov = neighbor_uncertainty_novelty(session, label_id, chatlog_id, message_index)
+    labeled_centroids = explore_service.labeled_student_centroids(session, label_id)
+    conv_nov = explore_service.conversation_novelty(
+        session, label_id, chatlog_id, labeled_centroids
+    )
+    theme_nov = explore_service.theme_novelty(session, label_id, chatlog_id)
+    pending_row = session.exec(
+        select(MessageCache.message_text).where(
+            MessageCache.chatlog_id == chatlog_id,
+            MessageCache.message_index == message_index,
+        )
+    ).first()
+    pending_str = (
+        pending_row[0] if pending_row is not None and isinstance(pending_row, tuple) else pending_row
+    )
+    rarity = explore_service.student_message_corpus_rarity(session, chatlog_id, message_index)
+    spec = (
+        explore_service.student_help_specificity(
+            pending_str or "", corpus_rarity=rarity
+        )
+        if pending_str is not None
+        else None
+    )
+    paste_score = (
+        explore_service.student_message_copy_paste_likelihood(pending_str or "")
+        if pending_str is not None
+        else None
+    )
+    profile = session.get(ConversationProfile, (label_id, chatlog_id))
+    conversation_summary = (
+        profile.one_liner.strip()
+        if profile and profile.one_liner and profile.one_liner.strip()
+        else None
+    )
+
+    meta = {
+        "sampling_pick": sampling_pick,
+        "conversation_student_messages": conversation_student_messages,
+        "pending_student_message_number": message_index + 1,
+        "neighbor_scores_available": unc_nov is not None,
+        "neighbor_uncertainty_pct": None,
+        "neighbor_novelty_pct": None,
+        "conversation_novelty_pct": None,
+        "theme_novelty_pct": None,
+        "student_specificity_pct": int(round(spec * 100)) if spec is not None else None,
+        "student_rarity_pct": int(round(rarity * 100)) if rarity is not None else None,
+        "conversation_summary": conversation_summary,
+        "pick_rationale": None,
+        "sampling_hint": None,
+    }
+    if unc_nov:
+        u, n = unc_nov
+        meta["neighbor_uncertainty_pct"] = int(round(u * 100))
+        meta["neighbor_novelty_pct"] = int(round(n * 100))
+    if conv_nov is not None:
+        meta["conversation_novelty_pct"] = int(round(conv_nov * 100))
+    if theme_nov is not None:
+        meta["theme_novelty_pct"] = int(round(theme_nov * 100))
+    if sampling_pick == "explore":
+        bits = []
+        if unc_nov:
+            bits.append("ambiguous neighbors")
+        if conv_nov is not None and conv_nov >= 0.5:
+            bits.append("unlike labeled conversations")
+        if theme_nov is not None and theme_nov >= 0.5:
+            bits.append("new theme vs prior chats")
+        if paste_score is not None and paste_score >= 0.65:
+            bits.append("likely copy-paste (deprioritized in explore)")
+        elif spec is not None and spec >= 0.55:
+            bits.append("specific student help (not generic spam)")
+        if rarity is not None and rarity >= 0.5 and (paste_score or 0) < 0.65:
+            bits.append("uncommon phrasing in the corpus")
+        if bits:
+            meta["pick_rationale"] = ", ".join(bits) + "."
+        elif unc_nov:
+            meta["pick_rationale"] = (
+                "Neighbors disagree or look less like prior message labels."
+            )
+        else:
+            meta["pick_rationale"] = (
+                "Seeking specific, uncommon student help (scores still warming up)."
+            )
+    elif sampling_pick == "continue":
+        meta["pick_rationale"] = (
+            "Continue mode — finishing a chat you already started."
+        )
+    elif sampling_pick == "round_robin":
+        meta["pick_rationale"] = (
+            "Round-robin mode — next new chat in fair rotation, not Explore scoring."
+        )
+    elif not unc_nov:
+        meta["pick_rationale"] = (
+            "Neighbor scores not ready — need human yes/no labels on other messages "
+            "with embeddings."
+        )
+    return meta
+
+
+def default_hybrid_explore_fraction() -> float:
+    """Server default when `LabelDefinition.hybrid_explore_fraction` is unset."""
+    try:
+        v = float(os.environ.get("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0.35"))
+    except (TypeError, ValueError):
+        v = 0.35
+    return max(0.0, min(1.0, v))
+
+
 def _shuffle_key(label_id: int, chatlog_id: int) -> int:
-    """Deterministic shuffle key: stable hash of (label_id, chatlog_id) → int.
-    Each label gets its own walk order; the same label always walks the same way
-    on resume, so progress is intuitive within a label even though different labels
-    don't share a starting conversation."""
     digest = hashlib.blake2b(
         f"{label_id}:{chatlog_id}".encode(),
         digest_size=8,
@@ -40,28 +200,152 @@ def _shuffle_key(label_id: int, chatlog_id: int) -> int:
     return int.from_bytes(digest, "big", signed=False)
 
 
+def _first_pending_turn(
+    cid: int,
+    msgs: list[tuple[int, str, Optional[str]]],
+    decided: set,
+) -> Optional[tuple[int, str, Optional[str]]]:
+    for midx, text, notebook in sorted(msgs, key=lambda t: t[0]):
+        if (cid, midx) not in decided:
+            return midx, text, notebook
+    return None
+
+
+def _select_next_chatlog_id(
+    session: Session,
+    label_id: int,
+    conv: dict[int, list[tuple[int, str, Optional[str]]]],
+    assign_by_cid: dict[int, Optional[int]],
+    decided: set,
+    in_progress: list[int],
+    not_started: list[int],
+    explore_fraction: float,
+) -> Tuple[Optional[int], Optional[str]]:
+    ip_pending = [
+        c for c in in_progress
+        if c in conv and _first_pending_turn(c, conv[c], decided)
+    ]
+    ns_pending = [
+        c for c in not_started
+        if c in conv and _first_pending_turn(c, conv[c], decided)
+    ]
+    if not ip_pending and not ns_pending:
+        return None, None
+
+    pool = ip_pending if ip_pending else ns_pending
+    in_prog_bucket = bool(ip_pending)
+
+    if len(pool) == 1:
+        if in_prog_bucket:
+            return pool[0], "continue"
+        return pool[0], "round_robin"
+
+    explore = random.random() < explore_fraction
+    if not explore:
+        if in_prog_bucket:
+            pool_sorted = sorted(pool, key=lambda c: _shuffle_key(label_id, c))
+            return pool_sorted[0], "continue"
+        pool_sorted = sorted(
+            pool,
+            key=lambda c: (
+                assign_by_cid.get(c) is None,
+                assign_by_cid.get(c) if assign_by_cid.get(c) is not None else -1,
+                _shuffle_key(label_id, c),
+            ),
+        )
+        return pool_sorted[0], "round_robin"
+
+    cap = explore_service.explore_score_pool_cap()
+    pool_to_score = pool
+    if len(pool) > cap:
+        rng = random.Random(_shuffle_key(label_id, 0) ^ len(pool))
+        pool_to_score = rng.sample(pool, cap)
+
+    def _shortlist_key(cid: int) -> tuple[float, int]:
+        pending = _first_pending_turn(cid, conv[cid], decided)
+        if not pending:
+            return (0.0, cid)
+        midx, text, _nb = pending
+        texts = [t for _i, t, _n in conv[cid]]
+        pri = explore_service.explore_candidate_priority(
+            session, cid, text, midx, texts, use_corpus_rarity=False
+        )
+        return (pri, cid)
+
+    explore_candidates = sorted(pool_to_score, key=lambda c: (-_shortlist_key(c)[0], c))[
+        : max(1, (len(pool_to_score) + 3) // 4)
+    ]
+
+    notebooks: dict[int, Optional[str]] = {}
+    for cid in explore_candidates:
+        for _midx, _text, notebook in conv.get(cid, []):
+            if notebook is not None:
+                notebooks[cid] = notebook
+                break
+        else:
+            notebooks[cid] = None
+    explore_service.warm_explore_candidates(
+        label_id,
+        explore_candidates,
+        conv,
+        notebooks,
+    )
+
+    labeled_centroids = explore_service.labeled_student_centroids(session, label_id)
+    theme_vectors = explore_service.labeled_theme_vectors(session, label_id)
+
+    def _conversation_utility(cid: int) -> float:
+        pending = _first_pending_turn(cid, conv[cid], decided)
+        if not pending:
+            return 0.0
+        midx, text, _notebook = pending
+        student_texts = [t for _i, t, _n in conv[cid]]
+        result = neighbor_uncertainty_novelty(session, label_id, cid, midx)
+        uncertainty, msg_nov = (result if result else (None, None))
+        conv_nov = explore_service.conversation_novelty(
+            session, label_id, cid, labeled_centroids
+        )
+        theme_nov = explore_service.theme_novelty(
+            session, label_id, cid, theme_vectors
+        )
+        rarity = explore_service.student_message_corpus_rarity(session, cid, midx)
+        spec = explore_service.student_help_specificity(text, corpus_rarity=rarity)
+        spam = explore_service.conversation_spam_penalty(student_texts)
+        return explore_service.blended_explore_utility(
+            uncertainty,
+            msg_nov,
+            conv_nov,
+            theme_nov,
+            spec,
+            rarity,
+            spam,
+        )
+
+    utility_scores = {
+        cid: _conversation_utility(cid) for cid in explore_candidates
+    }
+    scored = sorted(
+        explore_candidates,
+        key=lambda c: (-utility_scores[c], c),
+    )
+    top_k = max(1, (len(scored) + 3) // 4)
+    explore_choices = [c for c in scored[:top_k]]
+
+    return random.choice(explore_choices), "explore"
+
+
 def next_message_for_label(
     session: Session,
     label_id: int,
     assignment_id: Optional[int] = None,
+    explore_fraction: Optional[float] = None,
 ) -> Optional[dict]:
-    """Return the next student-message that needs a decision for this label.
+    eff_explore = (
+        max(0.0, min(1.0, explore_fraction))
+        if explore_fraction is not None
+        else default_hybrid_explore_fraction()
+    )
 
-    Conversation-by-conversation walk: in-progress conversations first (ones with
-    some decisions but not all), then not-started conversations by chatlog_id ascending.
-    Within a conversation, walks message_index ascending.
-
-    `assignment_id`: when provided, only conversations whose `MessageCache.assignment_id`
-    matches are considered.
-
-    Returns:
-        {
-          "chatlog_id", "message_index", "text", "notebook",
-          "conversation_turn_count", "thread": [...all turns...], "focus_index": int
-        } or None if there's nothing left to decide. The full conversation thread is
-        returned so the UI can render every turn in chronological order with the focused
-        turn highlighted in place.
-    """
     cache_q = select(
         MessageCache.id,
         MessageCache.chatlog_id,
@@ -74,7 +358,6 @@ def next_message_for_label(
         cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
     cache_rows = session.exec(cache_q).all()
 
-    # All decisions already recorded for this label, keyed by (chatlog_id, message_index).
     decided = set(
         session.exec(
             select(LabelApplication.chatlog_id, LabelApplication.message_index)
@@ -82,10 +365,12 @@ def next_message_for_label(
         ).all()
     )
 
-    # Per-conversation: list of student messages, and how many are decided.
     conv: dict[int, list[tuple[int, str, Optional[str]]]] = {}
-    for _id, cid, midx, text, notebook, _assign in cache_rows:
+    assign_by_cid: dict[int, Optional[int]] = {}
+    for _id, cid, midx, text, notebook, assign in cache_rows:
         conv.setdefault(cid, []).append((midx, text, notebook))
+        if cid not in assign_by_cid:
+            assign_by_cid[cid] = assign
 
     in_progress: list[int] = []
     not_started: list[int] = []
@@ -96,32 +381,40 @@ def next_message_for_label(
         elif decided_in_conv < len(msgs):
             in_progress.append(cid)
 
-    # In-progress conversations stay first (so the instructor finishes what they
-    # started), but ordering among them, and especially among not-started ones,
-    # uses a per-label deterministic shuffle so different labels don't all open at
-    # chatlog #1 and feel like a loop.
     in_progress.sort(key=lambda c: _shuffle_key(label_id, c))
     not_started.sort(key=lambda c: _shuffle_key(label_id, c))
 
-    for cid in in_progress + not_started:
-        msgs = sorted(conv[cid], key=lambda t: t[0])
-        for midx, text, notebook in msgs:
-            if (cid, midx) in decided:
-                continue
-            return _build_focus_payload(session, label_id, cid, midx, text, notebook)
+    cid_pick, pick_mode = _select_next_chatlog_id(
+        session,
+        label_id,
+        conv,
+        assign_by_cid,
+        decided,
+        in_progress,
+        not_started,
+        eff_explore,
+    )
+    if cid_pick is None or pick_mode is None:
+        return None
 
-    return None
+    tup = _first_pending_turn(cid_pick, conv[cid_pick], decided)
+    if not tup:
+        return None
+    midx, text, notebook = tup
+    sampling_meta = build_sampling_meta(
+        session,
+        label_id,
+        cid_pick,
+        midx,
+        len(conv[cid_pick]),
+        pick_mode,
+    )
+    return _build_focus_payload(
+        session, label_id, cid_pick, midx, text, notebook, sampling_meta=sampling_meta
+    )
 
 
 def _thread_from_message_cache(session: Session, chatlog_id: int) -> list[dict]:
-    """Reconstruct tutor + student turns from SQLite MessageCache only.
-
-    Each cached student row stores tutor snippets from ingest time:
-    `context_before` = tutor reply immediately preceding this question,
-    `context_after` = tutor reply immediately following this question.
-    Interleave them in order and dedupe back-to-back identical tutor text
-    (neighboring rows share the same boundary reply).
-    """
     cached_rows = session.exec(
         select(
             MessageCache.message_index,
@@ -192,12 +485,11 @@ def _build_focus_payload(
     message_index: int,
     text: str,
     notebook: Optional[str],
+    sampling_meta: Optional[dict] = None,
 ) -> dict:
     thread_pg = _fetch_full_thread(chatlog_id)
     focus_pg = _student_focus_index(thread_pg, message_index)
 
-    # Only hit SQLite for rebuild when Postgres thread is missing, mismatched,
-    # or student-only (tutor replies live in MessageCache.context_*).
     needs_cache = focus_pg is None or not _thread_has_tutor(thread_pg)
     thread_cache = (
         _thread_from_message_cache(session, chatlog_id) if needs_cache else []
@@ -222,7 +514,7 @@ def _build_focus_payload(
             {"message_index": 0, "role": "student", "text": text, "student_index": message_index}
         ]
         focus_index = 0
-    return {
+    out = {
         "chatlog_id": chatlog_id,
         "message_index": message_index,
         "text": text,
@@ -231,17 +523,26 @@ def _build_focus_payload(
         "thread": [{"message_index": t["message_index"], "role": t["role"], "text": t["text"]}
                    for t in thread],
         "focus_index": focus_index,
+        "sampling_pick": None,
+        "conversation_student_messages": None,
+        "pending_student_message_number": None,
+        "neighbor_scores_available": False,
+        "neighbor_uncertainty_pct": None,
+        "neighbor_novelty_pct": None,
+        "conversation_novelty_pct": None,
+        "theme_novelty_pct": None,
+        "student_specificity_pct": None,
+        "student_rarity_pct": None,
+        "conversation_summary": None,
+        "pick_rationale": None,
+        "sampling_hint": None,
     }
+    if sampling_meta:
+        out.update(sampling_meta)
+    return out
 
 
 def _fetch_full_thread(chatlog_id: int) -> list[dict]:
-    """Pull the entire conversation (every student question + tutor response) from
-    the external Postgres events table, in chronological order. Each entry includes
-    a `student_index` for student turns so we can locate the focused message.
-
-    Cached per-process by chatlog_id. Empty results (Postgres unreachable, etc.)
-    are NOT cached so a transient failure doesn't poison the cache.
-    """
     with _thread_cache_lock:
         cached = _thread_cache.get(chatlog_id)
         if cached is not None:
@@ -261,10 +562,6 @@ def _fetch_full_thread(chatlog_id: int) -> list[dict]:
 
 
 def _fetch_full_thread_uncached(chatlog_id: int) -> list[dict]:
-    # chatlog_id is the MIN(events.id) of its conversation by construction
-    # (see ingest paths in main.py). So resolving conversation_id is a single-row
-    # PK lookup — much cheaper than the old GROUP BY/HAVING scan, which was
-    # painful per-decide because /run hits this function on every cycle.
     sql = """
     SELECT event_type,
            payload->>'question' AS question,
@@ -287,7 +584,7 @@ def _fetch_full_thread_uncached(chatlog_id: int) -> list[dict]:
             chatlog_id,
             exc,
         )
-        return []  # external DB unreachable in tests / mock mode
+        return []
 
     turns: list[dict] = []
     midx = 0
@@ -306,5 +603,3 @@ def _fetch_full_thread_uncached(chatlog_id: int) -> list[dict]:
             turns.append({"message_index": midx, "role": "tutor", "text": r})
             midx += 1
     return turns
-
-

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -456,7 +456,9 @@ def _thread_from_message_cache(session: Session, chatlog_id: int) -> list[dict]:
         seq += 1
 
     for midx, msg_text, ctx_before, ctx_after in cached_rows:
-        append_tutor(ctx_before or "")
+        # context_before on message 0 is often a pre-conversation tutor event — skip it.
+        if midx > 0:
+            append_tutor(ctx_before or "")
         append_student(midx, msg_text)
         append_tutor(ctx_after or "")
 
@@ -589,8 +591,10 @@ def _fetch_full_thread_uncached(chatlog_id: int) -> list[dict]:
     turns: list[dict] = []
     midx = 0
     student_idx = 0
+    seen_query = False
     for et, q, r in rows:
         if et == "tutor_query" and q:
+            seen_query = True
             turns.append({
                 "message_index": midx,
                 "role": "student",
@@ -599,7 +603,7 @@ def _fetch_full_thread_uncached(chatlog_id: int) -> list[dict]:
             })
             midx += 1
             student_idx += 1
-        elif et == "tutor_response" and r:
+        elif et == "tutor_response" and r and seen_query:
             turns.append({"message_index": midx, "role": "tutor", "text": r})
             midx += 1
     return turns

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -267,6 +267,8 @@ class SingleLabelResponse(BaseModel):
     skip_count: int
     conversations_walked: int
     total_conversations: int
+    hybrid_explore_fraction: Optional[float] = None
+    hybrid_explore_effective: float = 0.35
 
 
 class TurnResponse(BaseModel):
@@ -283,6 +285,19 @@ class FocusedMessageResponse(BaseModel):
     conversation_turn_count: int
     thread: List[TurnResponse]
     focus_index: int
+    sampling_pick: Optional[str] = None  # "continue" | "explore" | "round_robin"
+    conversation_summary: Optional[str] = None
+    pick_rationale: Optional[str] = None
+    sampling_hint: Optional[str] = None  # deprecated; use conversation_summary / pick_rationale
+    conversation_student_messages: Optional[int] = None
+    pending_student_message_number: Optional[int] = None
+    neighbor_scores_available: bool = False
+    neighbor_uncertainty_pct: Optional[int] = None
+    neighbor_novelty_pct: Optional[int] = None
+    conversation_novelty_pct: Optional[int] = None
+    theme_novelty_pct: Optional[int] = None
+    student_specificity_pct: Optional[int] = None
+    student_rarity_pct: Optional[int] = None
 
 
 class ReadinessResponse(BaseModel):
@@ -512,3 +527,4 @@ class LabelUpdateRequest(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     review_threshold: Optional[float] = None
+    hybrid_explore_fraction: Optional[float] = None

--- a/server/python/tests/conftest.py
+++ b/server/python/tests/conftest.py
@@ -35,7 +35,9 @@ def session_fixture(engine):
 
 
 @pytest.fixture(name="client")
-def client_fixture(session):
+def client_fixture(session, monkeypatch):
+    monkeypatch.setenv("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0")
+
     def override_session():
         yield session
 

--- a/server/python/tests/test_explore_scoring.py
+++ b/server/python/tests/test_explore_scoring.py
@@ -1,0 +1,266 @@
+"""Tests for explore_service conversation + theme novelty (Layer A/B)."""
+import json
+import numpy as np
+import pytest
+from sqlmodel import Session
+
+from concept_service import EMBED_MODEL
+from explore_service import (
+    blended_explore_utility,
+    conversation_novelty,
+    conversation_centroid,
+    conversation_spam_penalty,
+    ensure_gradebook,
+    explore_candidate_priority,
+    student_help_genericness,
+    student_help_specificity,
+    student_message_copy_paste_likelihood,
+    student_message_corpus_rarity,
+    theme_novelty,
+    warm_explore_candidates,
+)
+from models import (
+    ConversationProfile,
+    LabelApplication,
+    LabelDefinition,
+    LabelExploreGradebook,
+    MessageCache,
+    MessageEmbedding,
+)
+
+
+def _emb(values):
+    v = np.array(values, dtype=np.float32)
+    n = np.linalg.norm(v)
+    return (v / n).tobytes() if n > 0 else v.tobytes()
+
+
+def test_conversation_centroid_mean(session):
+    for i in range(2):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}"))
+    session.add(MessageEmbedding(chatlog_id=1, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
+    session.add(MessageEmbedding(chatlog_id=1, message_index=1, embedding=_emb([0.0, 1.0]), model_version=EMBED_MODEL))
+    session.commit()
+    c = conversation_centroid(session, 1)
+    assert c is not None
+    assert abs(float(np.linalg.norm(c)) - 1.0) < 0.01
+
+
+def test_conversation_novelty_high_when_far_from_labeled(session):
+    label = LabelDefinition(name="nov", mode="single", is_active=True, phase="labeling")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+    lid = label.id
+
+    session.add(MessageCache(chatlog_id=10, message_index=0, message_text="a"))
+    session.add(MessageCache(chatlog_id=11, message_index=0, message_text="b"))
+    session.add(MessageEmbedding(chatlog_id=10, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
+    session.add(MessageEmbedding(chatlog_id=11, message_index=0, embedding=_emb([0.0, 1.0]), model_version=EMBED_MODEL))
+    session.add(LabelApplication(label_id=lid, chatlog_id=10, message_index=0, applied_by="human", value="yes"))
+    session.commit()
+
+    nov = conversation_novelty(session, lid, 11)
+    assert nov is not None
+    assert nov > 0.9
+
+
+def test_theme_novelty_uses_cached_profiles(session):
+    label = LabelDefinition(name="theme", mode="single", is_active=True, phase="labeling")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+    lid = label.id
+
+    session.add(LabelApplication(label_id=lid, chatlog_id=20, message_index=0, applied_by="human", value="yes"))
+    session.add(LabelApplication(label_id=lid, chatlog_id=21, message_index=0, applied_by="human", value="no"))
+    session.add(
+        ConversationProfile(
+            label_id=lid,
+            chatlog_id=20,
+            one_liner="pandas groupby",
+            theme_tags_json='["pandas"]',
+            summary_embedding=_emb([1.0, 0.0]),
+            human_label_count_at_build=2,
+        )
+    )
+    session.add(
+        ConversationProfile(
+            label_id=lid,
+            chatlog_id=21,
+            one_liner="matplotlib plots",
+            theme_tags_json='["viz"]',
+            summary_embedding=_emb([0.0, 1.0]),
+            human_label_count_at_build=2,
+        )
+    )
+    session.commit()
+
+    thm = theme_novelty(session, lid, 21)
+    assert thm is not None
+    assert thm > 0.9
+
+
+def test_student_help_genericness():
+    assert student_help_genericness("help") > 0.85
+    assert student_help_genericness("question 1.2") > 0.85
+    assert student_help_specificity(
+        "Can you give me an example of groupby in the context of this question?"
+    ) > 0.6
+
+
+def test_copy_paste_long_assignment_block():
+    pasted = """
+    Question 3.4
+    Using the following dataset, write a function that computes the mean price
+    grouped by category. You should submit a notebook with your code and a short
+  written explanation of your approach.
+    1. Load the data from the provided CSV.
+    2. Clean missing values according to the rubric.
+    3. Produce a bar chart of counts by category.
+    """
+    assert student_message_copy_paste_likelihood(pasted) >= 0.7
+    assert student_help_specificity(pasted) < 0.35
+    assert student_help_specificity(pasted, corpus_rarity=0.1) < 0.15
+
+
+def test_copy_paste_traceback():
+    tb = "Traceback (most recent call last):\n  File \"main.py\", line 4\n" + "x" * 300
+    assert student_message_copy_paste_likelihood(tb) >= 0.85
+
+
+def test_original_long_question_not_treated_as_paste():
+    original = (
+        "I'm confused about question 3 — can you give me an example of groupby "
+        "being used in the context of this homework question? My merge keeps "
+        "dropping rows and I think I'm using the wrong key."
+    )
+    assert student_message_copy_paste_likelihood(original) < 0.5
+    assert student_help_specificity(original) > 0.5
+
+
+def test_explore_priority_original_over_pasted_block(session):
+    pasted = [
+        "Question 1\nWrite a function using the dataset below.\n" + "step\n" * 8
+    ]
+    specific = (
+        "Can you give me an example of groupby being used in the context of this question?"
+    )
+    pri_paste = explore_candidate_priority(
+        session, 300, pasted[0], 0, pasted, use_corpus_rarity=False
+    )
+    pri_specific = explore_candidate_priority(
+        session, 301, specific, 0, [specific], use_corpus_rarity=False
+    )
+    assert pri_specific > pri_paste
+
+
+def test_conversation_spam_penalty():
+    assert conversation_spam_penalty(["help", "help", "question 1.2"]) > 0.4
+    assert conversation_spam_penalty(
+        ["Can you show an example of merge in this homework question?"]
+    ) == 0.0
+
+
+def test_explore_priority_specific_over_spam_length(session):
+    spam_texts = ["help", "help", "question 1.2"]
+    specific = (
+        "Can you give me an example of groupby being used in the context of this question?"
+    )
+    pri_spam = explore_candidate_priority(
+        session, 202, "help", 0, spam_texts, use_corpus_rarity=False
+    )
+    pri_specific = explore_candidate_priority(
+        session, 203, specific, 0, [specific], use_corpus_rarity=False
+    )
+    assert pri_specific > pri_spam
+
+
+def test_student_corpus_rarity(session):
+    session.add(MessageCache(chatlog_id=30, message_index=0, message_text="help"))
+    session.add(MessageCache(chatlog_id=31, message_index=0, message_text="help"))
+    session.add(
+        MessageCache(
+            chatlog_id=32,
+            message_index=0,
+            message_text="groupby example in context of lab 3",
+        )
+    )
+    session.add(MessageEmbedding(chatlog_id=30, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
+    session.add(MessageEmbedding(chatlog_id=31, message_index=0, embedding=_emb([0.99, 0.1]), model_version=EMBED_MODEL))
+    session.add(MessageEmbedding(chatlog_id=32, message_index=0, embedding=_emb([0.0, 1.0]), model_version=EMBED_MODEL))
+    session.commit()
+    rare = student_message_corpus_rarity(session, 32, 0)
+    common = student_message_corpus_rarity(session, 30, 0)
+    assert rare is not None and common is not None
+    assert rare > common
+
+
+def test_blended_utility_renormalizes_missing_components():
+    u = blended_explore_utility(0.8, None, 0.6, None, 0.7, 0.75, 0.0)
+    assert 0.0 <= u <= 1.0
+    assert u > 0.5
+    u_spam = blended_explore_utility(0.9, 0.9, 0.9, 0.9, 0.9, 0.9, spam_penalty=0.9)
+    assert u_spam < u
+
+
+def test_ensure_gradebook_skips_without_api_key(session, monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    label = LabelDefinition(name="gb", mode="single", is_active=True, phase="labeling")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+    for i in range(5):
+        session.add(
+            LabelApplication(
+                label_id=label.id,
+                chatlog_id=100 + i,
+                message_index=0,
+                applied_by="human",
+                value="yes" if i % 2 == 0 else "no",
+            )
+        )
+    session.commit()
+    assert ensure_gradebook(session, label.id) is None
+
+
+def test_ensure_gradebook_persists_with_mock(session, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    label = LabelDefinition(name="gb2", mode="single", is_active=True, phase="labeling")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+    for i in range(5):
+        session.add(
+            LabelApplication(
+                label_id=label.id,
+                chatlog_id=200 + i,
+                message_index=0,
+                applied_by="human",
+                value="yes",
+            )
+        )
+        session.add(
+            MessageCache(
+                chatlog_id=200 + i,
+                message_index=0,
+                message_text=f"msg {i}",
+            )
+        )
+    session.commit()
+
+    monkeypatch.setattr(
+        "explore_service.binary_autolabel_service.summarize_batch",
+        lambda *a, **k: {"included": ["stuck"], "excluded": ["thanks"]},
+    )
+    gb = ensure_gradebook(session, label.id)
+    assert gb is not None
+    assert gb["included"] == ["stuck"]
+    row = session.get(LabelExploreGradebook, label.id)
+    assert row is not None
+    assert json.loads(row.gradebook_json)["excluded"] == ["thanks"]
+
+
+def test_warm_explore_candidates_noop_without_api_key(session, monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    warm_explore_candidates(1, [1, 2], {1: [(0, "hi", None)]}, {1: None})

--- a/server/python/tests/test_hybrid_sampling.py
+++ b/server/python/tests/test_hybrid_sampling.py
@@ -1,0 +1,204 @@
+"""Unit + API tests for hybrid explore / round-robin conversation sampling."""
+import numpy as np
+import queue_service
+from sqlmodel import select
+
+from concept_service import EMBED_MODEL
+from models import LabelApplication, LabelDefinition, MessageCache, MessageEmbedding
+
+
+def _emb(values):
+    return np.array(values, dtype=np.float32).tobytes()
+
+
+def _seed_conv_sizes(session, sizes: dict[int, int]):
+    """sizes: chatlog_id -> number of student messages."""
+    for cid, n in sizes.items():
+        for i in range(n):
+            session.add(
+                MessageCache(
+                    chatlog_id=cid,
+                    message_index=i,
+                    message_text=f"chat {cid} msg {i}",
+                )
+            )
+    session.commit()
+
+
+def test_select_next_always_baseline_when_explore_fraction_zero(session, monkeypatch):
+    monkeypatch.setattr(queue_service.random, "random", lambda: 0.0)  # would explore if fraction > 0
+    conv = {
+        201: [(0, "a", None), (1, "b", None)],
+        202: [(0, "c", None)],
+    }
+    cid, mode = queue_service._select_next_chatlog_id(
+        session,
+        label_id=1,
+        conv=conv,
+        assign_by_cid={201: None, 202: None},
+        decided=set(),
+        in_progress=[],
+        not_started=[201, 202],
+        explore_fraction=0.0,
+    )
+    assert mode == "round_robin"
+    assert cid is not None
+
+
+def test_select_next_continue_when_multiple_in_progress(session, monkeypatch):
+    monkeypatch.setattr(queue_service.random, "random", lambda: 0.0)
+    conv = {
+        201: [(0, "a", None), (1, "b", None)],
+        202: [(0, "c", None), (1, "d", None)],
+        203: [(0, "e", None)],
+    }
+    decided = {(201, 0), (202, 0)}
+    cid, mode = queue_service._select_next_chatlog_id(
+        session,
+        label_id=1,
+        conv=conv,
+        assign_by_cid={201: None, 202: None, 203: None},
+        decided=decided,
+        in_progress=[201, 202],
+        not_started=[203],
+        explore_fraction=0.0,
+    )
+    assert mode == "continue"
+    assert cid in (201, 202)
+
+
+def test_select_next_continue_when_single_in_progress(session):
+    conv = {
+        201: [(0, "a", None), (1, "b", None)],
+        202: [(0, "c", None)],
+        203: [(0, "d", None)],
+    }
+    decided = {(201, 0)}
+    cid, mode = queue_service._select_next_chatlog_id(
+        session,
+        label_id=1,
+        conv=conv,
+        assign_by_cid={201: None, 202: None, 203: None},
+        decided=decided,
+        in_progress=[201],
+        not_started=[202, 203],
+        explore_fraction=0.97,
+    )
+    assert cid == 201
+    assert mode == "continue"
+
+
+def test_select_next_explore_when_fraction_one(session, monkeypatch):
+    monkeypatch.setattr(queue_service.random, "random", lambda: 0.0)
+    import explore_service
+
+    conv = {
+        201: [(0, "help", None)],
+        202: [(0, "help", None), (1, "help", None), (2, "question 1.2", None)],
+        203: [
+            (
+                0,
+                "Can you give me an example of groupby in the context of this question?",
+                None,
+            )
+        ],
+    }
+    pri_long_spam = explore_service.explore_candidate_priority(
+        session, 202, "help", 0, [t for _i, t, _n in conv[202]], use_corpus_rarity=False
+    )
+    pri_specific = explore_service.explore_candidate_priority(
+        session, 203, conv[203][0][1], 0, [conv[203][0][1]], use_corpus_rarity=False
+    )
+    assert pri_specific > pri_long_spam
+
+    chosen: list[int] = []
+
+    def _pick_one(seq):
+        chosen.append(seq[0])
+        return seq[0]
+
+    monkeypatch.setattr(queue_service.random, "choice", _pick_one)
+    cid, mode = queue_service._select_next_chatlog_id(
+        session,
+        label_id=1,
+        conv=conv,
+        assign_by_cid={201: None, 202: None, 203: None},
+        decided=set(),
+        in_progress=[],
+        not_started=[201, 202, 203],
+        explore_fraction=1.0,
+    )
+    assert mode == "explore"
+    assert cid == 203
+
+
+def test_next_message_includes_sampling_metadata(client, session, monkeypatch):
+    monkeypatch.setenv("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0")
+    _seed_conv_sizes(session, {300: 2, 301: 2})
+    label = client.post("/api/single-labels", json={"name": "sampling-meta"}).json()
+    client.post(f"/api/single-labels/{label['id']}/activate")
+    r = client.get(f"/api/single-labels/{label['id']}/next")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["sampling_pick"] in ("continue", "round_robin", "explore")
+    assert data["conversation_student_messages"] is not None
+    assert data["pending_student_message_number"] is not None
+    assert "conversation_summary" in data
+    assert "pick_rationale" in data
+
+
+def test_explore_fraction_patch_changes_effective_rate(client, session):
+    lab = client.post("/api/single-labels", json={"name": "rate"}).json()
+    lid = lab["id"]
+    client.post(f"/api/single-labels/{lid}/activate")
+    client.patch(f"/api/single-labels/{lid}", json={"hybrid_explore_fraction": 1.0})
+    active = client.get("/api/single-labels/active").json()
+    assert active["hybrid_explore_effective"] == 1.0
+
+
+def test_neighbor_scores_when_assist_has_neighbors(session):
+    label = LabelDefinition(name="scores", mode="single", is_active=True, phase="labeling")
+    session.add(label)
+    session.commit()
+    session.refresh(label)
+    session.add(MessageCache(chatlog_id=500, message_index=0, message_text="focus"))
+    session.add(MessageEmbedding(chatlog_id=500, message_index=0, embedding=_emb([1.0, 0.0]), model_version=EMBED_MODEL))
+    session.add(MessageCache(chatlog_id=501, message_index=0, message_text="prior yes"))
+    session.add(MessageEmbedding(chatlog_id=501, message_index=0, embedding=_emb([0.9, 0.1]), model_version=EMBED_MODEL))
+    session.add(LabelApplication(
+        label_id=label.id, chatlog_id=501, message_index=0,
+        applied_by="human", confidence=1.0, value="yes",
+    ))
+    session.commit()
+    result = queue_service.neighbor_uncertainty_novelty(session, label.id, 500, 0)
+    assert result is not None
+    u, n = result
+    assert 0.0 <= u <= 1.0
+    assert 0.0 <= n <= 1.0
+    meta = queue_service.build_sampling_meta(session, label.id, 500, 0, 1, "explore")
+    assert meta["neighbor_scores_available"] is True
+    assert meta["neighbor_uncertainty_pct"] is not None
+    assert meta["conversation_novelty_pct"] is not None
+
+
+def test_decide_response_carries_sampling_on_next(client, session, monkeypatch):
+    monkeypatch.setenv("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0")
+    _seed_conv_sizes(session, {400: 1, 401: 1})
+    label = client.post("/api/single-labels", json={"name": "decide-sampling"}).json()
+    lid = label["id"]
+    client.post(f"/api/single-labels/{lid}/activate")
+    first = client.get(f"/api/single-labels/{lid}/next").json()
+    r = client.post(
+        f"/api/single-labels/{lid}/decide",
+        json={
+            "chatlog_id": first["chatlog_id"],
+            "message_index": first["message_index"],
+            "value": "yes",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    nxt = body.get("next")
+    if nxt is not None:
+        assert "sampling_pick" in nxt
+        assert "sampling_hint" in nxt

--- a/server/python/tests/test_single_label_routes.py
+++ b/server/python/tests/test_single_label_routes.py
@@ -313,6 +313,82 @@ def test_fetch_full_thread_empty_result_is_not_cached(monkeypatch):
     assert calls == [8888, 8888]
 
 
+def test_fetch_full_thread_uncached_skips_preamble_tutor(monkeypatch):
+    """Leading tutor_response events must not appear before the first student turn."""
+    queue_service._clear_thread_cache()
+
+    class _Conn:
+        def execute(self, _sql, _params):
+            return self
+
+        def fetchall(self):
+            return [
+                ("tutor_response", None, "Welcome to the tutor."),
+                ("tutor_query", "first student question", None),
+                ("tutor_response", None, "Tutor answer."),
+            ]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(queue_service.ext_engine, "connect", lambda: _Conn())
+
+    thread = queue_service._fetch_full_thread_uncached(12345)
+    assert [t["role"] for t in thread] == ["student", "tutor"]
+    assert thread[0]["text"] == "first student question"
+    assert thread[1]["text"] == "Tutor answer."
+
+
+def test_thread_from_cache_skips_context_before_on_first_message(session):
+    """Message 0 context_before is pre-conversation; thread must start with student."""
+    session.add(MessageCache(
+        chatlog_id=920,
+        message_index=0,
+        message_text="first student question",
+        context_before="pre-conversation tutor greeting",
+        context_after="tutor after first",
+    ))
+    session.add(MessageCache(
+        chatlog_id=920,
+        message_index=1,
+        message_text="second student question",
+        context_before="tutor after first",
+        context_after="tutor after second",
+    ))
+    session.commit()
+
+    thread = queue_service._thread_from_message_cache(session, 920)
+    assert [t["role"] for t in thread] == ["student", "tutor", "student", "tutor"]
+    assert thread[0]["text"] == "first student question"
+    assert "pre-conversation" not in "\n".join(t["text"] for t in thread)
+
+
+def test_next_thread_starts_with_student_when_pg_has_preamble(client, session, monkeypatch):
+    """/next must not surface a leading tutor turn from Postgres ordering."""
+    queue_service._clear_thread_cache()
+    monkeypatch.setattr(
+        queue_service,
+        "_fetch_full_thread_uncached",
+        lambda _cid: [
+            {"message_index": 0, "role": "student", "text": "first student", "student_index": 0},
+            {"message_index": 1, "role": "tutor", "text": "Tutor answer."},
+        ],
+    )
+
+    session.add(MessageCache(chatlog_id=930, message_index=0, message_text="first student"))
+    session.commit()
+
+    label = client.post("/api/single-labels", json={"name": "preamble"}).json()
+    client.post(f"/api/single-labels/{label['id']}/activate")
+    r = client.get(f"/api/single-labels/{label['id']}/next")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["thread"][0]["role"] == "student"
+
+
 def test_next_focused_fallback_includes_tutor_from_cache(client, session, monkeypatch):
     """When Postgres thread fetch fails, rebuild thread from MessageCache including tutor snippets."""
     monkeypatch.setattr(queue_service, "_fetch_full_thread", lambda chatlog_id: [])

--- a/server/python/tests/test_single_label_routes.py
+++ b/server/python/tests/test_single_label_routes.py
@@ -263,6 +263,22 @@ def test_skip_conversation_endpoint_jumps_to_next_conversation(client, session):
     assert all(r.value == "skip" for r in skips)
 
 
+def test_patch_hybrid_explore_fraction(client, session):
+    lab = client.post("/api/single-labels", json={"name": "hybrid"}).json()
+    lid = lab["id"]
+    client.post(f"/api/single-labels/{lid}/activate")
+    r = client.patch(f"/api/single-labels/{lid}", json={"hybrid_explore_fraction": 0.42})
+    assert r.status_code == 200
+    active = client.get("/api/single-labels/active").json()
+    assert active["hybrid_explore_fraction"] == 0.42
+    assert active["hybrid_explore_effective"] == 0.42
+    r2 = client.patch(f"/api/single-labels/{lid}", json={"hybrid_explore_fraction": None})
+    assert r2.status_code == 200
+    active2 = client.get("/api/single-labels/active").json()
+    assert active2["hybrid_explore_fraction"] is None
+    assert active2["hybrid_explore_effective"] == 0.0
+
+
 def test_fetch_full_thread_cache_hits_avoid_second_call(monkeypatch):
     """Second call for the same chatlog_id should reuse cache without re-invoking the uncached fetcher."""
     queue_service._clear_thread_cache()

--- a/src/components/run/ConversationMeta.tsx
+++ b/src/components/run/ConversationMeta.tsx
@@ -1,6 +1,5 @@
-import { useId, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import type { SamplingPick } from '../../types'
+import { HoverTip } from './HoverTip'
 
 interface ConversationMetaProps {
   chatlogId: number
@@ -22,65 +21,6 @@ const MONO = 'font-mono text-[10px] tracking-[0.14em] uppercase'
 
 function Sep() {
   return <span className="mx-1.5 opacity-50 shrink-0">·</span>
-}
-
-function HoverTip({
-  label,
-  tip,
-  tone = 'faint',
-}: {
-  label: string
-  tip: string
-  tone?: 'faint' | 'ochre' | 'paper'
-}) {
-  const [open, setOpen] = useState(false)
-  const [coords, setCoords] = useState({ top: 0, left: 0 })
-  const triggerRef = useRef<HTMLSpanElement>(null)
-  const id = useId()
-  const toneClass =
-    tone === 'ochre' ? 'text-ochre' : tone === 'paper' ? 'text-on-surface' : 'text-faint'
-
-  const show = () => {
-    const el = triggerRef.current
-    if (el) {
-      const r = el.getBoundingClientRect()
-      setCoords({ top: r.bottom + 6, left: r.left })
-    }
-    setOpen(true)
-  }
-
-  const hide = () => setOpen(false)
-
-  return (
-    <span
-      className="relative inline shrink-0"
-      onMouseEnter={show}
-      onMouseLeave={hide}
-      onFocus={show}
-      onBlur={hide}
-    >
-      <span
-        ref={triggerRef}
-        tabIndex={0}
-        aria-describedby={open ? id : undefined}
-        className={`cursor-help border-b border-faint/70 outline-none ${toneClass}`}
-      >
-        {label}
-      </span>
-      {open &&
-        createPortal(
-          <span
-            id={id}
-            role="tooltip"
-            style={{ top: coords.top, left: coords.left }}
-            className="fixed z-[200] block w-[min(18rem,calc(100vw-3rem))] max-w-[18rem] rounded border border-edge bg-elevated px-2.5 py-2 text-[11px] font-sans normal-case tracking-normal leading-snug text-on-surface shadow-lg pointer-events-none"
-          >
-            {tip}
-          </span>,
-          document.body,
-        )}
-    </span>
-  )
 }
 
 function pickLabel(pick: SamplingPick): string {

--- a/src/components/run/ConversationMeta.tsx
+++ b/src/components/run/ConversationMeta.tsx
@@ -1,22 +1,252 @@
+import { useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { SamplingPick } from '../../types'
+
 interface ConversationMetaProps {
   chatlogId: number
   notebook: string | null
   turnCount: number
+  samplingPick?: SamplingPick | null
+  conversationStudentMessages?: number | null
+  pendingStudentMessageNumber?: number | null
+  neighborScoresAvailable?: boolean
+  neighborUncertaintyPct?: number | null
+  neighborNoveltyPct?: number | null
+  conversationNoveltyPct?: number | null
+  themeNoveltyPct?: number | null
+  studentSpecificityPct?: number | null
+  studentRarityPct?: number | null
 }
 
-export function ConversationMeta({ chatlogId, notebook, turnCount }: ConversationMetaProps) {
+const MONO = 'font-mono text-[10px] tracking-[0.14em] uppercase'
+
+function Sep() {
+  return <span className="mx-1.5 opacity-50 shrink-0">·</span>
+}
+
+function HoverTip({
+  label,
+  tip,
+  tone = 'faint',
+}: {
+  label: string
+  tip: string
+  tone?: 'faint' | 'ochre' | 'paper'
+}) {
+  const [open, setOpen] = useState(false)
+  const [coords, setCoords] = useState({ top: 0, left: 0 })
+  const triggerRef = useRef<HTMLSpanElement>(null)
+  const id = useId()
+  const toneClass =
+    tone === 'ochre' ? 'text-ochre' : tone === 'paper' ? 'text-on-surface' : 'text-faint'
+
+  const show = () => {
+    const el = triggerRef.current
+    if (el) {
+      const r = el.getBoundingClientRect()
+      setCoords({ top: r.bottom + 6, left: r.left })
+    }
+    setOpen(true)
+  }
+
+  const hide = () => setOpen(false)
+
   return (
-    <div className="px-12 py-[11px] border-t border-b border-edge-subtle bg-canvas">
-      <div className="max-w-[760px] mx-auto font-mono text-[10px] tracking-[0.14em] uppercase text-faint">
-        Conversation #{chatlogId}
-        {notebook && (
-          <>
-            <span className="mx-2.5 opacity-50">·</span>
-            {notebook}
-          </>
+    <span
+      className="relative inline shrink-0"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      <span
+        ref={triggerRef}
+        tabIndex={0}
+        aria-describedby={open ? id : undefined}
+        className={`cursor-help border-b border-faint/70 outline-none ${toneClass}`}
+      >
+        {label}
+      </span>
+      {open &&
+        createPortal(
+          <span
+            id={id}
+            role="tooltip"
+            style={{ top: coords.top, left: coords.left }}
+            className="fixed z-[200] block w-[min(18rem,calc(100vw-3rem))] max-w-[18rem] rounded border border-edge bg-elevated px-2.5 py-2 text-[11px] font-sans normal-case tracking-normal leading-snug text-on-surface shadow-lg pointer-events-none"
+          >
+            {tip}
+          </span>,
+          document.body,
         )}
-        <span className="mx-2.5 opacity-50">·</span>
-        {turnCount} turns
+    </span>
+  )
+}
+
+function pickLabel(pick: SamplingPick): string {
+  switch (pick) {
+    case 'explore':
+      return 'Explore'
+    case 'round_robin':
+      return 'Robin'
+    case 'continue':
+      return 'Continue'
+    default:
+      return 'Continue'
+  }
+}
+
+function pickTip(pick: SamplingPick): string {
+  switch (pick) {
+    case 'explore':
+      return (
+        'Explore queue opened this as a new conversation. We favor chats with specific, ' +
+        'uncommon student questions — not generic “help” or copy-pasted prompts.'
+      )
+    case 'round_robin':
+      return (
+        'Round-robin queue: next new conversation in a fair fixed order ' +
+        '(grouped by assignment, then shuffled).'
+      )
+    case 'continue':
+      return (
+        'You already labeled part of this chat — the queue keeps you here until ' +
+        'it is finished before picking new conversations.'
+      )
+    default:
+      return 'How this conversation was chosen from the labeling queue.'
+  }
+}
+
+function pickTone(pick: SamplingPick): 'faint' | 'ochre' | 'paper' {
+  if (pick === 'explore') return 'ochre'
+  if (pick === 'continue') return 'paper'
+  return 'faint'
+}
+
+export function ConversationMeta({
+  chatlogId,
+  notebook,
+  turnCount,
+  samplingPick,
+  conversationStudentMessages,
+  pendingStudentMessageNumber,
+  neighborScoresAvailable,
+  neighborUncertaintyPct,
+  neighborNoveltyPct,
+  conversationNoveltyPct,
+  themeNoveltyPct,
+  studentSpecificityPct,
+  studentRarityPct,
+}: ConversationMetaProps) {
+  const showQueue =
+    samplingPick != null &&
+    conversationStudentMessages != null &&
+    pendingStudentMessageNumber != null
+
+  return (
+    <div className={`px-12 py-5 border-t border-b border-edge-subtle bg-canvas ${MONO} text-faint`}>
+      <div className="max-w-[760px] mx-auto overflow-x-auto overflow-y-visible [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="inline-flex flex-nowrap items-center whitespace-nowrap min-w-min">
+          <span className="shrink-0 text-on-surface">Conversation #{chatlogId}</span>
+          {notebook && (
+            <>
+              <Sep />
+              <span className="shrink-0">{notebook}</span>
+            </>
+          )}
+          <Sep />
+          <span className="shrink-0">{turnCount} turns</span>
+
+          {showQueue && (
+            <>
+              <Sep />
+              <HoverTip
+                label={pickLabel(samplingPick)}
+                tip={pickTip(samplingPick)}
+                tone={pickTone(samplingPick)}
+              />
+              <Sep />
+              <HoverTip
+                label={`Msg ${pendingStudentMessageNumber}/${conversationStudentMessages}`}
+                tip={
+                  `Labeling student message ${pendingStudentMessageNumber} of ` +
+                  `${conversationStudentMessages} in this conversation (from the local cache).`
+                }
+              />
+              {neighborScoresAvailable &&
+                neighborUncertaintyPct != null &&
+                neighborNoveltyPct != null && (
+                  <>
+                    <Sep />
+                    <HoverTip
+                      label={`Amb ${neighborUncertaintyPct}%`}
+                      tip={
+                        'Ambiguity from your nearest labeled neighbors: similar past messages ' +
+                        'disagree on yes vs no. Higher means a harder borderline call.'
+                      }
+                    />
+                    <Sep />
+                    <HoverTip
+                      label={`Msg nov ${neighborNoveltyPct}%`}
+                      tip={
+                        'Message novelty: this student line looks different from individual ' +
+                        'messages you already labeled (embedding similarity).'
+                      }
+                    />
+                  </>
+                )}
+              {conversationNoveltyPct != null && (
+                <>
+                  <Sep />
+                  <HoverTip
+                    label={`Conv nov ${conversationNoveltyPct}%`}
+                    tip={
+                      'Conversation novelty: overall student messages in this chat look unlike ' +
+                      'chats where you already applied this label.'
+                    }
+                  />
+                </>
+              )}
+              {themeNoveltyPct != null && (
+                <>
+                  <Sep />
+                  <HoverTip
+                    label={`Theme ${themeNoveltyPct}%`}
+                    tip={
+                      'Theme novelty: the main topic of this chat is unlike themes in ' +
+                      'conversations you have already walked for this label.'
+                    }
+                  />
+                </>
+              )}
+              {studentSpecificityPct != null && (
+                <>
+                  <Sep />
+                  <HoverTip
+                    label={`Spec ${studentSpecificityPct}%`}
+                    tip={
+                      'Specificity: this looks like a real student question in their own words — ' +
+                      'not vague “help”, question numbers only, or pasted assignment/error text.'
+                    }
+                  />
+                </>
+              )}
+              {studentRarityPct != null && (
+                <>
+                  <Sep />
+                  <HoverTip
+                    label={`Rare ${studentRarityPct}%`}
+                    tip={
+                      'Rarity: this wording is uncommon compared to other student messages ' +
+                      'in the course corpus (many students did not ask it this way).'
+                    }
+                  />
+                </>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/run/DecisionDock.tsx
+++ b/src/components/run/DecisionDock.tsx
@@ -65,7 +65,12 @@ export function DecisionDock({
             >
               <KeyChip>⇧S</KeyChip> skip conversation
             </button>
-            <button onClick={onHandoff} className="hover:text-on-canvas transition-colors">
+            <button
+              type="button"
+              onClick={onHandoff}
+              className="hover:text-on-canvas transition-colors"
+              title="Open handoff readiness (Enter)"
+            >
               <KeyChip>⏎</KeyChip> hand off
             </button>
           </div>

--- a/src/components/run/HoverTip.tsx
+++ b/src/components/run/HoverTip.tsx
@@ -1,0 +1,63 @@
+import { useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+export function HoverTip({
+  label,
+  tip,
+  tone = 'faint',
+  className = '',
+}: {
+  label: string
+  tip: string
+  tone?: 'faint' | 'ochre' | 'paper'
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [coords, setCoords] = useState({ top: 0, left: 0 })
+  const triggerRef = useRef<HTMLSpanElement>(null)
+  const id = useId()
+  const toneClass =
+    tone === 'ochre' ? 'text-ochre' : tone === 'paper' ? 'text-on-surface' : 'text-faint'
+
+  const show = () => {
+    const el = triggerRef.current
+    if (el) {
+      const r = el.getBoundingClientRect()
+      setCoords({ top: r.bottom + 6, left: r.left })
+    }
+    setOpen(true)
+  }
+
+  const hide = () => setOpen(false)
+
+  return (
+    <span
+      className="relative inline shrink-0"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      <span
+        ref={triggerRef}
+        tabIndex={0}
+        aria-describedby={open ? id : undefined}
+        className={`cursor-help border-b border-faint/70 outline-none ${toneClass} ${className}`.trim()}
+      >
+        {label}
+      </span>
+      {open &&
+        createPortal(
+          <span
+            id={id}
+            role="tooltip"
+            style={{ top: coords.top, left: coords.left }}
+            className="fixed z-[200] block w-[min(18rem,calc(100vw-3rem))] max-w-[18rem] rounded border border-edge bg-elevated px-2.5 py-2 text-[11px] font-sans normal-case tracking-normal leading-snug text-on-surface shadow-lg pointer-events-none"
+          >
+            {tip}
+          </span>,
+          document.body,
+        )}
+    </span>
+  )
+}

--- a/src/components/run/ReadinessChip.tsx
+++ b/src/components/run/ReadinessChip.tsx
@@ -4,6 +4,9 @@ import type { ReadinessState } from '../../types'
 interface ReadinessChipProps {
   readiness: ReadinessState
   onHandoff: () => void
+  /** When set, the readiness panel is controlled by the parent (e.g. Enter shortcut). */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 const tierLabel: Record<ReadinessState['tier'], string> = {
@@ -33,8 +36,15 @@ const tierBlurb: Record<ReadinessState['tier'], string> = {
     'You have enough variety. Hand off whenever you’re ready — Gemini will classify the rest and surface low-confidence cases for review.',
 }
 
-export function ReadinessChip({ readiness, onHandoff }: ReadinessChipProps) {
-  const [open, setOpen] = useState(false)
+export function ReadinessChip({
+  readiness,
+  onHandoff,
+  open: openProp,
+  onOpenChange,
+}: ReadinessChipProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = openProp ?? internalOpen
+  const setOpen = onOpenChange ?? setInternalOpen
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -3,6 +3,7 @@ import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount } fr
 import { api } from '../../services/api'
 import { AssignmentPicker } from './AssignmentPicker'
 import { ReadinessChip } from './ReadinessChip'
+import { HoverTip } from './HoverTip'
 
 interface StripBarProps {
   label: SingleLabel
@@ -117,13 +118,16 @@ function HybridExploreMix({
   }
 
   return (
-    <div
-      className="inline-flex items-center gap-1.5 shrink-0 max-w-[200px] flex-wrap"
-      title="When choosing a new conversation (not while continuing one in progress), this % use explore scoring; the rest use round-robin order."
-    >
-      <span className="text-[9px] tracking-[0.06em] uppercase text-faint whitespace-nowrap">
-        new-chat explore
-      </span>
+    <div className="inline-flex items-center gap-1.5 shrink-0 max-w-[200px] flex-wrap">
+      <HoverTip
+        label="new-chat explore"
+        className="text-[9px] tracking-[0.06em] uppercase"
+        tip={
+          'When choosing a new conversation (not while continuing one you started), this % ' +
+          'uses Explore scoring — favoring specific, uncommon student help. The rest use ' +
+          'round-robin order. Finishing an in-progress chat is never affected.'
+        }
+      />
       <input
         type="number"
         min={0}

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -15,6 +15,8 @@ interface StripBarProps {
   onSampleHandoff?: (n: number) => void
   onAbort: () => void
   onLabelMetaUpdated?: () => void | Promise<void>
+  readinessOpen?: boolean
+  onReadinessOpenChange?: (open: boolean) => void
 }
 
 export function StripBar({
@@ -28,6 +30,8 @@ export function StripBar({
   onSampleHandoff,
   onAbort,
   onLabelMetaUpdated,
+  readinessOpen,
+  onReadinessOpenChange,
 }: StripBarProps) {
   return (
     <div className="flex items-center gap-[18px] px-12 pt-[14px] pb-2 text-muted text-[13px]">
@@ -58,7 +62,12 @@ export function StripBar({
       {import.meta.env.DEV && onSampleHandoff && (
         <SampleHandoffControl onSubmit={onSampleHandoff} />
       )}
-      <ReadinessChip readiness={readiness} onHandoff={onHandoff} />
+      <ReadinessChip
+        readiness={readiness}
+        onHandoff={onHandoff}
+        open={readinessOpen}
+        onOpenChange={onReadinessOpenChange}
+      />
       <button
         type="button"
         onClick={onAbort}

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount } from '../../types'
+import { api } from '../../services/api'
 import { AssignmentPicker } from './AssignmentPicker'
 import { ReadinessChip } from './ReadinessChip'
 
@@ -13,6 +14,7 @@ interface StripBarProps {
   onHandoff: () => void
   onSampleHandoff?: (n: number) => void
   onAbort: () => void
+  onLabelMetaUpdated?: () => void | Promise<void>
 }
 
 export function StripBar({
@@ -25,6 +27,7 @@ export function StripBar({
   onHandoff,
   onSampleHandoff,
   onAbort,
+  onLabelMetaUpdated,
 }: StripBarProps) {
   return (
     <div className="flex items-center gap-[18px] px-12 pt-[14px] pb-2 text-muted text-[13px]">
@@ -49,6 +52,9 @@ export function StripBar({
         selectedId={selectedAssignmentId}
         onSelect={onSelectAssignment}
       />
+      {onLabelMetaUpdated && (
+        <HybridExploreMix label={label} onSaved={onLabelMetaUpdated} />
+      )}
       {import.meta.env.DEV && onSampleHandoff && (
         <SampleHandoffControl onSubmit={onSampleHandoff} />
       )}
@@ -61,6 +67,81 @@ export function StripBar({
       >
         ✕ abort
       </button>
+    </div>
+  )
+}
+
+function HybridExploreMix({
+  label,
+  onSaved,
+}: {
+  label: SingleLabel
+  onSaved: () => void | Promise<void>
+}) {
+  const [pct, setPct] = useState(0)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    const eff = label.hybrid_explore_effective ?? 0.35
+    setPct(Math.round(eff * 100))
+  }, [label.hybrid_explore_effective, label.id])
+
+  const apply = async () => {
+    const v = Math.max(0, Math.min(100, pct)) / 100
+    setBusy(true)
+    try {
+      await api.patchSingleLabel(label.id, { hybrid_explore_fraction: v })
+      await onSaved()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const useDefault = async () => {
+    setBusy(true)
+    try {
+      await api.patchSingleLabel(label.id, { hybrid_explore_fraction: null })
+      await onSaved()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="inline-flex items-center gap-1.5 shrink-0 max-w-[200px] flex-wrap"
+      title="When choosing a new conversation (not while continuing one in progress), this % use explore scoring; the rest use round-robin order."
+    >
+      <span className="text-[9px] tracking-[0.06em] uppercase text-faint whitespace-nowrap">
+        new-chat explore
+      </span>
+      <input
+        type="number"
+        min={0}
+        max={100}
+        value={pct}
+        onChange={(e) => setPct(parseInt(e.target.value, 10) || 0)}
+        className="w-10 bg-transparent border-b border-edge focus:border-ochre-dim focus:outline-none text-on-surface text-center tabular-nums text-[11px]"
+      />
+      <span className="text-faint text-[10px]">%</span>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => void apply()}
+        className="text-ochre hover:text-paper text-[10px] disabled:opacity-40"
+      >
+        set
+      </button>
+      {label.hybrid_explore_fraction != null && (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void useDefault()}
+          className="text-faint hover:text-muted text-[10px] disabled:opacity-40"
+        >
+          default
+        </button>
+      )}
     </div>
   )
 }

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -44,6 +44,8 @@ export const mockApi = {
     mode: "single", phase: "queued", is_active: false, queue_position: 0,
     yes_count: 5, no_count: 0, skip_count: 0,
     conversations_walked: 1, total_conversations: 12,
+    hybrid_explore_fraction: null,
+    hybrid_explore_effective: 0.35,
   } satisfies SingleLabel,
 
   session: {

--- a/src/mocks/runMock.ts
+++ b/src/mocks/runMock.ts
@@ -18,6 +18,8 @@ export const mockActiveLabel: SingleLabel = {
   skip_count: 0,
   conversations_walked: 4,
   total_conversations: 12,
+  hybrid_explore_fraction: null,
+  hybrid_explore_effective: 0.35,
 }
 
 export const mockQueuedLabels: SingleLabel[] = [
@@ -34,6 +36,8 @@ export const mockQueuedLabels: SingleLabel[] = [
     skip_count: 0,
     conversations_walked: 0,
     total_conversations: 12,
+    hybrid_explore_fraction: null,
+    hybrid_explore_effective: 0.35,
   },
   {
     id: 3,
@@ -48,6 +52,8 @@ export const mockQueuedLabels: SingleLabel[] = [
     skip_count: 0,
     conversations_walked: 0,
     total_conversations: 12,
+    hybrid_explore_fraction: null,
+    hybrid_explore_effective: 0.35,
   },
 ]
 
@@ -127,6 +133,19 @@ export const mockFocusedMessage: FocusedMessage = {
   conversation_turn_count: fullThread.length,
   thread: fullThread,
   focus_index: 10,  // position of the focused turn in the full thread
+  sampling_pick: 'explore',
+  conversation_summary: null,
+  pick_rationale: 'Specific student help (not generic spam).',
+  conversation_student_messages: 7,
+  pending_student_message_number: 6,
+  neighbor_scores_available: true,
+  neighbor_uncertainty_pct: 72,
+  neighbor_novelty_pct: 41,
+  conversation_novelty_pct: 88,
+  theme_novelty_pct: 76,
+  student_specificity_pct: 91,
+  student_rarity_pct: 84,
+  sampling_hint: null,
 }
 
 export const mockReadiness: ReadinessState = {

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -44,6 +44,7 @@ export function LabelRunPage() {
   const [flash, setFlash] = useState<'yes' | 'no' | null>(null)
   const [assistNeighbors, setAssistNeighbors] = useState<AssistNeighbor[]>([])
   const [abortOpen, setAbortOpen] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
 
   // Mirrors activeLabel.id so async handlers can detect a label switch that
   // occurred while a decide/undo/skip was in flight, and avoid clobbering
@@ -104,7 +105,7 @@ export function LabelRunPage() {
     api.getAssist(
       activeLabel.id,
       focused.chatlog_id,
-      focused.thread[focused.focus_index].message_index,
+      focused.message_index,
       selectedAssignmentId ?? undefined,
     ).then((res) => {
       if (!cancelled) setAssistNeighbors(res.neighbors)
@@ -116,34 +117,39 @@ export function LabelRunPage() {
 
   // Refetch the page state. Called on mount, after decisions, after undo, after queue add.
   const refresh = useCallback(async () => {
-    const active = await api.getActiveSingleLabel()
-    setActiveLabel(active)
-    const [a, um] = await Promise.all([api.listAssignments(), api.getUnmappedCount()])
-    setAssignments(a)
-    setUnmapped(um)
-    if (active) {
-      const [next, ready, q] = await Promise.all([
-        api.getNextFocused(active.id, selectedAssignmentId ?? undefined),
-        api.getReadiness(active.id),
-        api.listSingleLabels({ phase: 'queued' }),
-      ])
-      setFocused(next)
-      setReadiness(ready)
-      setQueued(q)
-      // If we landed in reviewing phase (e.g., page reload mid-review), prime the queue.
-      if (active.phase === 'reviewing') {
-        const rq = await api.getReviewQueue(active.id)
-        setReviewQueue(rq)
-        setReviewIdx(0)
+    try {
+      setLoadError(null)
+      const active = await api.getActiveSingleLabel()
+      setActiveLabel(active)
+      const [a, um] = await Promise.all([api.listAssignments(), api.getUnmappedCount()])
+      setAssignments(a)
+      setUnmapped(um)
+      if (active) {
+        const [next, ready, q] = await Promise.all([
+          api.getNextFocused(active.id, selectedAssignmentId ?? undefined),
+          api.getReadiness(active.id),
+          api.listSingleLabels({ phase: 'queued' }),
+        ])
+        setFocused(next)
+        setReadiness(ready)
+        setQueued(q)
+        if (active.phase === 'reviewing') {
+          const rq = await api.getReviewQueue(active.id)
+          setReviewQueue(rq)
+          setReviewIdx(0)
+        } else {
+          setReviewQueue(null)
+          setReviewIdx(0)
+        }
       } else {
-        setReviewQueue(null)
-        setReviewIdx(0)
+        setFocused(null)
+        setReadiness(null)
+        const q = await api.listSingleLabels({ phase: 'queued' })
+        setQueued(q)
       }
-    } else {
-      setFocused(null)
-      setReadiness(null)
-      const q = await api.listSingleLabels({ phase: 'queued' })
-      setQueued(q)
+    } catch (e) {
+      console.error('LabelRunPage refresh failed', e)
+      setLoadError(e instanceof Error ? e.message : 'Failed to load run page')
     }
   }, [selectedAssignmentId])
 
@@ -357,6 +363,27 @@ export function LabelRunPage() {
     )
   }
 
+  if (loadError) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-4 px-8 text-center">
+        <p className="text-brick text-sm max-w-md">{loadError}</p>
+        <p className="text-faint text-xs max-w-md">
+          If the backend just restarted, wait a few seconds and retry. Ensure port-forward to Postgres is running.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setLoading(true)
+            void refresh().finally(() => setLoading(false))
+          }}
+          className="font-mono text-[11px] tracking-widest uppercase text-ochre hover:text-paper"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
   if (!activeLabel) {
     return <NoActiveLabel onCreated={refresh} />
   }
@@ -394,6 +421,7 @@ export function LabelRunPage() {
                   onHandoff={handleHandoff}
                   onSampleHandoff={handleSampleHandoff}
                   onAbort={() => setAbortOpen(true)}
+                  onLabelMetaUpdated={refresh}
                 />
                 <QueueLine
                   queued={queued}
@@ -474,6 +502,7 @@ export function LabelRunPage() {
                 onHandoff={handleHandoff}
                 onSampleHandoff={handleSampleHandoff}
                 onAbort={() => setAbortOpen(true)}
+                onLabelMetaUpdated={refresh}
               />
               <QueueLine
                 queued={queued}
@@ -486,6 +515,16 @@ export function LabelRunPage() {
               chatlogId={focused.chatlog_id}
               notebook={focused.notebook}
               turnCount={focused.conversation_turn_count}
+              samplingPick={focused.sampling_pick}
+              conversationStudentMessages={focused.conversation_student_messages}
+              pendingStudentMessageNumber={focused.pending_student_message_number}
+              neighborScoresAvailable={focused.neighbor_scores_available}
+              neighborUncertaintyPct={focused.neighbor_uncertainty_pct}
+              neighborNoveltyPct={focused.neighbor_novelty_pct}
+              conversationNoveltyPct={focused.conversation_novelty_pct}
+              themeNoveltyPct={focused.theme_novelty_pct}
+              studentSpecificityPct={focused.student_specificity_pct}
+              studentRarityPct={focused.student_rarity_pct}
             />
           </>
         }

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -44,6 +44,7 @@ export function LabelRunPage() {
   const [flash, setFlash] = useState<'yes' | 'no' | null>(null)
   const [assistNeighbors, setAssistNeighbors] = useState<AssistNeighbor[]>([])
   const [abortOpen, setAbortOpen] = useState(false)
+  const [readinessOpen, setReadinessOpen] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
   // Mirrors activeLabel.id so async handlers can detect a label switch that
@@ -86,6 +87,14 @@ export function LabelRunPage() {
   useEffect(() => {
     setFlash(null)
   }, [focused?.chatlog_id, focused?.focus_index])
+
+  useEffect(() => {
+    setReadinessOpen(false)
+  }, [activeLabel?.id])
+
+  const openHandoffPanel = useCallback(() => {
+    setReadinessOpen(true)
+  }, [])
 
   // Reset the assignment filter when the active label changes (handoff,
   // abort, queue activation). Otherwise the new label inherits the previous
@@ -338,7 +347,7 @@ export function LabelRunPage() {
     const onKey = (e: KeyboardEvent) => {
       const tag = (document.activeElement as HTMLElement | null)?.tagName ?? ''
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
-      if (noteOpen || abortOpen) return
+      if (noteOpen || abortOpen || readinessOpen) return
       const k = e.key.toLowerCase()
       if (k === 'l') {
         e.preventDefault()
@@ -353,7 +362,7 @@ export function LabelRunPage() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [noteOpen, abortOpen, activeLabel?.phase, reviewQueue, handleSkipConversation])
+  }, [noteOpen, abortOpen, readinessOpen, activeLabel?.phase, reviewQueue, handleSkipConversation])
 
   if (loading) {
     return (
@@ -492,18 +501,20 @@ export function LabelRunPage() {
         header={
           <>
             <div className="bg-canvas">
-              <StripBar
-                label={activeLabel}
-                readiness={readiness ?? defaultReadiness()}
-                assignments={assignments}
-                unmapped={unmapped}
-                selectedAssignmentId={selectedAssignmentId}
-                onSelectAssignment={(id) => setSelectedAssignmentId(id)}
-                onHandoff={handleHandoff}
-                onSampleHandoff={handleSampleHandoff}
-                onAbort={() => setAbortOpen(true)}
-                onLabelMetaUpdated={refresh}
-              />
+                <StripBar
+                  label={activeLabel}
+                  readiness={readiness ?? defaultReadiness()}
+                  assignments={assignments}
+                  unmapped={unmapped}
+                  selectedAssignmentId={selectedAssignmentId}
+                  onSelectAssignment={(id) => setSelectedAssignmentId(id)}
+                  onHandoff={handleHandoff}
+                  onSampleHandoff={handleSampleHandoff}
+                  onAbort={() => setAbortOpen(true)}
+                  onLabelMetaUpdated={refresh}
+                  readinessOpen={readinessOpen}
+                  onReadinessOpenChange={setReadinessOpen}
+                />
               <QueueLine
                 queued={queued}
                 onAdd={() => setNoteOpen(true)}
@@ -533,7 +544,7 @@ export function LabelRunPage() {
           <DecisionDock
             onDecide={handleDecide}
             onUndo={handleUndo}
-            onHandoff={handleHandoff}
+            onHandoff={openHandoffPanel}
             onSkipConversation={handleSkipConversation}
             disabled={busy}
             recent={recent}
@@ -544,8 +555,8 @@ export function LabelRunPage() {
         onNo={() => handleDecide('no')}
         onSkip={() => handleDecide('skip')}
         onUndo={handleUndo}
-        // INTENTIONALLY no onAcceptAi — original keyboard handler did not bind Enter.
-        disabled={busy || noteOpen || abortOpen}
+        onAcceptAi={recent ? undefined : openHandoffPanel}
+        disabled={busy || noteOpen || abortOpen || readinessOpen}
       />
       <NoteLabelPopover
         open={noteOpen}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -571,7 +571,12 @@ export const api = {
 
   patchSingleLabel: (
     id: number,
-    patch: { name?: string; description?: string; review_threshold?: number },
+    patch: {
+      name?: string
+      description?: string
+      review_threshold?: number
+      hybrid_explore_fraction?: number | null
+    },
   ): Promise<SingleLabelDetail> =>
     USE_MOCK ? Promise.resolve({
       id, name: patch.name ?? 'Mock Label', description: patch.description ?? null,

--- a/src/tests/run/ReadinessChip.test.tsx
+++ b/src/tests/run/ReadinessChip.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import { ReadinessChip } from '../../components/run/ReadinessChip'
+import type { ReadinessState } from '../../types'
+
+const readiness: ReadinessState = {
+  tier: 'amber',
+  yes_count: 2,
+  no_count: 1,
+  skip_count: 0,
+  conversations_walked: 2,
+  total_conversations: 10,
+  hint: 'Walk 3 more conversations for a green tier.',
+}
+
+describe('ReadinessChip', () => {
+  test('controlled open shows the handoff panel', () => {
+    render(
+      <ReadinessChip
+        readiness={readiness}
+        onHandoff={vi.fn()}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/Hand off to Gemini/i)).toBeInTheDocument()
+    expect(screen.getByText(/Walk 3 more conversations/i)).toBeInTheDocument()
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -268,7 +268,11 @@ export interface SingleLabel {
   skip_count: number
   conversations_walked: number
   total_conversations: number
+  hybrid_explore_fraction: number | null
+  hybrid_explore_effective: number
 }
+
+export type SamplingPick = 'continue' | 'explore' | 'round_robin'
 
 export interface ConversationTurn {
   message_index: number
@@ -284,6 +288,20 @@ export interface FocusedMessage {
   conversation_turn_count: number
   thread: ConversationTurn[]
   focus_index: number
+  sampling_pick: SamplingPick | null
+  conversation_summary: string | null
+  pick_rationale: string | null
+  conversation_student_messages: number | null
+  pending_student_message_number: number | null
+  neighbor_scores_available: boolean
+  neighbor_uncertainty_pct: number | null
+  neighbor_novelty_pct: number | null
+  conversation_novelty_pct: number | null
+  theme_novelty_pct: number | null
+  student_specificity_pct: number | null
+  student_rarity_pct: number | null
+  /** @deprecated use conversation_summary / pick_rationale */
+  sampling_hint: string | null
 }
 
 export type ReadinessTier = 'gray' | 'amber' | 'green'


### PR DESCRIPTION
## Summary
- Add hybrid explore sampling for single-label queue picks (continue / round-robin / explore).
- Add run UI for pick mode and sampling diagnostics.
- Fix /run threads starting with a leading tutor turn (#59).
