### PR TITLE
fix(single-label): abort clears is_active and pops next queued

### DIFF
--- a/server/python/main.py
+++ b/server/python/main.py
@@ -4526,15 +4526,33 @@ def patch_single_label(
 
 @app.delete("/api/single-labels/{label_id}")
 def delete_single_label(label_id: int, db: Session = Depends(get_session)):
-    """Archives the label (matches the existing label-archive behavior).
-    Returns orphaned messages to the unlabeled pool implicitly via the
-    `archived_at` filter applied by other queries."""
+    """Archives the label. If it was the active one, also clears is_active
+    and auto-promotes the next queued label so the Run page swaps cleanly
+    (mirrors the handoff flow). Without clearing is_active, the active-label
+    query keeps returning this archived row and abort appears broken."""
     label = db.get(LabelDefinition, label_id)
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="single-label not found")
 
+    was_active = label.is_active
     label.archived_at = datetime.utcnow()
+    label.is_active = False
     db.add(label)
+
+    if was_active:
+        next_q = db.exec(
+            select(LabelDefinition)
+            .where(LabelDefinition.mode == "single")
+            .where(LabelDefinition.phase == "queued")
+            .where(LabelDefinition.archived_at == None)  # noqa: E711
+            .order_by(LabelDefinition.queue_position)
+        ).first()
+        if next_q:
+            next_q.is_active = True
+            next_q.phase = "labeling"
+            next_q.queue_position = None
+            db.add(next_q)
+
     db.commit()
     return {"ok": True}
 

--- a/server/python/tests/test_single_label_routes.py
+++ b/server/python/tests/test_single_label_routes.py
@@ -134,6 +134,49 @@ def test_close_auto_pops_next_queued(client):
     assert body["queue_position"] is None
 
 
+def test_delete_active_clears_is_active_and_pops_queued(client):
+    # Regression: deleting (abort) the active label must clear is_active so
+    # /active stops returning the archived row, and the next queued label
+    # should auto-promote (mirrors handoff/close behavior).
+    active = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{active['id']}/activate")
+    queued = client.post("/api/single-labels/queue", json={"name": "frustration"}).json()
+
+    r = client.delete(f"/api/single-labels/{active['id']}")
+    assert r.status_code == 200
+
+    # /active must NOT return the archived label.
+    active_now = client.get("/api/single-labels/active").json()
+    assert active_now is not None
+    assert active_now["id"] == queued["id"]
+    assert active_now["phase"] == "labeling"
+    assert active_now["queue_position"] is None
+
+
+def test_delete_non_active_does_not_disturb_active(client):
+    active = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{active['id']}/activate")
+    queued = client.post("/api/single-labels/queue", json={"name": "frustration"}).json()
+
+    r = client.delete(f"/api/single-labels/{queued['id']}")
+    assert r.status_code == 200
+
+    active_now = client.get("/api/single-labels/active").json()
+    assert active_now is not None
+    assert active_now["id"] == active["id"]
+
+
+def test_delete_lone_active_leaves_no_active(client):
+    active = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{active['id']}/activate")
+
+    r = client.delete(f"/api/single-labels/{active['id']}")
+    assert r.status_code == 200
+
+    active_now = client.get("/api/single-labels/active").json()
+    assert active_now is None
+
+
 def test_undo_removes_last_decision(client, session):
     _seed_messages(session)
     label = client.post("/api/single-labels", json={"name": "help"}).json()


### PR DESCRIPTION
## Summary
- `DELETE /api/single-labels/{id}` (abort) used to set `archived_at` but leave `is_active=True`. `GET /api/single-labels/active` filters only on `is_active=True` with no archived check, so the just-aborted label kept being returned as active and the Run page never swapped — abort looked completely broken.
- Now mirrors the close/handoff flow: clears `is_active`, and if the deleted label was the active one, auto-promotes the next non-archived queued label (`phase='queued'`) into `phase='labeling'`, `is_active=True`, `queue_position=NULL`.
- Adds 3 regression tests in `test_single_label_routes.py`:
  - `test_delete_active_clears_is_active_and_pops_queued` — active label aborted with queued label waiting → queued label becomes active.
  - `test_delete_non_active_does_not_disturb_active` — aborting a queued label leaves the active label alone.
  - `test_delete_lone_active_leaves_no_active` — aborting the only active label with nothing queued leaves no active label.

## Repro of the original bug
1. On `/run`, activate a single-label.
2. Click "✕ abort" in the StripBar.
3. Before this fix: page keeps showing the same label (zombie row with `archived_at` set AND `is_active=1`). Local DB confirmed this state.
4. After this fix: next queued label takes over, or the "no active label" prompt appears if the queue is empty.

## Test plan
- [x] `uv run pytest tests/test_single_label_routes.py -v` — 22/22 pass (4 delete tests + 18 existing).
- [x] `uv run pytest` — full backend suite still 295/295.
- [x] Manually on `/run`: activate a label, queue a second, abort the active → second auto-activates.
- [x] Abort the only active label with nothing queued → "No active label" view appears.
- [x] Abort a queued label (via QueueLine ✕) → active label unchanged.