### PR TITLE
fix(nav): auto-navigate to /run or /queue when toggling mode

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 // src/components/Navigation.tsx
-import { NavLink } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { Sun, Moon, Monitor, Layers, Target } from 'lucide-react'
 import { useTheme, type Theme } from '../hooks/useTheme'
 import { useMode, type Mode } from '../hooks/useMode'
@@ -11,10 +11,12 @@ const themeLabel: Record<Theme, string> = { light: 'Light', dark: 'Dark', system
 const modeIcon: Record<Mode, typeof Layers> = { multi: Layers, single: Target }
 const modeNext: Record<Mode, Mode> = { multi: 'single', single: 'multi' }
 const modeLabel: Record<Mode, string> = { multi: 'Multi-label', single: 'Single-label' }
+const modeLandingPath: Record<Mode, string> = { multi: '/queue', single: '/run' }
 
 export function Navigation() {
   const { theme, setTheme } = useTheme()
   const { mode, setMode } = useMode()
+  const navigate = useNavigate()
   const ThemeIcon = themeIcon[theme]
   const ModeIcon = modeIcon[mode]
 
@@ -60,7 +62,11 @@ export function Navigation() {
       </div>
       <div className="ml-auto flex items-center gap-2">
         <button
-          onClick={() => setMode(modeNext[mode])}
+          onClick={() => {
+            const next = modeNext[mode]
+            setMode(next)
+            navigate(modeLandingPath[next])
+          }}
           className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full border font-mono text-[10px] tracking-[0.05em] transition-colors ${
             mode === 'single'
               ? 'border-ochre-dim text-ochre'

--- a/src/tests/Navigation.test.tsx
+++ b/src/tests/Navigation.test.tsx
@@ -1,6 +1,6 @@
 // src/tests/Navigation.test.tsx
-import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { Navigation } from '../components/Navigation'
 import { ModeProvider } from '../hooks/useMode'
 
@@ -14,6 +14,26 @@ function renderNav() {
   )
 }
 
+function LocationProbe() {
+  const loc = useLocation()
+  return <span data-testid="path">{loc.pathname}</span>
+}
+
+function renderNavWithLocation(initialPath = '/summaries') {
+  return render(
+    <ModeProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Navigation />
+        <LocationProbe />
+      </MemoryRouter>
+    </ModeProvider>
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
 test('renders Queue, Labels, and Analysis links in multi-label mode (default)', () => {
   renderNav()
   expect(screen.getByText('Queue')).toBeInTheDocument()
@@ -25,4 +45,19 @@ test('shows mode toggle button', () => {
   renderNav()
   // Default mode is "multi"; the toggle button has a title attribute reflecting the current mode.
   expect(screen.getByTitle(/Mode: Multi-label/)).toBeInTheDocument()
+})
+
+test('clicking mode toggle from multi navigates to /run (single landing)', () => {
+  renderNavWithLocation('/summaries')
+  expect(screen.getByTestId('path').textContent).toBe('/summaries')
+  fireEvent.click(screen.getByTitle(/Mode: Multi-label/))
+  expect(screen.getByTestId('path').textContent).toBe('/run')
+})
+
+test('clicking mode toggle from single navigates to /queue (multi landing)', () => {
+  localStorage.setItem('chatsight-mode', 'single')
+  renderNavWithLocation('/summaries')
+  expect(screen.getByTestId('path').textContent).toBe('/summaries')
+  fireEvent.click(screen.getByTitle(/Mode: Single-label/))
+  expect(screen.getByTestId('path').textContent).toBe('/queue')
 })


### PR DESCRIPTION
Closes #60.

## Summary
- Mode toggle in the top nav used to only flip the mode flag, leaving the user on whatever page they were on (e.g. clicking it on `/summaries` did nothing visible aside from the link list reshuffling).
- Now it also navigates to the labeling landing page for the *new* mode: `/run` for single, `/queue` for multi. Mirrors how `LabelsPage` already pairs `setMode('single')` with `<Link to="/run">`.
- New `modeLandingPath` lookup keeps the routing decision next to the existing `modeNext` / `modeIcon` / `modeLabel` tables.
- Added 2 regression tests in `src/tests/Navigation.test.tsx` that render under `MemoryRouter` with a `LocationProbe`, click the toggle from `/summaries`, and assert the resulting path for each direction.

## Test plan
- [x] `npx vitest run src/tests/Navigation.test.tsx src/tests/useMode.test.tsx` — 7/7 pass.
- [x] `npm test -- --run` — full frontend suite 142/142.
- [x] `npx tsc --noEmit` — clean.
- [x] Manually: on `/summaries`, click the mode toggle from multi → page lands on `/run`. Toggle again → lands on `/queue`.
- [x] On `/run` already, click toggle → lands on `/queue` (no-op feel since it's the equivalent page).