### PR TITLE
feat(export): one-hot CSV export for Summaries page

### DIFF
--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2539,6 +2539,109 @@ def get_analysis_temporal(
     }
 
 
+@app.get("/api/export/onehot-csv")
+def export_onehot_csv(db: Session = Depends(get_session)):
+    """Wide-format export for the single-label Summaries page: one row per
+    reviewed message, with each non-archived single-mode label as a one-hot
+    column (1 = value="yes"; 0 = "no"/"skip"/no decision). Joins external
+    Postgres to fetch user_email and the external conversation_id (UUID)."""
+    labels = db.exec(
+        select(LabelDefinition)
+        .where(
+            LabelDefinition.archived_at == None,
+            LabelDefinition.mode == "single",
+        )
+        .order_by(LabelDefinition.sort_order, LabelDefinition.id)
+    ).all()
+    label_id_to_name: dict = {lbl.id: lbl.name for lbl in labels}
+    label_columns = [lbl.name for lbl in labels]
+    active_label_ids = set(label_id_to_name.keys())
+
+    apps = db.exec(
+        select(
+            LabelApplication.chatlog_id,
+            LabelApplication.message_index,
+            LabelApplication.label_id,
+            LabelApplication.value,
+        )
+    ).all()
+
+    # (chatlog_id, message_index) -> set of label_ids with value="yes" (active only)
+    msg_labels: dict = {}
+    reviewed_keys: set = set()
+    for chatlog_id, message_index, label_id, value in apps:
+        if label_id not in active_label_ids:
+            continue
+        key = (chatlog_id, message_index)
+        reviewed_keys.add(key)
+        if value == "yes":
+            msg_labels.setdefault(key, set()).add(label_id)
+
+    if not reviewed_keys:
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(["message", "email", "conversation_id"] + label_columns)
+        return Response(
+            content=buf.getvalue(),
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": "attachment; filename=chatsight-onehot.csv"},
+        )
+
+    # message_text from local cache
+    needed_keys = reviewed_keys
+    text_by_key: dict = {}
+    for mc in db.exec(select(MessageCache)).all():
+        k = (mc.chatlog_id, mc.message_index)
+        if k in needed_keys:
+            text_by_key[k] = mc.message_text or ""
+
+    # email + external conversation_id per chatlog_id (best-effort: skip on failure)
+    chatlog_ids = sorted({k[0] for k in needed_keys})
+    email_by_chatlog: dict = {}
+    convid_by_chatlog: dict = {}
+    try:
+        with ext_engine.connect() as conn:
+            rows = conn.execute(
+                text("""
+                    SELECT MIN(id) AS chatlog_id,
+                           MAX(user_email) AS user_email,
+                           payload->>'conversation_id' AS conv_id
+                    FROM events
+                    WHERE event_type IN ('tutor_query', 'tutor_response')
+                      AND payload->>'conversation_id' IS NOT NULL
+                    GROUP BY payload->>'conversation_id'
+                    HAVING MIN(id) = ANY(:ids)
+                """),
+                {"ids": chatlog_ids},
+            ).mappings().all()
+            for r in rows:
+                email_by_chatlog[r["chatlog_id"]] = r["user_email"] or ""
+                convid_by_chatlog[r["chatlog_id"]] = r["conv_id"] or ""
+    except Exception as e:
+        logging.warning(f"export_onehot_csv: external DB unreachable, email/conv_id will be blank: {e}")
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["message", "email", "conversation_id"] + label_columns)
+    for key in sorted(needed_keys):
+        chatlog_id, _ = key
+        applied = msg_labels.get(key, set())
+        row = [
+            text_by_key.get(key, ""),
+            email_by_chatlog.get(chatlog_id, ""),
+            convid_by_chatlog.get(chatlog_id, ""),
+        ]
+        for lbl in labels:
+            row.append(1 if lbl.id in applied else 0)
+        writer.writerow(row)
+
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": "attachment; filename=chatsight-onehot.csv"},
+    )
+
+
 @app.get("/api/export/csv")
 def export_csv(db: Session = Depends(get_session)):
     rows = db.exec(

--- a/src/components/summaries/LabelRail.tsx
+++ b/src/components/summaries/LabelRail.tsx
@@ -1,9 +1,22 @@
+import { useState } from 'react'
+import { api } from '../../services/api'
 import type { HandoffSummaryItem } from '../../types'
 
 interface LabelRailProps {
   items: HandoffSummaryItem[]
   activeId: number | null
   onSelect: (id: number) => void
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
 }
 
 type Kind = 'done' | 'classifying' | 'failed' | 'archived'
@@ -31,10 +44,36 @@ function subtitle(item: HandoffSummaryItem): string {
 }
 
 export function LabelRail({ items, activeId, onSelect }: LabelRailProps) {
+  const [exporting, setExporting] = useState(false)
+
+  const handleExport = async () => {
+    if (exporting) return
+    setExporting(true)
+    try {
+      const blob = await api.exportOneHotCsv()
+      triggerDownload(blob, 'chatsight-onehot.csv')
+    } catch (e) {
+      console.error('CSV export failed', e)
+      alert('CSV export failed — see console for details.')
+    } finally {
+      setExporting(false)
+    }
+  }
+
   return (
     <aside className="w-[220px] shrink-0 border-r border-edge bg-canvas overflow-y-auto p-3">
-      <div className="font-mono text-[9.5px] tracking-[0.18em] uppercase text-faint mb-2 px-1.5">
-        Labels · {items.length}
+      <div className="flex items-center justify-between mb-2 px-1.5">
+        <span className="font-mono text-[9.5px] tracking-[0.18em] uppercase text-faint">
+          Labels · {items.length}
+        </span>
+        <button
+          onClick={handleExport}
+          disabled={exporting}
+          title="Export labeled messages as CSV (one-hot labels)"
+          className="font-mono text-[9.5px] tracking-[0.18em] uppercase text-ochre hover:text-paper disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {exporting ? '…' : 'Export ↓'}
+        </button>
       </div>
       {items.map((item) => {
         const isActive = item.label_id === activeId

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -258,6 +258,16 @@ export const api = {
     return res.blob()
   },
 
+  exportOneHotCsv: async (): Promise<Blob> => {
+    if (USE_MOCK) {
+      const header = 'message,email,conversation_id,Concept Question\n'
+      return new Blob([header + '"Hello",a@b.edu,abc-123,1\n'], { type: 'text/csv' })
+    }
+    const res = await fetch('/api/export/onehot-csv')
+    if (!res.ok) throw new Error(`${res.status} ${await res.text()}`)
+    return res.blob()
+  },
+
   // ── Recalibration ──────────────────────────────────────────────
   getRecalibration: (force = false): Promise<RecalibrationItem | null> =>
     USE_MOCK ? Promise.resolve(force ? mockApi.recalibrationForced() : mockApi.recalibration())


### PR DESCRIPTION
## Summary
- New `GET /api/export/onehot-csv` endpoint: one row per reviewed message, with one-hot columns for every active single-mode label (`1` = `value="yes"`; `0` otherwise). Joins external Postgres for `user_email` and the external `conversation_id` UUID (best-effort — left blank if the DB is unreachable, with a warning logged).
- `api.exportOneHotCsv()` client helper + mock-mode stub in `src/services/api.ts`.
- "Export ↓" button on the Summaries `LabelRail` header that downloads `chatsight-onehot.csv`.

## Test plan
- [ ] Backend up + at least one single-mode label with `yes`/`no` decisions → `curl http://localhost:8000/api/export/onehot-csv -o out.csv` returns a non-empty CSV with `message,email,conversation_id,<label1>,<label2>,…` header and one row per reviewed message.
- [ ] With `kubectl port-forward` running, verify `email` and `conversation_id` columns are populated.
- [ ] With the external DB unreachable, verify the endpoint still returns a CSV (email/conv_id blank) and logs a warning.
- [ ] In the UI: open `/summaries`, click the "Export ↓" button on the left rail → browser downloads `chatsight-onehot.csv`.
- [ ] Mock mode (`VITE_USE_MOCK=true`) → button still returns a tiny stub CSV.