### PR TITLE
Add human-vs-AI label indicator in /summaries (single-label)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-summaries-applied-by-indicator.md
+++ b/docs/superpowers/plans/2026-05-20-summaries-applied-by-indicator.md
@@ -1,0 +1,227 @@
+# Summaries AI-vs-Human Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a 👤 glyph on human-labeled messages in the `/summaries` single-label view (Browse list rows + detail pane); AI-labeled messages get no glyph.
+
+**Architecture:** Pure frontend. The `applied_by` field is already returned by the backend and present in the TS types (`MessageListItem`, `MessageDetail`). A single shared component (`AppliedByGlyph`) renders the glyph for `applied_by === 'human'` and exports a `HUMAN_GLYPH` constant so the detail pane reuses the same source of truth. The Browse row gains a fixed leading gutter column so alignment stays stable whether or not the glyph is present.
+
+**Tech Stack:** React 19 + TypeScript + Tailwind v4 (warm palette), Vitest + React Testing Library.
+
+---
+
+### Task 1: Human glyph in Browse list rows
+
+**Files:**
+- Create: `src/components/summaries/AppliedByGlyph.tsx`
+- Modify: `src/components/summaries/MessageListRow.tsx`
+- Test: `src/tests/summaries/MessageList.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests to `src/tests/summaries/MessageList.test.tsx`. The existing `items` array (top of file) has three rows, all `applied_by: 'ai'`. Add a fourth human row and assertions.
+
+First, change the `items` array to include a human row (replace the closing `]` of the existing array by adding this entry before it):
+
+```tsx
+  { chatlog_id: 4, message_index: 0, text: 'human reviewed this one',
+    confidence: 0.42, verdict: 'no', applied_by: 'human', flagged: false, has_note: false, notebook: null },
+```
+
+Then append these tests at the end of the file:
+
+```tsx
+test('human-labeled row shows the human glyph', () => {
+  render(<MessageList items={items} activeKey={null} onSelect={vi.fn()} height={2000} />)
+  expect(screen.getByTestId('applied-by-human-4-0')).toBeInTheDocument()
+})
+
+test('ai-labeled row shows no human glyph', () => {
+  render(<MessageList items={items} activeKey={null} onSelect={vi.fn()} height={2000} />)
+  expect(screen.queryByTestId('applied-by-human-1-0')).not.toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/tests/summaries/MessageList.test.tsx`
+Expected: the two new tests FAIL (testid `applied-by-human-4-0` not found); the existing tests still PASS.
+
+- [ ] **Step 3: Create the `AppliedByGlyph` component**
+
+Create `src/components/summaries/AppliedByGlyph.tsx`:
+
+```tsx
+export const HUMAN_GLYPH = '👤'
+export const HUMAN_TITLE = 'Labeled by human'
+
+interface AppliedByGlyphProps {
+  appliedBy: 'ai' | 'human' | null
+  chatlogId: number
+  messageIndex: number
+}
+
+export function AppliedByGlyph({ appliedBy, chatlogId, messageIndex }: AppliedByGlyphProps) {
+  if (appliedBy !== 'human') return null
+  return (
+    <span
+      data-testid={`applied-by-human-${chatlogId}-${messageIndex}`}
+      title={HUMAN_TITLE}
+      aria-label={HUMAN_TITLE}
+      className="text-[11px] leading-none"
+    >
+      {HUMAN_GLYPH}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 4: Wire the glyph into `MessageListRow`**
+
+Modify `src/components/summaries/MessageListRow.tsx`. Add the import at the top:
+
+```tsx
+import type { MessageListItem } from '../../types'
+import { AppliedByGlyph } from './AppliedByGlyph'
+```
+
+Change the grid template from `grid-cols-[38px_1fr]` to `grid-cols-[16px_38px_1fr]` and add the glyph cell as the first child of the row `<div>` (before the confidence `<span>`):
+
+```tsx
+    <div
+      onClick={onSelect}
+      className={`grid grid-cols-[16px_38px_1fr] items-center gap-2.5 px-5 py-2 cursor-pointer ${
+        active ? 'bg-elevated border-l-2 border-ochre pl-[18px]' : 'hover:bg-surface'
+      }`}
+    >
+      <span className="flex justify-center">
+        <AppliedByGlyph
+          appliedBy={item.applied_by}
+          chatlogId={item.chatlog_id}
+          messageIndex={item.message_index}
+        />
+      </span>
+      <span className={`font-mono text-[11px] text-right tabular-nums ${confColor(item.verdict)}`}>
+        {item.confidence !== null ? item.confidence.toFixed(2) : '—'}
+      </span>
+```
+
+Leave the rest of the row (the text `<span>` with flag/note) unchanged.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/tests/summaries/MessageList.test.tsx`
+Expected: all tests PASS (including the two new ones and the unchanged note-dot/flag-glyph tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/summaries/AppliedByGlyph.tsx src/components/summaries/MessageListRow.tsx src/tests/summaries/MessageList.test.tsx
+git commit -m "feat(summaries): show human glyph on human-labeled list rows"
+```
+
+---
+
+### Task 2: Human glyph in the detail pane (`VerdictBlock`)
+
+**Files:**
+- Modify: `src/components/summaries/VerdictBlock.tsx`
+- Test: `src/tests/summaries/VerdictBlock.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/summaries/VerdictBlock.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { VerdictBlock } from '../../components/summaries/VerdictBlock'
+
+const baseProps = {
+  verdict: 'no' as const,
+  confidence: 0.42,
+  matchedPattern: null,
+  rationale: null,
+  nearThreshold: false,
+  onAccept: vi.fn(),
+  onFlip: vi.fn(),
+  onFlag: vi.fn(),
+}
+
+test('shows the human glyph when applied by a human', () => {
+  render(<VerdictBlock {...baseProps} appliedBy="human" />)
+  expect(screen.getByTestId('verdict-applied-by-human')).toBeInTheDocument()
+})
+
+test('shows no human glyph when applied by AI', () => {
+  render(<VerdictBlock {...baseProps} appliedBy="ai" />)
+  expect(screen.queryByTestId('verdict-applied-by-human')).not.toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/tests/summaries/VerdictBlock.test.tsx`
+Expected: FAIL — `verdict-applied-by-human` not found (the component currently drops `appliedBy`).
+
+- [ ] **Step 3: Render `appliedBy` in `VerdictBlock`**
+
+Modify `src/components/summaries/VerdictBlock.tsx`.
+
+(a) Add the import at the top, after the existing `import type` line:
+
+```tsx
+import { useState } from 'react'
+import type { MessageVerdict } from '../../types'
+import { HUMAN_GLYPH, HUMAN_TITLE } from './AppliedByGlyph'
+```
+
+(b) Add `appliedBy` to the destructured parameters (it is already declared in `VerdictBlockProps` and passed by `FocusedMessage`, just not destructured):
+
+```tsx
+export function VerdictBlock({
+  verdict, confidence, appliedBy, matchedPattern, rationale, nearThreshold,
+  onAccept, onFlip, onFlag,
+}: VerdictBlockProps) {
+```
+
+(c) Render the glyph inside the header `flex` row, immediately after the verdict badge `</span>` (the one closing the `badgeStyles` span) and before the `matchedPattern` block:
+
+```tsx
+        {appliedBy === 'human' && (
+          <span
+            data-testid="verdict-applied-by-human"
+            title={HUMAN_TITLE}
+            className="inline-flex items-center gap-1 font-mono text-[10.5px] text-muted"
+          >
+            {HUMAN_GLYPH}
+            <span className="uppercase tracking-[0.08em]">human</span>
+          </span>
+        )}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/tests/summaries/VerdictBlock.test.tsx`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Type-check, full test run, and commit**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+Run: `npm test`
+Expected: full vitest suite PASSES.
+
+```bash
+git add src/components/summaries/VerdictBlock.tsx src/tests/summaries/VerdictBlock.test.tsx
+git commit -m "feat(summaries): show human glyph in detail pane verdict block"
+```
+
+---
+
+## Notes for the implementer
+
+- The warm palette tokens (`ochre`, `moss`, `brick`, `muted`, `paper`, `elevated`, `surface`, `canvas`, `edge`) are defined globally for single-label mode — no import needed; use them as Tailwind classes like existing code.
+- Do NOT touch `server/python/`, `src/services/api.ts`, or `src/types/index.ts` — `applied_by` is already plumbed through.
+- AI-labeled and `null` rows intentionally render no glyph; the 16px gutter column keeps confidence/text aligned regardless.

--- a/docs/superpowers/specs/2026-05-20-summaries-applied-by-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-20-summaries-applied-by-indicator-design.md
@@ -1,0 +1,93 @@
+# Summaries: AI-vs-human label indicator (single-label workflow)
+
+**Date:** 2026-05-20
+**Scope:** Frontend only — `/summaries` single-label view.
+
+## Problem
+
+In the single-label workflow, every message in `/summaries` carries a label that
+was applied either by Gemini (auto-label) or by a human (review/flip). The Browse
+list rows and the detail pane don't surface this distinction, so an instructor
+reading summaries can't tell which verdicts a human actually touched.
+
+## What already exists
+
+The data is fully wired end-to-end — no backend or type work is needed:
+
+- Backend `GET /api/single-labels/{label_id}/messages` returns `applied_by`
+  (`server/python/main.py`, in the `MessageListItem` construction).
+- `LabelApplication.applied_by` defaults to `"human"` and is set to `"ai"` by the
+  binary auto-label path; a human review/flip sets it back to `"human"`.
+- Frontend types already include the field:
+  - `MessageListItem.applied_by: 'ai' | 'human' | null` (`src/types/index.ts`)
+  - `MessageDetail.applied_by: 'ai' | 'human' | null` (`src/types/index.ts`)
+- `FocusedMessage` already passes `appliedBy={detail.applied_by}` into
+  `VerdictBlock` — but `VerdictBlock` never destructures or renders it.
+
+So this is purely a presentation gap in two components.
+
+## Design decisions
+
+- **Mark only human-labeled messages.** AI auto-labeling is expected to cover the
+  large majority of messages, so human-applied labels are the smaller, more
+  noteworthy set. AI rows are the baseline and get no glyph.
+- **Use an emoji glyph:** 👤 for human. (`applied_by === 'ai'` or `null` → render
+  nothing.)
+- **Single shared component** so the list row and detail pane stay visually
+  consistent and there is one place to change the glyph.
+
+## Components
+
+### 1. `src/components/summaries/AppliedByGlyph.tsx` (new)
+
+```tsx
+interface AppliedByGlyphProps {
+  appliedBy: 'ai' | 'human' | null
+  chatlogId: number
+  messageIndex: number
+}
+```
+
+- Renders `👤` only when `appliedBy === 'human'`; otherwise returns `null`.
+- Includes `title="Labeled by human"`, `aria-label="Labeled by human"`, and
+  `data-testid={`applied-by-human-${chatlogId}-${messageIndex}`}` — matching the
+  existing `flag-glyph-*` / `note-dot-*` testid convention in `MessageListRow`.
+- Styled small/subtle to fit the dense warm-palette rows (e.g.
+  `text-[11px] leading-none`).
+
+### 2. `src/components/summaries/MessageListRow.tsx`
+
+- Change the grid from `grid-cols-[38px_1fr]` to `grid-cols-[16px_38px_1fr]`,
+  adding a fixed leading gutter column for the glyph.
+- The glyph cell renders `<AppliedByGlyph .../>`. For AI/null rows the cell is
+  empty, so the fixed-width column keeps confidence and text aligned across all
+  rows (no horizontal jitter).
+
+### 3. `src/components/summaries/VerdictBlock.tsx`
+
+- Add `appliedBy` to the destructured props (currently received but dropped).
+- Render the human glyph in the verdict header `flex` row (alongside the verdict
+  badge), only when `appliedBy === 'human'`. Reuse `AppliedByGlyph` (the detail
+  pane has room, so a short "Human" text label next to the glyph is acceptable
+  but optional).
+
+## Testing
+
+- New vitest test for `MessageListRow`:
+  - `applied_by: 'human'` → `applied-by-human-{id}-{idx}` testid present.
+  - `applied_by: 'ai'` and `applied_by: null` → that testid absent.
+- Follows the existing summaries component test patterns in `src/tests/`.
+
+## Out of scope
+
+- Backend / API changes (`main.py`, `api.ts`).
+- TypeScript type changes (`applied_by` already present).
+- Any AI-vs-human classification or persistence logic.
+- The multi-label `/summaries` view and other pages.
+
+## Success criteria
+
+- Human-labeled messages show 👤 in both the Browse list and the detail pane.
+- AI-labeled / unlabeled messages show no glyph.
+- `npm run build` (type-check + build) passes.
+- New test passes (`npm test`).

--- a/src/components/summaries/AppliedByGlyph.tsx
+++ b/src/components/summaries/AppliedByGlyph.tsx
@@ -1,0 +1,22 @@
+export const HUMAN_GLYPH = '👤'
+export const HUMAN_TITLE = 'Labeled by human'
+
+interface AppliedByGlyphProps {
+  appliedBy: 'ai' | 'human' | null
+  chatlogId: number
+  messageIndex: number
+}
+
+export function AppliedByGlyph({ appliedBy, chatlogId, messageIndex }: AppliedByGlyphProps) {
+  if (appliedBy !== 'human') return null
+  return (
+    <span
+      data-testid={`applied-by-human-${chatlogId}-${messageIndex}`}
+      title={HUMAN_TITLE}
+      aria-label={HUMAN_TITLE}
+      className="text-[11px] leading-none"
+    >
+      {HUMAN_GLYPH}
+    </span>
+  )
+}

--- a/src/components/summaries/AppliedByGlyph.tsx
+++ b/src/components/summaries/AppliedByGlyph.tsx
@@ -11,6 +11,7 @@ export function AppliedByGlyph({ appliedBy, chatlogId, messageIndex }: AppliedBy
   if (appliedBy !== 'human') return null
   return (
     <span
+      role="img"
       data-testid={`applied-by-human-${chatlogId}-${messageIndex}`}
       title={HUMAN_TITLE}
       aria-label={HUMAN_TITLE}

--- a/src/components/summaries/MessageListRow.tsx
+++ b/src/components/summaries/MessageListRow.tsx
@@ -1,4 +1,5 @@
 import type { MessageListItem } from '../../types'
+import { AppliedByGlyph } from './AppliedByGlyph'
 
 interface MessageListRowProps {
   item: MessageListItem
@@ -16,10 +17,19 @@ export function MessageListRow({ item, active, onSelect }: MessageListRowProps) 
   return (
     <div
       onClick={onSelect}
-      className={`grid grid-cols-[38px_1fr] items-center gap-2.5 px-5 py-2 cursor-pointer ${
+      // active rows draw a 2px left border; pl-[18px] = px-5 (20px) minus that
+      // border so the glyph/confidence columns don't shift.
+      className={`grid grid-cols-[16px_38px_1fr] items-center gap-2.5 px-5 py-2 cursor-pointer ${
         active ? 'bg-elevated border-l-2 border-ochre pl-[18px]' : 'hover:bg-surface'
       }`}
     >
+      <span className="flex justify-center">
+        <AppliedByGlyph
+          appliedBy={item.applied_by}
+          chatlogId={item.chatlog_id}
+          messageIndex={item.message_index}
+        />
+      </span>
       <span className={`font-mono text-[11px] text-right tabular-nums ${confColor(item.verdict)}`}>
         {item.confidence !== null ? item.confidence.toFixed(2) : '—'}
       </span>

--- a/src/components/summaries/VerdictBlock.tsx
+++ b/src/components/summaries/VerdictBlock.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { MessageVerdict } from '../../types'
+import { HUMAN_GLYPH, HUMAN_TITLE } from './AppliedByGlyph'
 
 interface VerdictBlockProps {
   verdict: MessageVerdict | null
@@ -20,7 +21,7 @@ function badgeStyles(v: MessageVerdict | null) {
 }
 
 export function VerdictBlock({
-  verdict, confidence, matchedPattern, rationale, nearThreshold,
+  verdict, confidence, appliedBy, matchedPattern, rationale, nearThreshold,
   onAccept, onFlip, onFlag,
 }: VerdictBlockProps) {
   const [whyOpen, setWhyOpen] = useState(false)
@@ -33,6 +34,17 @@ export function VerdictBlock({
           <strong>{(verdict ?? '').toUpperCase()}</strong>
           {confidence !== null && <span className="text-paper">· {confidence.toFixed(2)}</span>}
         </span>
+        {appliedBy === 'human' && (
+          <span
+            data-testid="verdict-applied-by-human"
+            title={HUMAN_TITLE}
+            aria-label={HUMAN_TITLE}
+            className="inline-flex items-center gap-1 font-mono text-[10.5px] text-muted"
+          >
+            {HUMAN_GLYPH}
+            <span className="uppercase tracking-[0.08em]">human</span>
+          </span>
+        )}
         {matchedPattern && (
           <span className="text-ochre text-[12.5px] underline decoration-dotted underline-offset-[3px] cursor-pointer">"{matchedPattern}"</span>
         )}

--- a/src/components/summaries/VerdictBlock.tsx
+++ b/src/components/summaries/VerdictBlock.tsx
@@ -36,6 +36,7 @@ export function VerdictBlock({
         </span>
         {appliedBy === 'human' && (
           <span
+            role="img"
             data-testid="verdict-applied-by-human"
             title={HUMAN_TITLE}
             aria-label={HUMAN_TITLE}

--- a/src/tests/ProgressSidebar.test.tsx
+++ b/src/tests/ProgressSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from './test-utils'
 import { ProgressSidebar } from '../components/queue/ProgressSidebar'
 import { mockApi } from '../mocks'
 

--- a/src/tests/QueuePage.test.tsx
+++ b/src/tests/QueuePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from './test-utils'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
 import { QueuePage } from '../pages/QueuePage'

--- a/src/tests/Recalibration.test.tsx
+++ b/src/tests/Recalibration.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from './test-utils'
 import { MemoryRouter } from 'react-router-dom'
 import { vi, beforeEach } from 'vitest'
 import { QueuePage } from '../pages/QueuePage'

--- a/src/tests/decision/AiReviewDock.test.tsx
+++ b/src/tests/decision/AiReviewDock.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '../test-utils'
 import { vi, beforeEach } from 'vitest'
 import { AiReviewDock } from '../../components/decision/AiReviewDock'
 

--- a/src/tests/decision/DecisionWorkspace.test.tsx
+++ b/src/tests/decision/DecisionWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '../test-utils'
 import { vi, beforeEach } from 'vitest'
 import { DecisionWorkspace } from '../../components/decision/DecisionWorkspace'
 import type { ConversationTurn } from '../../types'
@@ -103,25 +103,10 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-test('pressing "y" fires onYes', () => {
-  const onYes = vi.fn()
-  render(
-    <DecisionWorkspace thread={thread} focusIndex={0} dock={<div />} onYes={onYes} />,
-  )
-  fireEvent.keyDown(window, { key: 'y' })
-  expect(onYes).toHaveBeenCalledTimes(1)
-})
-
-test('pressing "Y" (uppercase) also fires onYes', () => {
-  const onYes = vi.fn()
-  render(
-    <DecisionWorkspace thread={thread} focusIndex={0} dock={<div />} onYes={onYes} />,
-  )
-  fireEvent.keyDown(window, { key: 'Y' })
-  expect(onYes).toHaveBeenCalledTimes(1)
-})
-
-test('pressing "n", "s", "z", "Enter" fires the matching handlers', () => {
+// The yes-key bindings (a / A) are covered in DecisionWorkspaceKeybinds.test.tsx.
+// This asserts the remaining default decision keys dispatch to their handlers,
+// including plain Enter -> onAcceptAi (only covered here).
+test('default keys dispatch handlers: no=d, skip=Space, undo=s, acceptAi=Enter', () => {
   const onNo = vi.fn()
   const onSkip = vi.fn()
   const onUndo = vi.fn()
@@ -137,9 +122,9 @@ test('pressing "n", "s", "z", "Enter" fires the matching handlers', () => {
       onAcceptAi={onAcceptAi}
     />,
   )
-  fireEvent.keyDown(window, { key: 'n' })
+  fireEvent.keyDown(window, { key: 'd' })
+  fireEvent.keyDown(window, { key: ' ' })
   fireEvent.keyDown(window, { key: 's' })
-  fireEvent.keyDown(window, { key: 'z' })
   fireEvent.keyDown(window, { key: 'Enter' })
   expect(onNo).toHaveBeenCalledTimes(1)
   expect(onSkip).toHaveBeenCalledTimes(1)

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,5 +1,13 @@
 // src/tests/setup.ts
 import '@testing-library/jest-dom'
+import { beforeEach } from 'vitest'
+
+// Reset persisted UI state between tests so values like `chatsight-keybinds`
+// (set by keybind tests) and `chatsight-mode` don't leak across files and
+// cause order-dependent flakes. Runs before each test's own beforeEach.
+beforeEach(() => {
+  localStorage.clear()
+})
 
 // jsdom doesn't implement matchMedia — stub it for useTheme hook
 Object.defineProperty(window, 'matchMedia', {

--- a/src/tests/summaries/MessageList.test.tsx
+++ b/src/tests/summaries/MessageList.test.tsx
@@ -10,6 +10,8 @@ const items: MessageListItem[] = [
     confidence: 0.78, verdict: 'yes', applied_by: 'ai', flagged: false, has_note: true, notebook: null },
   { chatlog_id: 3, message_index: 0, text: 'flagged: can you help me with part 2',
     confidence: 0.15, verdict: 'no', applied_by: 'ai', flagged: true, has_note: false, notebook: null },
+  { chatlog_id: 4, message_index: 0, text: 'human reviewed this one',
+    confidence: 0.42, verdict: 'no', applied_by: 'human', flagged: false, has_note: false, notebook: null },
 ]
 
 test('renders one row per item', () => {
@@ -34,4 +36,20 @@ test('row with note shows a note dot', () => {
 test('row with flag shows a flag glyph', () => {
   render(<MessageList items={items} activeKey={null} onSelect={vi.fn()} height={2000} />)
   expect(screen.getByTestId('flag-glyph-3-0')).toBeInTheDocument()
+})
+
+test('human-labeled row shows the human glyph', () => {
+  render(<MessageList items={items} activeKey={null} onSelect={vi.fn()} height={2000} />)
+  expect(screen.getByTestId('applied-by-human-4-0')).toBeInTheDocument()
+})
+
+test('ai-labeled row shows no human glyph', () => {
+  render(<MessageList items={items} activeKey={null} onSelect={vi.fn()} height={2000} />)
+  expect(screen.queryByTestId('applied-by-human-1-0')).not.toBeInTheDocument()
+})
+
+test('null applied_by row shows no human glyph', () => {
+  const nullItems = [{ ...items[0], chatlog_id: 99, applied_by: null }]
+  render(<MessageList items={nullItems} activeKey={null} onSelect={vi.fn()} height={2000} />)
+  expect(screen.queryByTestId('applied-by-human-99-0')).not.toBeInTheDocument()
 })

--- a/src/tests/summaries/MessageList.test.tsx
+++ b/src/tests/summaries/MessageList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '../test-utils'
 import { vi } from 'vitest'
 import { MessageList } from '../../components/summaries/MessageList'
 import type { MessageListItem } from '../../types'

--- a/src/tests/summaries/VerdictBlock.test.tsx
+++ b/src/tests/summaries/VerdictBlock.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '../test-utils'
 import { vi } from 'vitest'
 import { VerdictBlock } from '../../components/summaries/VerdictBlock'
 

--- a/src/tests/summaries/VerdictBlock.test.tsx
+++ b/src/tests/summaries/VerdictBlock.test.tsx
@@ -59,3 +59,39 @@ test('accept button calls onAccept', () => {
   fireEvent.click(screen.getByText(/accept/i))
   expect(onAccept).toHaveBeenCalled()
 })
+
+test('shows the human glyph when applied by a human', () => {
+  render(
+    <VerdictBlock
+      verdict="no" confidence={0.42} appliedBy="human"
+      matchedPattern={null} rationale={null}
+      nearThreshold={false}
+      onAccept={vi.fn()} onFlip={vi.fn()} onFlag={vi.fn()}
+    />
+  )
+  expect(screen.getByTestId('verdict-applied-by-human')).toBeInTheDocument()
+})
+
+test('shows no human glyph when applied by AI', () => {
+  render(
+    <VerdictBlock
+      verdict="no" confidence={0.42} appliedBy="ai"
+      matchedPattern={null} rationale={null}
+      nearThreshold={false}
+      onAccept={vi.fn()} onFlip={vi.fn()} onFlag={vi.fn()}
+    />
+  )
+  expect(screen.queryByTestId('verdict-applied-by-human')).not.toBeInTheDocument()
+})
+
+test('shows no human glyph when applied_by is null', () => {
+  render(
+    <VerdictBlock
+      verdict={null} confidence={null} appliedBy={null}
+      matchedPattern={null} rationale={null}
+      nearThreshold={false}
+      onAccept={vi.fn()} onFlip={vi.fn()} onFlag={vi.fn()}
+    />
+  )
+  expect(screen.queryByTestId('verdict-applied-by-human')).not.toBeInTheDocument()
+})

--- a/src/tests/test-utils.tsx
+++ b/src/tests/test-utils.tsx
@@ -1,0 +1,18 @@
+// Shared test render helper. Wraps components in the providers they need at
+// runtime so unit tests don't have to repeat the boilerplate. Currently this is
+// KeybindProvider (required by useKeybinds, used across queue/decision UI).
+import type { ReactElement, ReactNode } from 'react'
+import { render as rtlRender, type RenderOptions } from '@testing-library/react'
+import { KeybindProvider } from '../hooks/useKeybinds'
+
+function AllProviders({ children }: { children: ReactNode }) {
+  return <KeybindProvider>{children}</KeybindProvider>
+}
+
+function render(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
+  return rtlRender(ui, { wrapper: AllProviders, ...options })
+}
+
+// Re-export everything from RTL, then override `render` with the wrapped version.
+export * from '@testing-library/react'
+export { render }


### PR DESCRIPTION
## Summary
- Show a 👤 indicator in the `/summaries` single-label view for messages whose label was applied by a **human** (the minority case); AI-labeled messages show no glyph. Appears on both the Browse list rows and the detail pane.
- New shared `AppliedByGlyph` component (`HUMAN_GLYPH`/`HUMAN_TITLE` single source of truth); `MessageListRow` gains a leading gutter column; `VerdictBlock` reuses the constants. `role="img"` + `aria-label` for screen readers.
- UI-only: `applied_by` was already returned by the backend and present in the TS types — no backend, API, or type changes.
- Also fixes a pre-existing test baseline (regression from #66 keybinds): shared `test-utils` render wrapping `KeybindProvider`, `localStorage` reset between tests to stop cross-file pollution, and removal of stale `y/n/s/z` keyboard tests superseded by `DecisionWorkspaceKeybinds.test.tsx`.

## Test Plan
- [x] `npm test` — 24 files / 158 tests pass (was 63 failing before the baseline fix)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Manual: in `/summaries` single-label mode, human-reviewed messages show 👤 in the Browse list and detail pane; AI-labeled ones don't.