### PR TITLE
Study bundle: study fixes, sampling continuity, recalibration, handoff UX

### DIFF
--- a/docs/superpowers/plans/2026-06-01-week-scoped-routes.md
+++ b/docs/superpowers/plans/2026-06-01-week-scoped-routes.md
@@ -1,0 +1,559 @@
+# Week-Scoped Routes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hard-lock `/queue` (multi-label) to DSC 10 Winter-2026 Week 3 (Lab 1 + HW 1) and `/run` (single-label) to Week 8 (Lab 5 + HW 5), server-side, including the Gemini handoff classification.
+
+**Architecture:** A single source-of-truth module `study_scope.py` defines per-week assignment-name sets and reuses `assignment_service._canonical_name` to decide whether a `MessageCache.notebook` is in scope. Scope is keyed on label **mode** (multi → Week 3, single → Week 8) because `next_message_for_label` is shared. Enforcement is unconditional and ignores any client `assignment_id`.
+
+**Tech Stack:** FastAPI + SQLModel + SQLite (backend), pytest, React + TypeScript + Vite (frontend).
+
+---
+
+## File Structure
+
+- **Create** `server/python/study_scope.py` — scope constants + predicate helpers. One responsibility: "is this notebook in the locked week?".
+- **Create** `server/python/tests/test_study_scope.py` — unit + route tests.
+- **Modify** `server/python/queue_service.py` — scope `next_message_for_label` by mode.
+- **Modify** `server/python/decision_service.py` — scope `compute_readiness` denominator.
+- **Modify** `server/python/main.py` — scope `/api/queue`, `/api/queue/stats`, `/api/queue/position`, and `_do_classification`.
+- **Modify** `src/components/run/StripBar.tsx` — replace assignment picker with a fixed-scope label.
+- **Modify** `src/pages/QueuePage.tsx` — add a fixed-scope banner.
+
+---
+
+## Task 1: `study_scope` module
+
+**Files:**
+- Create: `server/python/study_scope.py`
+- Test: `server/python/tests/test_study_scope.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/python/tests/test_study_scope.py
+import study_scope
+
+
+def test_queue_scope_matches_week3_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab1.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("lab01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw1.ipynb", study_scope.QUEUE_SCOPE)
+
+
+def test_run_scope_matches_week8_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab5.ipynb", study_scope.RUN_SCOPE)
+    assert study_scope.notebook_in_scope("hw05.ipynb", study_scope.RUN_SCOPE)
+
+
+def test_out_of_scope_and_none():
+    assert not study_scope.notebook_in_scope("lab2.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab15.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab1.ipynb", study_scope.RUN_SCOPE)
+    assert not study_scope.notebook_in_scope(None, study_scope.QUEUE_SCOPE)
+
+
+def test_scope_for_mode():
+    assert study_scope.scope_for_mode("single") == study_scope.RUN_SCOPE
+    assert study_scope.scope_for_mode("multi") == study_scope.QUEUE_SCOPE
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'study_scope'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# server/python/study_scope.py
+"""Study fixture: hard-locked per-week assignment scopes for the user study.
+
+`/queue` (multi-label) is locked to DSC 10 Winter-2026 Week 3 (Lab 1 + HW 1);
+`/run` (single-label) is locked to Week 8 (Lab 5 + HW 5). Scope is expressed in
+canonical assignment names (the same vocabulary as assignment_service) so it does
+not depend on AssignmentMapping rows existing. Weeks come from
+https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
+data/milestones/dsc10_wi26.json).
+"""
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from assignment_service import _canonical_name
+from models import MessageCache
+
+QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
+RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
+
+
+def scope_for_mode(mode: str) -> set[str]:
+    """Single-label runs are Week 8; everything else (multi/onboarding) is Week 3."""
+    return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
+
+
+def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
+    return notebook is not None and _canonical_name(notebook) in names
+
+
+def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
+    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`."""
+    rows = session.exec(
+        select(
+            MessageCache.chatlog_id,
+            MessageCache.message_index,
+            MessageCache.notebook,
+        )
+    ).all()
+    return {
+        (cid, midx)
+        for cid, midx, nb in rows
+        if notebook_in_scope(nb, names)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/study_scope.py server/python/tests/test_study_scope.py
+git commit -m "feat: study_scope module locking weeks to assignment-name sets"
+```
+
+---
+
+## Task 2: Scope the multi-label `/queue` endpoints (Week 3)
+
+**Files:**
+- Modify: `server/python/main.py` (`get_queue`, `get_queue_stats`, `get_queue_position`)
+- Test: `server/python/tests/test_study_scope.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_study_scope.py`. This uses the existing test fixture pattern (see `server/python/tests/conftest.py`): `client` is a `TestClient` over the app with an in-memory DB and a `session` fixture for seeding.
+
+```python
+from models import MessageCache
+
+
+def _seed(session, chatlog_id, message_index, notebook):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id, message_index=message_index,
+        message_text=f"msg {chatlog_id}.{message_index}", notebook=notebook,
+    ))
+    session.commit()
+
+
+def test_queue_returns_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")   # in scope (Week 3)
+    _seed(session, 2, 0, "lab5.ipynb")   # out of scope (Week 8)
+    _seed(session, 3, 0, "lab2.ipynb")   # out of scope
+    resp = client.get("/api/queue?limit=50")
+    assert resp.status_code == 200
+    ids = {row["chatlog_id"] for row in resp.json()}
+    assert ids == {1}
+
+
+def test_queue_stats_counts_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")
+    _seed(session, 2, 0, "hw1.ipynb")
+    _seed(session, 3, 0, "lab5.ipynb")
+    stats = client.get("/api/queue/stats").json()
+    assert stats["total_messages"] == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -k queue -v`
+Expected: FAIL — `test_queue_returns_only_week3` sees `{1, 2, 3}`; `total_messages` is 3.
+
+- [ ] **Step 3: Implement — scope `get_queue` candidates**
+
+In `server/python/main.py`, add the import near the other service imports (next to `import assignment_service`):
+
+```python
+import study_scope
+```
+
+In `get_queue`, replace the candidate-building block:
+
+```python
+    # Query from cache instead of external DB CTE
+    all_cached = db.exec(select(MessageCache)).all()
+
+    candidates = [
+        c for c in all_cached
+        if (c.chatlog_id, c.message_index) not in excluded
+    ]
+```
+
+with:
+
+```python
+    # Query from cache instead of external DB CTE. Study lock: Week 3 only.
+    all_cached = db.exec(select(MessageCache)).all()
+
+    candidates = [
+        c for c in all_cached
+        if (c.chatlog_id, c.message_index) not in excluded
+        and study_scope.notebook_in_scope(c.notebook, study_scope.QUEUE_SCOPE)
+    ]
+```
+
+- [ ] **Step 4: Implement — scope `get_queue_stats`**
+
+Replace the body of `get_queue_stats` with an in-scope-keyed version:
+
+```python
+@app.get("/api/queue/stats")
+def get_queue_stats(db: Session = Depends(get_session)):
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
+    return {
+        "total_messages": len(in_scope),
+        "labeled_count": labeled_count,
+        "skipped_count": skipped_count,
+    }
+```
+
+- [ ] **Step 5: Implement — scope `get_queue_position`**
+
+Replace the body of `get_queue_position` with:
+
+```python
+@app.get("/api/queue/position")
+def get_queue_position(db: Session = Depends(get_session)):
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
+    total = len(in_scope)
+    total_remaining = max(0, total - labeled_count - skipped_count)
+    position = labeled_count + skipped_count + 1
+    return {"position": position, "total_remaining": total_remaining}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: PASS (all, including the two new queue tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/python/main.py server/python/tests/test_study_scope.py
+git commit -m "feat: lock /queue endpoints to Week 3 (Lab 1 + HW 1)"
+```
+
+---
+
+## Task 3: Scope single-label `next_message_for_label` (Week 8)
+
+**Files:**
+- Modify: `server/python/queue_service.py` (`next_message_for_label`)
+- Test: `server/python/tests/test_study_scope.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_study_scope.py`:
+
+```python
+import queue_service
+from models import LabelDefinition
+
+
+def test_run_next_returns_only_week8(session):
+    # Seed an in-scope (Week 8) and an out-of-scope conversation.
+    _seed(session, 10, 0, "lab5.ipynb")   # Week 8 — in scope for single mode
+    _seed(session, 11, 0, "lab1.ipynb")   # Week 3 — out of scope for single mode
+    label = LabelDefinition(name="needs help", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+
+    picks = set()
+    for _ in range(10):
+        payload = queue_service.next_message_for_label(session, label.id)
+        if payload:
+            picks.add(payload["chatlog_id"])
+    assert picks <= {10}
+    assert 11 not in picks
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py::test_run_next_returns_only_week8 -v`
+Expected: FAIL — conversation 11 is also picked.
+
+- [ ] **Step 3: Implement — filter `cache_rows` by mode scope**
+
+In `server/python/queue_service.py`, add the import at the top (with the other local imports):
+
+```python
+import study_scope
+```
+
+In `next_message_for_label`, find the cache query block:
+
+```python
+    if assignment_id is not None:
+        cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
+    cache_rows = session.exec(cache_q).all()
+```
+
+Replace it with (note: `cache_rows` columns are `(_id, cid, midx, text, notebook, assign)` — `notebook` is index 4):
+
+```python
+    if assignment_id is not None:
+        cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
+    cache_rows = session.exec(cache_q).all()
+
+    # Study lock: restrict to the week tied to this label's mode
+    # (single -> Week 8, multi/onboarding -> Week 3). Unconditional; the
+    # client assignment_id filter above only narrows further.
+    _label = session.get(LabelDefinition, label_id)
+    _scope = study_scope.scope_for_mode(_label.mode if _label else "multi")
+    cache_rows = [
+        row for row in cache_rows
+        if study_scope.notebook_in_scope(row[4], _scope)
+    ]
+```
+
+(`LabelDefinition` is already imported in `queue_service.py`; confirm with `grep "LabelDefinition" server/python/queue_service.py` — it is used later in the same function.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py::test_run_next_returns_only_week8 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/queue_service.py server/python/tests/test_study_scope.py
+git commit -m "feat: scope single-label /run selection to Week 8 by mode"
+```
+
+---
+
+## Task 4: Scope readiness denominator + handoff classification (Week 8)
+
+**Files:**
+- Modify: `server/python/decision_service.py` (`compute_readiness`)
+- Modify: `server/python/main.py` (`_do_classification`)
+- Test: `server/python/tests/test_study_scope.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_study_scope.py`:
+
+```python
+import decision_service
+
+
+def test_readiness_total_convs_scoped_to_week8(session):
+    _seed(session, 20, 0, "lab5.ipynb")   # Week 8
+    _seed(session, 21, 0, "lab1.ipynb")   # Week 3
+    _seed(session, 22, 0, "lab2.ipynb")   # other
+    label = LabelDefinition(name="x", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+    state = decision_service.compute_readiness(session, label.id)
+    assert state["total_conversations"] == 1
+
+
+def test_classification_pending_excludes_out_of_scope(session, monkeypatch):
+    import main
+    _seed(session, 30, 0, "lab5.ipynb")   # Week 8 — should be classified
+    _seed(session, 31, 0, "lab1.ipynb")   # Week 3 — must be skipped
+    label = LabelDefinition(name="y", mode="single", phase="labeling",
+                            review_threshold=0.5)
+    session.add(label)
+    session.commit()
+
+    captured = {}
+
+    def fake_parallel(db, label, pending, yes_examples, no_examples):
+        captured["pending"] = pending
+        return {"yes": 0, "no": 0, "skip": 0, "errors": 0}
+
+    monkeypatch.setattr(main, "_classify_in_parallel", fake_parallel)
+    # Force the inline parallel path (small job) by keeping pending tiny.
+    main._do_classification(session, label)
+    keys = {(c, i) for (c, i, _t) in captured["pending"]}
+    assert (30, 0) in keys
+    assert (31, 0) not in keys
+```
+
+NOTE: `_classify_in_parallel`'s real signature must be confirmed before writing the `fake_parallel` stub — open `server/python/main.py` at `def _classify_in_parallel(` and match its parameters exactly. If the small-job path calls a differently named function, stub that one instead. Adjust the stub signature to match; the assertion on `captured["pending"]` is the invariant that matters.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -k "readiness or classification" -v`
+Expected: FAIL — `total_conversations` is 3; classification pending includes `(31, 0)`.
+
+- [ ] **Step 3: Implement — scope `compute_readiness`**
+
+In `server/python/decision_service.py`, add the import at the top:
+
+```python
+import study_scope
+```
+
+Find:
+
+```python
+    total_convs = session.exec(
+        select(MessageCache.chatlog_id).distinct()
+    ).all()
+    total_convs_count = len(total_convs)
+```
+
+Replace with:
+
+```python
+    # Study lock: single-label runs are Week 8 — count only in-scope convs.
+    label = session.get(LabelDefinition, label_id)
+    scope = study_scope.scope_for_mode(label.mode if label else "single")
+    in_scope = study_scope.in_scope_keys(session, scope)
+    total_convs_count = len({cid for cid, _ in in_scope})
+```
+
+(`LabelDefinition` and `MessageCache` are already imported in `decision_service.py`; verify with `grep "^from models" server/python/decision_service.py`.)
+
+- [ ] **Step 4: Implement — scope `_do_classification`**
+
+In `server/python/main.py` (`study_scope` already imported in Task 2), find in `_do_classification`:
+
+```python
+    cached = db.exec(
+        select(MessageCache.chatlog_id, MessageCache.message_index, MessageCache.message_text)
+    ).all()
+    pending = [(c, i, t) for (c, i, t) in cached if (c, i) not in decided_keys]
+```
+
+Replace with:
+
+```python
+    cached = db.exec(
+        select(MessageCache.chatlog_id, MessageCache.message_index, MessageCache.message_text)
+    ).all()
+    # Study lock: only classify the week this label's mode is scoped to
+    # (single -> Week 8). Keeps Gemini handoff bounded and fast.
+    scope = study_scope.scope_for_mode(label.mode)
+    in_scope = study_scope.in_scope_keys(db, scope)
+    pending = [
+        (c, i, t) for (c, i, t) in cached
+        if (c, i) not in decided_keys and (c, i) in in_scope
+    ]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 6: Run the full backend suite (no regressions)**
+
+Run: `cd server/python && uv run pytest`
+Expected: PASS. If pre-existing unrelated tests assume the full corpus appears in `/queue` or `/run`, note them — they may need a scope-aware seed, but do not loosen the lock to make them pass without confirming with the spec.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/python/decision_service.py server/python/main.py server/python/tests/test_study_scope.py
+git commit -m "feat: bound readiness + Gemini handoff classification to Week 8"
+```
+
+---
+
+## Task 5: Frontend — replace assignment pickers with fixed-scope labels
+
+**Files:**
+- Modify: `src/components/run/StripBar.tsx`
+- Modify: `src/pages/QueuePage.tsx`
+
+- [ ] **Step 1: Replace the `/run` assignment picker with a scope label**
+
+In `src/components/run/StripBar.tsx`, find the `AssignmentPicker` usage:
+
+```tsx
+            <AssignmentPicker
+              assignments={assignments}
+              unmapped={unmapped}
+              selectedId={selectedAssignmentId}
+              onSelect={onSelectAssignment}
+            />
+```
+
+Replace with a static label (the server ignores `assignment_id` now):
+
+```tsx
+            <span className="inline-flex items-center gap-2 font-mono text-[11px] text-muted">
+              <span className="text-[9px] tracking-[0.06em] uppercase text-faint">scope</span>
+              <span className="text-fg">Week 8 — Lab 5 &amp; HW 5</span>
+            </span>
+```
+
+Leave the `AssignmentPicker` import in place only if still referenced elsewhere; if it becomes unused, remove the import to keep the type-check clean.
+
+- [ ] **Step 2: Add a fixed-scope banner to `/queue`**
+
+In `src/pages/QueuePage.tsx`, locate the top of the page's main returned JSX (the outermost container that holds the queue header). Add, as the first child inside that container:
+
+```tsx
+      <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-neutral-800 bg-neutral-900 px-3 py-1.5 font-mono text-[11px] text-neutral-300">
+        <span className="text-[9px] uppercase tracking-[0.06em] text-neutral-500">scope</span>
+        <span>Week 3 — Lab 1 &amp; HW 1</span>
+      </div>
+```
+
+(Place it where it reads naturally above the message card; match the surrounding indentation.)
+
+- [ ] **Step 3: Type-check and build**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. Then `npm run build` — expected: success.
+
+- [ ] **Step 4: Run frontend tests (no regressions)**
+
+Run: `npm test`
+Expected: PASS. If a StripBar test asserts the assignment picker is rendered, update it to assert the scope label instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/run/StripBar.tsx src/pages/QueuePage.tsx
+git commit -m "feat: show fixed week-scope label, drop assignment picker on locked routes"
+```
+
+---
+
+## Final verification
+
+- [ ] `cd server/python && uv run pytest` — all pass.
+- [ ] `npx tsc --noEmit && npm test` — all pass.
+- [ ] Manual smoke (optional, needs DB tunnel): start backend + frontend, confirm `/queue` shows only Lab 1 / HW 1 messages and `/run` shows only Lab 5 / HW 5, and that triggering handoff classifies only Week 8.

--- a/docs/superpowers/plans/2026-06-03-label-suggestions.md
+++ b/docs/superpowers/plans/2026-06-03-label-suggestions.md
@@ -1,0 +1,952 @@
+# Label Name Suggestions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace browser contact autofill on single-label name inputs with a custom autocomplete dropdown populated by concept candidates filtered to exclude semantically similar existing labels.
+
+**Architecture:** A new backend service (`name_suggestion_service.py`) embeds both concept candidate names and existing label names via `gemini-embedding-001`, filters candidates where cosine similarity to any existing label exceeds 0.75, and returns a clean list. A `useLabelSuggestions` hook fetches this once on mount in `LabelRunPage`. A reusable `LabelNameInput` component wraps `<input>` + dropdown and is wired into `StripBar` and `NoteLabelPopover` — the only two single-label name entry points. Multi-label components (`NewLabelPopover`, `LabelsPage`, `QueuePage`) are not touched.
+
+**Tech Stack:** Python/FastAPI, SQLModel, `google-genai` SDK, numpy (already installed), React 18, TypeScript, Tailwind v4, Vitest + React Testing Library
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `server/python/name_suggestion_service.py` | Cosine-similarity filtering + Gemini embedding call |
+| Modify | `server/python/main.py` | Add `GET /api/concepts/name-suggestions` endpoint |
+| Create | `server/python/tests/test_name_suggestions.py` | Backend unit + integration tests |
+| Modify | `src/types/index.ts` | Add `LabelNameSuggestion` interface |
+| Modify | `src/services/api.ts` | Add `getNameSuggestions` call |
+| Create | `src/hooks/useLabelSuggestions.ts` | Fetch + cache suggestions on mount |
+| Create | `src/components/run/LabelNameInput.tsx` | Input + filtered dropdown component |
+| Create | `src/tests/run/LabelNameInput.test.tsx` | Frontend component tests |
+| Modify | `src/components/run/StripBar.tsx` | Accept + forward suggestions; use LabelNameInput |
+| Modify | `src/components/run/NoteLabelPopover.tsx` | Accept + forward suggestions; use LabelNameInput |
+| Modify | `src/pages/LabelRunPage.tsx` | Call useLabelSuggestions; pass to StripBar + NoteLabelPopover |
+
+---
+
+## Task 1: Add `LabelNameSuggestion` type and `getNameSuggestions` API call
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/services/api.ts`
+
+- [ ] **Step 1: Add type to `src/types/index.ts`**
+
+Find the `ConceptCandidate` interface (around line 192) and add the new type immediately after it:
+
+```ts
+export interface LabelNameSuggestion {
+  name: string
+  description: string
+}
+```
+
+- [ ] **Step 2: Add API call to `src/services/api.ts`**
+
+Find the `getCandidates` entry (around line 131) and add the new call immediately after it:
+
+```ts
+  getNameSuggestions: (): Promise<LabelNameSuggestion[]> =>
+    USE_MOCK ? Promise.resolve([]) : req('/api/concepts/name-suggestions'),
+```
+
+Add `LabelNameSuggestion` to the import from `'../types'` at the top of `api.ts`.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/index.ts src/services/api.ts
+git commit -m "feat: add LabelNameSuggestion type and getNameSuggestions API call"
+```
+
+---
+
+## Task 2: Create `name_suggestion_service.py` (TDD)
+
+**Files:**
+- Create: `server/python/name_suggestion_service.py`
+- Create: `server/python/tests/test_name_suggestions.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/python/tests/test_name_suggestions.py`:
+
+```python
+import math
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _emb(values):
+    e = MagicMock()
+    e.values = values
+    return e
+
+
+def _mock_embed(*batches):
+    """Return a mock embed_content that yields embeddings from `batches` in order."""
+    responses = []
+    for vecs in batches:
+        r = MagicMock()
+        r.embeddings = [_emb(v) for v in vecs]
+        responses.append(r)
+    m = MagicMock(side_effect=responses)
+    return m
+
+
+# ── _cosine_sim ──────────────────────────────────────────────────────────────
+
+def test_cosine_sim_identical_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_sim_orthogonal_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]) == pytest.approx(0.0)
+
+
+def test_cosine_sim_zero_vector_returns_zero():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([0.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == 0.0
+
+
+# ── filter_suggestions ───────────────────────────────────────────────────────
+
+def test_filter_removes_synonym(monkeypatch):
+    """'puzzled' should be filtered when 'confusion' exists (cos_sim ≈ 0.99 > 0.75)."""
+    import name_suggestion_service as svc
+
+    # candidates: ["puzzled", "code syntax help"], existing: ["confusion"]
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        result = svc.filter_suggestions(
+            candidate_names=["puzzled", "code syntax help"],
+            candidate_descriptions=["lost student", "syntax questions"],
+            existing_names=["confusion"],
+        )
+
+    names = [r["name"] for r in result]
+    assert "puzzled" not in names          # cos([0.99,0.14,0],[1,0,0]) ≈ 0.99 > 0.75
+    assert "code syntax help" in names     # cos([0,0,1],[1,0,0]) = 0.0 < 0.75
+
+
+def test_filter_returns_all_when_no_existing_labels():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=["error tracing"],
+        candidate_descriptions=["tracing errors"],
+        existing_names=[],
+    )
+    assert result == [{"name": "error tracing", "description": "tracing errors"}]
+
+
+def test_filter_returns_empty_when_no_candidates():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=[],
+        candidate_descriptions=[],
+        existing_names=["confusion"],
+    )
+    assert result == []
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py -v
+```
+
+Expected: `ImportError: No module named 'name_suggestion_service'`
+
+- [ ] **Step 3: Implement `name_suggestion_service.py`**
+
+Create `server/python/name_suggestion_service.py`:
+
+```python
+import math
+import os
+from typing import List
+
+import numpy as np
+from google import genai
+
+SUGGESTION_SIMILARITY_THRESHOLD = 0.75
+_EMBED_MODEL = "gemini-embedding-001"
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+def _cosine_sim(a: List[float], b: List[float]) -> float:
+    va, vb = np.array(a, dtype=np.float32), np.array(b, dtype=np.float32)
+    denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(va, vb) / denom)
+
+
+def filter_suggestions(
+    candidate_names: List[str],
+    candidate_descriptions: List[str],
+    existing_names: List[str],
+) -> List[dict]:
+    """Return candidates not semantically similar to any existing label name.
+
+    Embeds all texts in one batch call: candidates first, then existing names.
+    Drops any candidate whose max cosine similarity to an existing label
+    exceeds SUGGESTION_SIMILARITY_THRESHOLD.
+    """
+    if not candidate_names:
+        return []
+    if not existing_names:
+        return [
+            {"name": n, "description": d}
+            for n, d in zip(candidate_names, candidate_descriptions)
+        ]
+
+    all_texts = candidate_names + existing_names
+    resp = client.models.embed_content(model=_EMBED_MODEL, contents=all_texts)
+    embeddings = [e.values for e in resp.embeddings]
+
+    cand_vecs = embeddings[: len(candidate_names)]
+    exist_vecs = embeddings[len(candidate_names) :]
+
+    result = []
+    for name, desc, vec in zip(candidate_names, candidate_descriptions, cand_vecs):
+        max_sim = max(_cosine_sim(vec, ex) for ex in exist_vecs)
+        if max_sim <= SUGGESTION_SIMILARITY_THRESHOLD:
+            result.append({"name": name, "description": desc})
+    return result
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py -v
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/name_suggestion_service.py server/python/tests/test_name_suggestions.py
+git commit -m "feat: add name_suggestion_service with cosine-similarity label filtering"
+```
+
+---
+
+## Task 3: Add `/api/concepts/name-suggestions` endpoint to `main.py`
+
+**Files:**
+- Modify: `server/python/main.py`
+- Modify: `server/python/tests/test_name_suggestions.py`
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+Append to `server/python/tests/test_name_suggestions.py`:
+
+```python
+# ── endpoint ─────────────────────────────────────────────────────────────────
+
+def test_endpoint_returns_empty_when_no_candidates(client):
+    resp = client.get("/api/concepts/name-suggestions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_endpoint_filters_and_returns_suggestions(client, session):
+    from models import LabelDefinition, ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(LabelDefinition(name="confusion", mode="single", description=""))
+    session.add(ConceptCandidate(
+        name="puzzled", description="student seems lost",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.add(ConceptCandidate(
+        name="code syntax help", description="syntax questions",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    names = [s["name"] for s in resp.json()]
+    assert "puzzled" not in names
+    assert "code syntax help" in names
+
+
+def test_endpoint_returns_empty_on_gemini_error(client, session):
+    from models import ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(ConceptCandidate(
+        name="scope clarification", description="...",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    with patch.object(svc.client.models, "embed_content", side_effect=Exception("network")):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+```
+
+- [ ] **Step 2: Run new tests — confirm they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py::test_endpoint_returns_empty_when_no_candidates -v
+```
+
+Expected: `404 Not Found` (endpoint doesn't exist yet).
+
+- [ ] **Step 3: Add endpoint to `main.py`**
+
+Find the existing `GET /api/concepts/candidates` endpoint (around line 2067) and add the new endpoint immediately after it:
+
+```python
+@app.get("/api/concepts/name-suggestions")
+def get_name_suggestions(db: Session = Depends(get_session)):
+    """Return pending concept candidates filtered to exclude semantic duplicates of existing labels."""
+    import name_suggestion_service
+
+    candidates = db.exec(
+        select(ConceptCandidate).where(ConceptCandidate.status == "pending")
+    ).all()
+    if not candidates:
+        return []
+
+    existing_names = list(db.exec(select(LabelDefinition.name)).all())
+
+    try:
+        return name_suggestion_service.filter_suggestions(
+            candidate_names=[c.name for c in candidates],
+            candidate_descriptions=[c.description for c in candidates],
+            existing_names=existing_names,
+        )
+    except Exception:
+        return []
+```
+
+- [ ] **Step 4: Run all name suggestion tests**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py -v
+```
+
+Expected: 9 tests pass.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+cd server/python && uv run pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/python/main.py server/python/tests/test_name_suggestions.py
+git commit -m "feat: add GET /api/concepts/name-suggestions endpoint"
+```
+
+---
+
+## Task 4: Create `useLabelSuggestions` hook
+
+**Files:**
+- Create: `src/hooks/useLabelSuggestions.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `src/hooks/useLabelSuggestions.ts`:
+
+```ts
+import { useState, useEffect } from 'react'
+import { api } from '../services/api'
+import type { LabelNameSuggestion } from '../types'
+
+export function useLabelSuggestions() {
+  const [suggestions, setSuggestions] = useState<LabelNameSuggestion[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getNameSuggestions()
+      .then(setSuggestions)
+      .catch(() => setSuggestions([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { suggestions, loading }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useLabelSuggestions.ts
+git commit -m "feat: add useLabelSuggestions hook"
+```
+
+---
+
+## Task 5: Create `LabelNameInput` component (TDD)
+
+**Files:**
+- Create: `src/components/run/LabelNameInput.tsx`
+- Create: `src/tests/run/LabelNameInput.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/tests/run/LabelNameInput.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LabelNameInput } from '../../components/run/LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+
+const suggestions: LabelNameSuggestion[] = [
+  { name: 'confusion', description: 'Student shows confusion about a concept' },
+  { name: 'code help', description: 'Requesting help with code' },
+]
+
+describe('LabelNameInput', () => {
+  it('shows filtered suggestions when focused and typing', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('confusion')).toBeInTheDocument()
+    expect(screen.queryByText('code help')).not.toBeInTheDocument()
+  })
+
+  it('hides dropdown when typed value exactly matches a suggestion', () => {
+    render(<LabelNameInput value="confusion" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('calls onChange and onCommit when suggestion is clicked', () => {
+    const onChange = vi.fn()
+    const onCommit = vi.fn()
+    render(
+      <LabelNameInput value="con" onChange={onChange} onCommit={onCommit} suggestions={suggestions} />
+    )
+    fireEvent.focus(screen.getByRole('combobox'))
+    fireEvent.mouseDown(screen.getByText('confusion'))
+    expect(onChange).toHaveBeenCalledWith('confusion')
+    expect(onCommit).toHaveBeenCalled()
+  })
+
+  it('selects first suggestion on Enter when dropdown is open', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="con" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('confusion')
+  })
+
+  it('navigates to second suggestion with ArrowDown then selects with Enter', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="c" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('code help')
+  })
+
+  it('closes dropdown on Escape', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('passes unhandled keyDown events to the onKeyDown prop', () => {
+    const onKeyDown = vi.fn()
+    render(
+      <LabelNameInput value="" onChange={() => {}} suggestions={[]} onKeyDown={onKeyDown} />
+    )
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' })
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  it('renders as a plain input when suggestions is empty', () => {
+    render(<LabelNameInput value="any" onChange={() => {}} suggestions={[]} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+npm test -- run src/tests/run/LabelNameInput.test.tsx
+```
+
+Expected: `Cannot find module '../../components/run/LabelNameInput'`
+
+- [ ] **Step 3: Implement `LabelNameInput`**
+
+Create `src/components/run/LabelNameInput.tsx`:
+
+```tsx
+import { useState, useEffect, useRef } from 'react'
+import type { LabelNameSuggestion } from '../../types'
+
+interface LabelNameInputProps {
+  value: string
+  onChange: (value: string) => void
+  onCommit?: () => void
+  suggestions: LabelNameSuggestion[]
+  placeholder?: string
+  readOnly?: boolean
+  autoFocus?: boolean
+  className?: string
+  onBlur?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  'data-tutorial'?: string
+}
+
+export function LabelNameInput({
+  value,
+  onChange,
+  onCommit,
+  suggestions,
+  placeholder,
+  readOnly,
+  autoFocus,
+  className,
+  onBlur,
+  onKeyDown,
+  ...rest
+}: LabelNameInputProps) {
+  const [open, setOpen] = useState(false)
+  const [highlighted, setHighlighted] = useState(0)
+
+  const filtered = suggestions.filter(
+    (s) =>
+      value.length > 0 &&
+      s.name.toLowerCase().includes(value.toLowerCase()) &&
+      s.name.toLowerCase() !== value.toLowerCase()
+  )
+  const showDropdown = open && filtered.length > 0
+
+  // Reset highlight when the filtered list changes
+  useEffect(() => {
+    setHighlighted(0)
+  }, [value])
+
+  function select(name: string) {
+    onChange(name)
+    setOpen(false)
+    onCommit?.()
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (showDropdown) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setHighlighted((h) => Math.min(h + 1, filtered.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setHighlighted((h) => Math.max(h - 1, 0))
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        select(filtered[highlighted].name)
+        return
+      }
+      if (e.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+    }
+    onKeyDown?.(e)
+  }
+
+  return (
+    <div className="relative">
+      <input
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        type="text"
+        autoComplete="off"
+        value={value}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        className={className}
+        onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => { setTimeout(() => setOpen(false), 150); onBlur?.() }}
+        onKeyDown={handleKeyDown}
+        {...rest}
+      />
+      {showDropdown && (
+        <ul
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-lg"
+        >
+          {filtered.map((s, i) => (
+            <li
+              key={s.name}
+              role="option"
+              aria-selected={i === highlighted}
+              className={`cursor-pointer px-3 py-2 ${
+                i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
+              }`}
+              onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
+              onMouseEnter={() => setHighlighted(i)}
+            >
+              <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
+              {s.description && (
+                <div className="truncate text-xs text-muted">{s.description}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+npm test -- run src/tests/run/LabelNameInput.test.tsx
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/run/LabelNameInput.tsx src/tests/run/LabelNameInput.test.tsx
+git commit -m "feat: add LabelNameInput component with filtered autocomplete dropdown"
+```
+
+---
+
+## Task 6: Wire `LabelNameInput` into `StripBar.tsx`
+
+**Files:**
+- Modify: `src/components/run/StripBar.tsx`
+
+- [ ] **Step 1: Add `suggestions` to `StripBarProps` and destructure it**
+
+In `src/components/run/StripBar.tsx`, add to the `StripBarProps` interface (after `onRemoveQueued`):
+
+```ts
+  suggestions?: LabelNameSuggestion[]
+```
+
+Add to the imports at the top:
+
+```ts
+import { LabelNameInput } from './LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+```
+
+Add `suggestions = []` to the destructured props in `StripBar`:
+
+```ts
+export function StripBar({
+  // ...existing props...
+  suggestions = [],
+}: StripBarProps) {
+```
+
+- [ ] **Step 2: Replace the bare `<input>` with `LabelNameInput`**
+
+Find the `<input>` block inside `{showNameInput ? (` (around line 102). Replace the entire `<input ... />` element with:
+
+```tsx
+<LabelNameInput
+  data-tutorial="label-name"
+  value={labelNameDraft ?? ''}
+  readOnly={labelNameLocked}
+  suggestions={suggestions}
+  onChange={(v) => onLabelNameDraftChange?.(v)}
+  onCommit={() => {
+    const name = (labelNameDraft ?? '').trim()
+    if (name && !isPlaceholderLabelName(name) && !labelNameLocked) {
+      commitName?.()
+    }
+  }}
+  onKeyDown={(e) => {
+    const name = (labelNameDraft ?? '').trim()
+    if (e.key === 'Enter' && name && !isPlaceholderLabelName(name) && !labelNameLocked) {
+      e.preventDefault()
+      commitName?.()
+    }
+  }}
+  onBlur={() => {
+    if (draftMode || labelNameLocked) return
+    onLabelNameCommit?.()
+  }}
+  placeholder="Label name…"
+  className="box-border w-full min-w-[10rem] max-w-[18rem] rounded-sm border border-edge bg-surface px-2.5 py-1.5 font-sans text-sm text-on-canvas placeholder:text-faint focus:outline-none focus:border-ochre-dim disabled:opacity-70"
+/>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/run/StripBar.tsx
+git commit -m "feat: use LabelNameInput in StripBar for single-label name field"
+```
+
+---
+
+## Task 7: Wire `LabelNameInput` into `NoteLabelPopover.tsx`
+
+**Files:**
+- Modify: `src/components/run/NoteLabelPopover.tsx`
+
+- [ ] **Step 1: Add `suggestions` to `NoteLabelPopoverProps` and import**
+
+In `src/components/run/NoteLabelPopover.tsx`, update the imports and props:
+
+```tsx
+import { LabelNameInput } from './LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+
+interface NoteLabelPopoverProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (name: string, description: string) => void
+  suggestions?: LabelNameSuggestion[]
+}
+```
+
+Add `suggestions = []` to the destructured function args:
+
+```tsx
+export function NoteLabelPopover({ open, onClose, onSubmit, suggestions = [] }: NoteLabelPopoverProps) {
+```
+
+- [ ] **Step 2: Replace the bare `<input>` with `LabelNameInput`**
+
+Find the `<input ref={nameRef} ...>` (around line 65). Replace it with:
+
+```tsx
+<LabelNameInput
+  ref={nameRef as React.Ref<HTMLInputElement>}
+  autoFocus
+  autoComplete="off"
+  placeholder="e.g. frustration"
+  value={name}
+  suggestions={suggestions}
+  onChange={setName}
+  onCommit={() => { if (name.trim()) onSubmit(name.trim(), description.trim()) }}
+  className="appearance-none bg-canvas border border-edge text-on-canvas px-[11px] py-[9px] rounded-sm font-sans text-[13px] focus:outline-none focus:border-ochre-dim"
+/>
+```
+
+Since `LabelNameInput` wraps a `<div>`, remove the `ref={nameRef}` forwarding and instead focus the input a different way. Update the `useEffect` that focuses on open:
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null)
+
+useEffect(() => {
+  if (open) {
+    requestAnimationFrame(() => {
+      const input = document.querySelector<HTMLInputElement>('[data-note-input]')
+      input?.focus()
+    })
+  } else {
+    setName('')
+    setDescription('')
+  }
+}, [open])
+```
+
+And add `data-note-input` to the `LabelNameInput`:
+
+```tsx
+<LabelNameInput
+  data-note-input=""
+  autoFocus
+  ...
+/>
+```
+
+Also update the `onKey` handler that checks `document.activeElement === nameRef.current` — replace with a check on `data-note-input`:
+
+```tsx
+const onKey = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    onClose()
+  } else if (
+    e.key === 'Enter' &&
+    (document.activeElement as HTMLElement)?.dataset?.noteInput !== undefined
+  ) {
+    e.preventDefault()
+    if (name.trim()) onSubmit(name.trim(), description.trim())
+  }
+}
+```
+
+Remove the `nameRef` ref entirely.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/run/NoteLabelPopover.tsx
+git commit -m "feat: use LabelNameInput in NoteLabelPopover for single-label name field"
+```
+
+---
+
+## Task 8: Connect `useLabelSuggestions` in `LabelRunPage.tsx`
+
+**Files:**
+- Modify: `src/pages/LabelRunPage.tsx`
+
+- [ ] **Step 1: Call `useLabelSuggestions` in `LabelRunPage`**
+
+Add the import at the top of `LabelRunPage.tsx`:
+
+```ts
+import { useLabelSuggestions } from '../hooks/useLabelSuggestions'
+```
+
+Add the hook call near the top of the component body (alongside the other hooks):
+
+```ts
+const { suggestions } = useLabelSuggestions()
+```
+
+- [ ] **Step 2: Pass `suggestions` to `StripBar`**
+
+Find the `<StripBar ... />` usage in `LabelRunPage.tsx` (around line 754). Add:
+
+```tsx
+suggestions={suggestions}
+```
+
+- [ ] **Step 3: Pass `suggestions` to both `NoteLabelPopover` instances**
+
+There are two `<NoteLabelPopover` instances (around lines 720 and 818). Add `suggestions={suggestions}` to both:
+
+```tsx
+<NoteLabelPopover
+  open={noteOpen}
+  onClose={() => setNoteOpen(false)}
+  onSubmit={handleNoteSubmit}
+  suggestions={suggestions}
+/>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run full frontend test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run full backend test suite**
+
+```bash
+cd server/python && uv run pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/LabelRunPage.tsx
+git commit -m "feat: connect label name suggestions to single-label run page"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Backend embedding filter at 0.75 threshold → Task 2
+- ✅ Only `pending` candidates → Task 3 (`where status == "pending"`)
+- ✅ Fetch existing labels from `LabelDefinition` (all modes) → Task 3
+- ✅ Returns empty list on error → Task 3 (try/except)
+- ✅ `useLabelSuggestions` hook, fetch once on mount → Task 4
+- ✅ `LabelNameInput` with `autoComplete="off"`, ↑↓ navigation, Enter/Escape → Task 5
+- ✅ Shows description per suggestion → Task 5
+- ✅ Wired into `StripBar` → Task 6
+- ✅ Wired into `NoteLabelPopover` → Task 7
+- ✅ `useLabelSuggestions` called in `LabelRunPage`, passed to both components → Task 8
+- ✅ Multi-label components not touched — `NewLabelPopover`, `QueuePage`, `LabelsPage` absent from file map
+
+**Type consistency:**
+- `LabelNameSuggestion` defined in Task 1, used in Tasks 4, 5, 6, 7 ✅
+- `filter_suggestions` signature in Task 2 matches call in Task 3 ✅
+- `suggestions` prop on `StripBar` is `LabelNameSuggestion[]` with default `[]` ✅
+- `suggestions` prop on `NoteLabelPopover` is `LabelNameSuggestion[]` with default `[]` ✅

--- a/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
+++ b/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
@@ -1,0 +1,118 @@
+# Week-scoped routes (user-study branch)
+
+**Date:** 2026-06-01
+**Branch:** `study/week-scoped-routes` (off `main`)
+**Status:** Design approved, pending spec review
+
+## Motivation
+
+For the upcoming user study we want each labeling interface scoped to a single
+week of DSC 10 (Winter 2026) coursework, so participants label a bounded,
+comparable slice of conversations. A secondary goal: when an instructor triggers
+**handoff** in single-label mode, Gemini should only classify the in-scope week,
+not the entire chatlog corpus — keeping auto-labeling fast during sessions.
+
+## Scope mapping
+
+Weeks come from the Winter 2026 schedule
+(<https://dsc-courses.github.io/dsc10-2026-wi/>), cross-checked against the
+repo's own `server/python/data/milestones/dsc10_wi26.json`:
+
+| Route   | Mode         | Week | Assignments       |
+|---------|--------------|------|-------------------|
+| `/queue`| multi-label  | 3    | Lab 1 + HW 1      |
+| `/run`  | single-label | 8    | Lab 5 + HW 5      |
+
+(Week 3 = "Histograms and Functions": Lab 1 due Jan 20, HW 1 due Jan 21.
+Week 8 = "Hypothesis and Permutation Testing": Lab 5 due Feb 23, HW 5 due Feb 25.)
+
+Quizzes and discussions are excluded — only graded notebook assignments (Lab/HW)
+map to `MessageCache.notebook` filenames.
+
+## Design
+
+### Key constraint
+
+The two routes need **different** scopes, and the message-selection code is
+shared: `queue_service.next_message_for_label` backs both single-label `/run`
+and multi-label onboarding-browse. So scope is keyed on **label mode**
+(multi → Week 3, single → Week 8), not a single global filter.
+
+### 1. New module `server/python/study_scope.py`
+
+Single source of truth. Reuses `assignment_service._canonical_name` so scope is
+expressed in the same vocabulary as the rest of the app, and does **not** depend
+on `AssignmentMapping` rows having been created by the instructor.
+
+```python
+QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
+RUN_SCOPE   = {"Lab 5", "Homework 5"}   # Week 8 — single-label
+
+def notebook_in_scope(notebook: str | None, names: set[str]) -> bool:
+    return notebook is not None and _canonical_name(notebook) in names
+
+def scope_for_mode(mode: str) -> set[str]:
+    return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
+
+def in_scope_keys(session, names) -> set[tuple[int, int]]:
+    """(chatlog_id, message_index) pairs whose notebook is in scope."""
+```
+
+`_canonical_name` maps `hw01.ipynb` → `"Homework 1"`, `lab5.ipynb` → `"Lab 5"`,
+etc. (`hw`/`homework` → `Homework`).
+
+### 2. Hard lock — server-side enforcement
+
+The lock is server-side and unconditional: any client-supplied `assignment_id`
+is ignored on the locked routes. Enforcement points:
+
+**Queue (Week 3):**
+- `/api/queue` — filter `all_cached` candidates to `notebook_in_scope(..., QUEUE_SCOPE)`.
+- `/api/queue/stats` and `/api/queue/position` — restrict `total`/`labeled`/`skipped`
+  denominators to in-scope keys so progress numbers match the bounded queue.
+
+**Run (Week 8):**
+- `queue_service.next_message_for_label` — filter `cache_rows` by the label's
+  mode-derived scope (single → `RUN_SCOPE`). Multi-mode callers
+  (onboarding-browse) get `QUEUE_SCOPE`.
+- `decision_service.compute_readiness` — `total_conversations` counts only
+  in-scope conversations, so the readiness denominator reflects Week 8.
+- `main._do_classification` — restrict the `pending` set to in-scope keys, so
+  the Gemini handoff classifies only Week 8 (the performance goal).
+
+### 3. Frontend
+
+Since the server now ignores `assignment_id` on these routes, the assignment
+picker becomes a no-op and should be hidden/disabled to avoid confusion:
+- `/run`: hide the assignment picker in `StripBar`.
+- `/queue`: hide the assignment picker if present.
+- Each page shows a small fixed-scope label, e.g. "Week 3 — Lab 1 & HW 1" /
+  "Week 8 — Lab 5 & HW 5".
+
+### 4. Tests
+
+Backend (`pytest`, in-memory SQLite):
+- `study_scope.notebook_in_scope` — Lab 1 / HW 1 / Homework 1 notebooks match
+  `QUEUE_SCOPE`; Lab 5 matches `RUN_SCOPE`; Lab 2 / unmapped match neither.
+- `/api/queue` returns only Week-3 messages; a seeded Week-5 message never appears.
+- single-label `next_message_for_label` (single mode) returns only Week-8 messages.
+- `_do_classification` pending set excludes out-of-scope messages (Gemini call
+  mocked).
+
+## Out of scope / non-goals
+
+- No DB schema change; no new migration. Scope is computed from existing
+  `MessageCache.notebook`.
+- No change to the labeling pipeline, AI prompt construction, or analysis pages.
+- Week numbers are hardcoded constants for this study branch (not configurable
+  via env/UI) — intentional, since the study fixes them.
+- This branch is not intended to merge to `main` as-is; it is a study fixture.
+
+## Success criteria
+
+- `/queue` surfaces only Week-3 (Lab 1 / HW 1) messages; stats/position reflect
+  that bounded set.
+- `/run` surfaces only Week-8 (Lab 5 / HW 5) messages; readiness denominator and
+  Gemini handoff classification are both bounded to Week 8.
+- Assignment pickers no longer present a choice on either route.
+- Backend tests pass.

--- a/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
+++ b/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
@@ -104,8 +104,11 @@ Backend (`pytest`, in-memory SQLite):
 - No DB schema change; no new migration. Scope is computed from existing
   `MessageCache.notebook`.
 - No change to the labeling pipeline, AI prompt construction, or analysis pages.
-- Week numbers are hardcoded constants for this study branch (not configurable
-  via env/UI) — intentional, since the study fixes them.
+- Week→assignment mappings are hardcoded constants for this study branch (not
+  configurable via UI) — intentional, since the study fixes them. The lock as a
+  whole is gated by `CHATSIGHT_STUDY_LOCK` (default ON); it exists only so the
+  legacy test suite (which seeds unscoped data) can disable it via
+  `conftest.py`. Production/study runs leave it ON.
 - This branch is not intended to merge to `main` as-is; it is a study fixture.
 
 ## Success criteria

--- a/docs/superpowers/specs/2026-06-03-label-suggestions-design.md
+++ b/docs/superpowers/specs/2026-06-03-label-suggestions-design.md
@@ -1,0 +1,136 @@
+# Label Name Suggestions — Design Spec
+
+**Date:** 2026-06-03  
+**Scope:** Single-label mode only (`/run`). Multi-label queue is explicitly out of scope — do not touch `NewLabelPopover.tsx`, `LabelsPage.tsx`, or any queue-mode component.
+
+---
+
+## Problem
+
+Browser autofill on label name inputs was injecting contact names from participants' computers during user studies. `autoComplete="off"` is not reliably respected by Chrome/Safari. The fix is a custom dropdown that replaces browser suggestions entirely — and since we're building one, it should surface actually useful suggestions: concept candidate names discovered from the chatlog data, filtered to exclude labels that are semantically redundant with ones the instructor already has.
+
+---
+
+## Filtering requirement
+
+Filtering must work at the synonym level, not just string matching. If "confusion" exists as a label, the dropdown must not suggest "Confusion", "confused", "puzzled", "unsure", or other near-synonyms. Simple case-insensitive string comparison is not sufficient.
+
+---
+
+## Architecture
+
+### Backend: `GET /api/concepts/name-suggestions`
+
+New endpoint in `main.py`. Logic:
+
+1. Fetch all `ConceptCandidate` rows where `status == "pending"` from SQLite
+2. Fetch all existing label names from `LabelDefinition` (all rows, both `mode='multi'` and `mode='single'` — they share one table)
+3. Batch-embed both sets of names using `gemini-embedding-001`
+4. For each candidate, compute cosine similarity against every existing label name
+5. Drop any candidate where `max_similarity > SUGGESTION_SIMILARITY_THRESHOLD` (constant, default `0.75`)
+6. Return `[{ name: str, description: str }]`
+
+The threshold `0.75` is where true synonyms converge in embedding space. Expose as a backend constant (`SUGGESTION_SIMILARITY_THRESHOLD`) so it can be tuned after testing.
+
+If no concept candidates exist, or if the Gemini embedding call fails, return an empty list — do not error.
+
+### Frontend: `useLabelSuggestions` hook
+
+**File:** `src/hooks/useLabelSuggestions.ts`
+
+- Calls `GET /api/concepts/name-suggestions` once on mount
+- Returns `{ suggestions: { name: string; description: string }[], loading: boolean }`
+- On error: sets `suggestions = []`, does not throw or surface to UI
+- No polling or refetching within a session
+
+### Frontend: `LabelNameInput` component
+
+**File:** `src/components/run/LabelNameInput.tsx`  
+(Placed in `run/` since it is single-label only.)
+
+Props:
+```ts
+interface LabelNameInputProps {
+  value: string
+  onChange: (value: string) => void
+  onCommit?: () => void
+  suggestions: { name: string; description: string }[]
+  placeholder?: string
+  readOnly?: boolean
+  className?: string
+  // forwarded: autoFocus, onBlur, onKeyDown, data-*, etc.
+}
+```
+
+Behavior:
+- `autoComplete="off"` on the underlying `<input>`
+- Dropdown appears when: input is focused AND typed value is non-empty AND at least one suggestion contains the typed string (case-insensitive)
+- Client-side filter: suggestions where `name.toLowerCase().includes(typed.toLowerCase())`
+- Dropdown does not appear if typed value is an exact case-insensitive match to a suggestion (user already has it)
+- ↑↓ keys navigate highlighted row; Enter selects highlighted row (calls `onChange` with the name, then `onCommit`); Escape closes dropdown
+- Clicking a suggestion fills the input and calls `onCommit`
+- Each row: suggestion name (bold, `text-on-canvas`) + description (muted, truncated to one line)
+- If `suggestions` is empty, component behaves as a plain `<input>` — no dropdown ever renders
+
+### Wiring
+
+`useLabelSuggestions` is called in `LabelRunPage.tsx`. The resulting `suggestions` array is passed as a prop down to:
+
+- `StripBar.tsx` — replaces the bare `<input>` in the label name slot with `LabelNameInput`
+- `NoteLabelPopover.tsx` — replaces the bare `<input>` for the name field with `LabelNameInput`
+
+**Do not wire into any multi-label component.**
+
+---
+
+## Data flow
+
+```
+LabelRunPage mounts
+  → useLabelSuggestions fires once
+  → GET /api/concepts/name-suggestions
+      → fetch pending ConceptCandidates
+      → fetch existing label names (single + multi)
+      → embed both with gemini-embedding-001
+      → cosine filter at 0.75 threshold
+      → return [{name, description}]
+  → suggestions stored in hook state
+  → passed as prop to StripBar + NoteLabelPopover
+  → LabelNameInput renders dropdown on focus+type
+```
+
+---
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| No concept candidates | Returns `[]`, input is a plain text field |
+| Gemini embedding call fails | Returns `[]`, input is a plain text field |
+| All candidates filtered out | Returns `[]`, input is a plain text field |
+| Frontend fetch error | `suggestions = []`, no error shown |
+
+The input must never be broken or degraded by a failed suggestion fetch.
+
+---
+
+## Testing
+
+**Backend:**
+- Unit test `cosine_similarity` filter: confirm "confusion" (existing) suppresses "confused", "puzzled", "unsure" as candidates; confirm unrelated candidates (e.g., "code syntax help") pass through
+- Mock `gemini-embedding-001` call — return pre-computed vectors
+- Test empty-candidate and Gemini-error paths return `[]` gracefully
+
+**Frontend:**
+- `LabelNameInput` is pure props-driven UI — no fetch logic to test separately
+- Verify dropdown appears/hides at correct conditions via existing vitest + RTL setup
+- `useLabelSuggestions` is a thin fetch wrapper; covered by integration if needed
+
+---
+
+## Out of scope
+
+- Multi-label queue (`NewLabelPopover`, `QueuePage`, `LabelsPage`) — do not touch
+- The label split dialog in `LabelsPage.tsx` — intentionally shows existing labels, leave as-is
+- Suggestion ranking or sorting beyond the existing candidate order
+- Re-fetching suggestions after a new label is created within the session

--- a/server/python/autolabel_service.py
+++ b/server/python/autolabel_service.py
@@ -101,7 +101,7 @@ def classify_batch(
     prompt = build_prompt(label_definitions, examples_by_label, messages)
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=CONFIG,
     )
@@ -136,7 +136,7 @@ def summarize_message(message_text: str) -> str:
     )
     
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=message_text,
         config=config,
     )

--- a/server/python/binary_autolabel_service.py
+++ b/server/python/binary_autolabel_service.py
@@ -19,7 +19,7 @@ client = genai.Client(
     http_options=types.HttpOptions(timeout=GEMINI_REQUEST_TIMEOUT_MS),
 )
 
-CLASSIFY_MODEL = "gemini-2.0-flash"
+CLASSIFY_MODEL = "gemini-2.5-flash"
 
 CLASSIFY_SYSTEM_INSTRUCTION = (
     "You are classifying student messages from AI-tutoring conversations as yes/no for "
@@ -128,7 +128,7 @@ def classify_binary(
         return []
     prompt = _build_classify_prompt(label_name, label_description, yes_examples, no_examples, messages, guidance)
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=CLASSIFY_CONFIG,
     )
@@ -248,7 +248,7 @@ def summarize_batch(
             parts.append(f"- {m}")
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents="\n".join(parts),
         config=SUMMARY_CONFIG,
     )

--- a/server/python/concept_service.py
+++ b/server/python/concept_service.py
@@ -294,7 +294,7 @@ def discover_concepts(
     # 5. Call Gemini
     prompt = _build_discovery_prompt(samples_by_cluster, existing, rejected)
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=SUGGEST_CONFIG,
     )

--- a/server/python/decision_service.py
+++ b/server/python/decision_service.py
@@ -4,6 +4,8 @@ from typing import Optional, Tuple
 
 from sqlmodel import Session, select
 
+import study_scope
+
 from models import (
     ConversationCursor,
     LabelApplication,
@@ -146,10 +148,11 @@ def compute_readiness(session: Session, label_id: int) -> dict:
 
     walked = len({c for _, c in rows})
 
-    total_convs = session.exec(
-        select(MessageCache.chatlog_id).distinct()
-    ).all()
-    total_convs_count = len(total_convs)
+    # Study lock: single-label runs are Week 8 — count only in-scope convs.
+    label = session.get(LabelDefinition, label_id)
+    scope = study_scope.scope_for_mode(label.mode if label else "single")
+    in_scope = study_scope.in_scope_keys(session, scope)
+    total_convs_count = len({cid for cid, _ in in_scope})
 
     if yes == 0 or no == 0:
         tier = "gray"

--- a/server/python/definition_service.py
+++ b/server/python/definition_service.py
@@ -31,7 +31,7 @@ An example is 'Responds to AI question or message'. It does not restate any of t
         prompt += f"\n\nAdditional guidance from the instructor: {guidance}\n\nRevise the definition to incorporate this guidance while remaining grounded in the examples above."
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=types.GenerateContentConfig(temperature=0),
     )
@@ -59,7 +59,7 @@ The following student messages have been labeled "{label_name}" by human instruc
 Which single message best exemplifies the description above? It should be the message that most explicitly shows this description. If there are messages that are equally related the description, prioritize the shorter message. Reply with only the number of that message (e.g. "3"). Nothing else."""
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=types.GenerateContentConfig(temperature=0),
     )

--- a/server/python/explore_service.py
+++ b/server/python/explore_service.py
@@ -603,7 +603,7 @@ def _summarize_conversation_gemini(
     for i, t in enumerate(student_texts[:12]):
         parts.append(f"{i + 1}. {t[:500]}")
     response = _client_get().models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents="\n".join(parts),
         config=_SUMMARY_CONFIG,
     )

--- a/server/python/label_service.py
+++ b/server/python/label_service.py
@@ -64,7 +64,7 @@ For each student-AI interaction turn, identify:
 Call the `generate_labels` tool with a JSON array of label objects. Label every meaningful interaction turn (typically every 1-3 message pairs)."""
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=user_message,
         config=GENERATE_CONFIG,
     )

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2169,17 +2169,13 @@ def export_csv(db: Session = Depends(get_session)):
 
 @app.get("/api/session/label-review", response_model=List[LabelReviewResponse])
 def get_label_review(db: Session = Depends(get_session)):
-    from concurrent.futures import ThreadPoolExecutor
-    from definition_service import generate_label_definition, select_best_example
-
     labels = db.exec(
         select(LabelDefinition)
-        .where(LabelDefinition.archived_at == None)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
         .order_by(LabelDefinition.created_at.desc())
     ).all()
 
-    # Collect all DB data first (before spawning threads — db session is not thread-safe)
-    label_data = []
+    results = []
     for label in labels:
         app_rows = db.exec(
             select(LabelApplication)
@@ -2188,43 +2184,28 @@ def get_label_review(db: Session = Depends(get_session)):
                 LabelApplication.applied_by == "human",
             )
             .order_by(LabelApplication.created_at.desc())
-            .limit(20)
+            .limit(1)
         ).all()
 
-        example_messages = []
-        for app_row in app_rows:
+        example_text = None
+        if app_rows:
             cache_row = db.exec(
                 select(MessageCache).where(
-                    MessageCache.chatlog_id == app_row.chatlog_id,
-                    MessageCache.message_index == app_row.message_index,
+                    MessageCache.chatlog_id == app_rows[0].chatlog_id,
+                    MessageCache.message_index == app_rows[0].message_index,
                 )
             ).first()
             if cache_row:
-                example_messages.append(cache_row.message_text)
+                example_text = cache_row.message_text
 
-        label_data.append((label, example_messages))
-
-    # Run Gemini calls for all labels in parallel
-    def process(item):
-        label, example_messages = item
-        if not example_messages:
-            return label.id, None
-        description = label.description or generate_label_definition(label.name, example_messages)
-        example_text = select_best_example(label.name, description, example_messages)
-        return label.id, example_text
-
-    with ThreadPoolExecutor() as executor:
-        example_map = dict(executor.map(process, label_data))
-
-    return [
-        LabelReviewResponse(
+        results.append(LabelReviewResponse(
             label_id=label.id,
             name=label.name,
             description=label.description,
-            example_text=example_map.get(label.id),
-        )
-        for label, _ in label_data
-    ]
+            example_text=example_text,
+        ))
+
+    return results
 
 
 # ── Recalibration ────────────────────────────────────────────────────────────
@@ -2273,8 +2254,6 @@ def _compute_trend(events: list[RecalibrationEvent]) -> str:
 
 @app.get("/api/session/recalibration")
 def get_recalibration(force: bool = False, db: Session = Depends(get_session)):
-    # `force=true` is honored only when CHATSIGHT_DEV is set; otherwise silently ignored.
-    force = force and DEV_MODE
     # 1. Check for active session
     labeling_session = db.exec(
         select(LabelingSession).order_by(LabelingSession.id.desc())

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3752,7 +3752,14 @@ def _do_classification(
     cached = db.exec(
         select(MessageCache.chatlog_id, MessageCache.message_index, MessageCache.message_text)
     ).all()
-    pending = [(c, i, t) for (c, i, t) in cached if (c, i) not in decided_keys]
+    # Study lock: only classify the week this label's mode is scoped to
+    # (single -> Week 8). Keeps Gemini handoff bounded and fast.
+    scope = study_scope.scope_for_mode(label.mode)
+    in_scope = study_scope.in_scope_keys(db, scope)
+    pending = [
+        (c, i, t) for (c, i, t) in cached
+        if (c, i) not in decided_keys and (c, i) in in_scope
+    ]
 
     if sample_size is not None:
         pending = random.sample(pending, min(sample_size, len(pending)))

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2086,21 +2086,37 @@ def get_candidates(db: Session = Depends(get_session)):
 
 @app.get("/api/concepts/name-suggestions")
 def get_name_suggestions(db: Session = Depends(get_session)):
-    """Return pending concept candidates filtered to exclude semantic duplicates of existing labels."""
+    """Return label name suggestions filtered to exclude semantic duplicates of existing labels.
+
+    Primary source: pending concept candidates (populated by the Discover flow).
+    Fallback: generate suggestions on-demand from a sample of cached student messages.
+    """
     import name_suggestion_service
 
     candidates = db.exec(
         select(ConceptCandidate).where(ConceptCandidate.status == "pending")
     ).all()
-    if not candidates:
-        return []
 
     existing_names = list(db.exec(select(LabelDefinition.name)).all())
 
+    if candidates:
+        try:
+            return name_suggestion_service.filter_suggestions(
+                candidate_names=[c.name for c in candidates],
+                candidate_descriptions=[c.description for c in candidates],
+                existing_names=existing_names,
+            )
+        except Exception:
+            return []
+
+    # No concept candidates yet — generate from message cache
+    message_texts = list(db.exec(select(MessageCache.message_text).limit(50)).all())
+    if not message_texts:
+        return []
+
     try:
-        return name_suggestion_service.filter_suggestions(
-            candidate_names=[c.name for c in candidates],
-            candidate_descriptions=[c.description for c in candidates],
+        return name_suggestion_service.generate_from_messages(
+            message_texts=message_texts,
             existing_names=existing_names,
         )
     except Exception:

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1267,6 +1267,7 @@ def get_queue_history(
 # ── Auto-labeling ────────────────────────────────────────────────────────────
 
 _autolabel_status = {"running": False, "processed": 0, "total": 0, "error": None}
+_autolabel_stop_requested = False
 
 
 def _run_split_autolabel(
@@ -1478,9 +1479,14 @@ def _run_autolabel():
         ]
         _autolabel_status["total"] = len(unlabeled)
 
-        # Process in batches of 30
+        # Process in batches of 30; check stop flag between each batch
         BATCH_SIZE = 30
+        global _autolabel_stop_requested
         for i in range(0, len(unlabeled), BATCH_SIZE):
+            if _autolabel_stop_requested:
+                _autolabel_stop_requested = False
+                _autolabel_status["running"] = False
+                return
             batch = unlabeled[i : i + BATCH_SIZE]
             try:
                 results = classify_batch(label_defs, examples_by_label, batch)
@@ -1548,6 +1554,33 @@ def start_autolabel(db: Session = Depends(get_session)):
 @app.get("/api/queue/autolabel/status")
 def get_autolabel_status():
     return _autolabel_status
+
+
+@app.post("/api/queue/autolabel/stop")
+def stop_autolabel():
+    global _autolabel_stop_requested
+    if not _autolabel_status["running"]:
+        raise HTTPException(status_code=409, detail="Auto-labeling is not running")
+    _autolabel_stop_requested = True
+    return {"ok": True, "message": "Stop requested — will halt after current batch"}
+
+
+@app.delete("/api/queue/autolabel/results")
+def clear_autolabel_results(db: Session = Depends(get_session)):
+    """Delete all AI-applied multi-label applications so autolabel can be re-run."""
+    if _autolabel_status["running"]:
+        raise HTTPException(status_code=409, detail="Auto-labeling is currently running")
+    deleted = db.exec(
+        select(LabelApplication).where(
+            LabelApplication.applied_by == "ai",
+            _is_multi_application(),
+        )
+    ).all()
+    count = len(deleted)
+    for row in deleted:
+        db.delete(row)
+    db.commit()
+    return {"ok": True, "deleted": count}
 
 
 # ── Stub routes (feature tracks implement these) ──────────────────────────────

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -69,6 +69,7 @@ import onboarding_service
 import queue_service
 import binary_autolabel_service
 import assignment_service
+import study_scope
 from models import AssignmentMapping
 
 REVIEW_THRESHOLD = 0.75
@@ -1036,12 +1037,13 @@ def get_queue(limit: int = 20, seed: Optional[int] = None, db: Session = Depends
     ).all()
     excluded = {(cid, midx) for cid, midx in labeled_pairs} | {(cid, midx) for cid, midx in skipped_pairs}
 
-    # Query from cache instead of external DB CTE
+    # Query from cache instead of external DB CTE. Study lock: Week 3 only.
     all_cached = db.exec(select(MessageCache)).all()
 
     candidates = [
         c for c in all_cached
         if (c.chatlog_id, c.message_index) not in excluded
+        and study_scope.notebook_in_scope(c.notebook, study_scope.QUEUE_SCOPE)
     ]
 
     # Apply seed-based deterministic ordering or random shuffle
@@ -1068,20 +1070,21 @@ def get_queue(limit: int = 20, seed: Optional[int] = None, db: Session = Depends
 
 @app.get("/api/queue/stats")
 def get_queue_stats(db: Session = Depends(get_session)):
-    labeled_count = db.exec(
-        select(func.count()).select_from(
-            select(LabelApplication.chatlog_id, LabelApplication.message_index)
-            .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
-            .where(LabelDefinition.archived_at == None)  # noqa: E711
-            .where(_is_multi_application())
-            .distinct()
-            .subquery()
-        )
-    ).one()
-    skipped_count = db.exec(select(func.count(SkippedMessage.id))).one()
-    total = db.exec(select(func.count(MessageCache.id))).one() or 0
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
     return {
-        "total_messages": total,
+        "total_messages": len(in_scope),
         "labeled_count": labeled_count,
         "skipped_count": skipped_count,
     }
@@ -1089,18 +1092,20 @@ def get_queue_stats(db: Session = Depends(get_session)):
 
 @app.get("/api/queue/position")
 def get_queue_position(db: Session = Depends(get_session)):
-    labeled_count = db.exec(
-        select(func.count()).select_from(
-            select(LabelApplication.chatlog_id, LabelApplication.message_index)
-            .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
-            .where(LabelDefinition.archived_at == None)  # noqa: E711
-            .where(_is_multi_application())
-            .distinct()
-            .subquery()
-        )
-    ).one()
-    skipped_count = db.exec(select(func.count(SkippedMessage.id))).one()
-    total = db.exec(select(func.count(MessageCache.id))).one() or 0
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
+    total = len(in_scope)
     total_remaining = max(0, total - labeled_count - skipped_count)
     position = labeled_count + skipped_count + 1
     return {"position": position, "total_remaining": total_remaining}

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -61,7 +61,7 @@ from schemas import (
     ConfidenceHistogramBin, SingleLabelDetailResponse,
     MessageListItem, MessageListResponse,
     ConversationTurn, MessageDetailResponse,
-    FlipRequest, NoteRequest, LabelUpdateRequest,
+    FlipRequest, NoteRequest, FlagRequest, LabelUpdateRequest,
     GeminiPreviewResponse,
 )
 import decision_service
@@ -3651,9 +3651,17 @@ def get_assist(
 
 
 def _decide_response(
-    db: Session, label_id: int, assignment_id: Optional[int] = None
+    db: Session,
+    label_id: int,
+    assignment_id: Optional[int] = None,
+    hint_chatlog_id: Optional[int] = None,
 ) -> DecideResponse:
-    """Build the combined next-message + readiness payload for the /run hot path."""
+    """Build the combined next-message + readiness payload for the /run hot path.
+
+    `hint_chatlog_id` pins the next pick to the same conversation while it still
+    has undecided student turns, so yes/no/skip walk a conversation to completion
+    before the sampler jumps elsewhere.
+    """
     label = db.get(LabelDefinition, label_id)
     explore = _effective_hybrid_explore_fraction(label) if label else None
     assist_service.rebuild_cache_if_stale(db, label_id)
@@ -3662,6 +3670,7 @@ def _decide_response(
         label_id,
         assignment_id,
         explore_fraction=explore,
+        hint_chatlog_id=hint_chatlog_id,
     )
     db.commit()
     nxt = FocusedMessageResponse(**payload) if payload else None
@@ -3695,7 +3704,10 @@ def post_decide(
         message_index=req.message_index,
         value=req.value,
     )
-    return _decide_response(db, label_id, assignment_id)
+    # Stay in the same conversation until its student turns are exhausted.
+    return _decide_response(
+        db, label_id, assignment_id, hint_chatlog_id=req.chatlog_id
+    )
 
 
 @app.post(
@@ -3732,7 +3744,20 @@ def post_undo(
     label = db.get(LabelDefinition, label_id)
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="Single-label not found")
-    decision_service.undo_last_decision(db, label_id)
+    snapshot = decision_service.undo_last_decision(db, label_id)
+    # Re-focus the exact message we just undid so the instructor lands back on
+    # it, instead of the sampler jumping to a fresh conversation.
+    if snapshot is not None:
+        payload = queue_service.focus_payload_for_message(
+            db, label_id, snapshot.chatlog_id, snapshot.message_index
+        )
+        if payload is not None:
+            readiness = ReadinessResponse(
+                **decision_service.compute_readiness(db, label_id)
+            )
+            return DecideResponse(
+                next=FocusedMessageResponse(**payload), readiness=readiness
+            )
     return _decide_response(db, label_id, assignment_id)
 
 
@@ -4741,6 +4766,33 @@ def upsert_single_label_note(
     db.add(app_row)
     db.commit()
     return {"ok": True}
+
+
+@app.patch("/api/single-labels/{label_id}/applications/{chatlog_id}/flag")
+def set_single_label_flag(
+    label_id: int,
+    chatlog_id: int,
+    body: FlagRequest,
+    message_index: int = Query(0, ge=0),
+    db: Session = Depends(get_session),
+):
+    label = db.get(LabelDefinition, label_id)
+    if not label or label.mode != "single":
+        raise HTTPException(status_code=404, detail="single-label not found")
+
+    app_row = db.exec(
+        select(LabelApplication)
+        .where(LabelApplication.label_id == label_id)
+        .where(LabelApplication.chatlog_id == chatlog_id)
+        .where(LabelApplication.message_index == message_index)
+    ).first()
+    if not app_row:
+        raise HTTPException(status_code=404, detail="no application row")
+
+    app_row.flagged = body.flagged
+    db.add(app_row)
+    db.commit()
+    return {"ok": True, "flagged": app_row.flagged}
 
 
 @app.patch(

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3594,9 +3594,15 @@ def close_single_label(label_id: int, db: Session = Depends(get_session)):
 def get_next_focused(
     label_id: int,
     assignment_id: Optional[int] = None,
+    hint_chatlog_id: Optional[int] = None,
     db: Session = Depends(get_session),
 ):
-    """Walk the next focused message for the active labeling label."""
+    """Walk the next focused message for the active labeling label.
+
+    hint_chatlog_id: if provided, try to return the first undecided message
+    from that conversation before falling back to normal queue ordering.
+    Used after label switches to keep the instructor in the same conversation.
+    """
     label = db.get(LabelDefinition, label_id)
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="Single-label not found")
@@ -3607,6 +3613,7 @@ def get_next_focused(
         label_id,
         assignment_id,
         explore_fraction=_effective_hybrid_explore_fraction(label),
+        hint_chatlog_id=hint_chatlog_id,
     )
     db.commit()
     if not payload:

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2084,6 +2084,29 @@ def get_candidates(db: Session = Depends(get_session)):
     ]
 
 
+@app.get("/api/concepts/name-suggestions")
+def get_name_suggestions(db: Session = Depends(get_session)):
+    """Return pending concept candidates filtered to exclude semantic duplicates of existing labels."""
+    import name_suggestion_service
+
+    candidates = db.exec(
+        select(ConceptCandidate).where(ConceptCandidate.status == "pending")
+    ).all()
+    if not candidates:
+        return []
+
+    existing_names = list(db.exec(select(LabelDefinition.name)).all())
+
+    try:
+        return name_suggestion_service.filter_suggestions(
+            candidate_names=[c.name for c in candidates],
+            candidate_descriptions=[c.description for c in candidates],
+            existing_names=existing_names,
+        )
+    except Exception:
+        return []
+
+
 @app.put("/api/concepts/candidates/{candidate_id}")
 def resolve_candidate(candidate_id: int, req: ResolveCandidateRequest, db: Session = Depends(get_session)):
     candidate = db.get(ConceptCandidate, candidate_id)

--- a/server/python/name_suggestion_service.py
+++ b/server/python/name_suggestion_service.py
@@ -1,4 +1,3 @@
-import math
 import os
 from typing import List
 

--- a/server/python/name_suggestion_service.py
+++ b/server/python/name_suggestion_service.py
@@ -1,0 +1,53 @@
+import math
+import os
+from typing import List
+
+import numpy as np
+from google import genai
+
+SUGGESTION_SIMILARITY_THRESHOLD = 0.75
+_EMBED_MODEL = "gemini-embedding-001"
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+def _cosine_sim(a: List[float], b: List[float]) -> float:
+    va, vb = np.array(a, dtype=np.float32), np.array(b, dtype=np.float32)
+    denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(va, vb) / denom)
+
+
+def filter_suggestions(
+    candidate_names: List[str],
+    candidate_descriptions: List[str],
+    existing_names: List[str],
+) -> List[dict]:
+    """Return candidates not semantically similar to any existing label name.
+
+    Embeds all texts in one batch call: candidates first, then existing names.
+    Drops any candidate whose max cosine similarity to an existing label
+    exceeds SUGGESTION_SIMILARITY_THRESHOLD.
+    """
+    if not candidate_names:
+        return []
+    if not existing_names:
+        return [
+            {"name": n, "description": d}
+            for n, d in zip(candidate_names, candidate_descriptions)
+        ]
+
+    all_texts = candidate_names + existing_names
+    resp = client.models.embed_content(model=_EMBED_MODEL, contents=all_texts)
+    embeddings = [e.values for e in resp.embeddings]
+
+    cand_vecs = embeddings[: len(candidate_names)]
+    exist_vecs = embeddings[len(candidate_names) :]
+
+    result = []
+    for name, desc, vec in zip(candidate_names, candidate_descriptions, cand_vecs):
+        max_sim = max(_cosine_sim(vec, ex) for ex in exist_vecs)
+        if max_sim <= SUGGESTION_SIMILARITY_THRESHOLD:
+            result.append({"name": name, "description": desc})
+    return result

--- a/server/python/name_suggestion_service.py
+++ b/server/python/name_suggestion_service.py
@@ -1,13 +1,19 @@
+import json
 import os
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from google import genai
+from google.genai import types as genai_types
 
 SUGGESTION_SIMILARITY_THRESHOLD = 0.75
 _EMBED_MODEL = "gemini-embedding-001"
+_GENERATE_MODEL = "gemini-2.5-flash"
 
 client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+# Module-level cache so the on-demand generation only runs once per server session
+_generated_cache: Optional[List[dict]] = None
 
 
 def _cosine_sim(a: List[float], b: List[float]) -> float:
@@ -50,3 +56,82 @@ def filter_suggestions(
         if max_sim <= SUGGESTION_SIMILARITY_THRESHOLD:
             result.append({"name": name, "description": desc})
     return result
+
+
+def generate_from_messages(
+    message_texts: List[str],
+    existing_names: List[str],
+) -> List[dict]:
+    """Generate label name suggestions from a sample of messages.
+
+    Asks Gemini to propose label concepts visible in the data, then filters
+    them through cosine similarity to drop anything too close to existing labels.
+    Result is cached in _generated_cache so subsequent calls skip the Gemini call.
+    """
+    global _generated_cache
+    if _generated_cache is not None:
+        # Re-filter cached suggestions against current existing labels in case new
+        # labels were created since the cache was populated.
+        if not existing_names:
+            return _generated_cache
+        try:
+            return filter_suggestions(
+                candidate_names=[s["name"] for s in _generated_cache],
+                candidate_descriptions=[s["description"] for s in _generated_cache],
+                existing_names=existing_names,
+            )
+        except Exception:
+            return _generated_cache
+
+    if not message_texts:
+        return []
+
+    existing_str = (
+        ", ".join(f'"{n}"' for n in existing_names) if existing_names else "none yet"
+    )
+    sample = "\n".join(f"- {m[:200]}" for m in message_texts[:40])
+
+    prompt = (
+        "You are helping an instructor create labels for student-AI tutoring conversations.\n\n"
+        f"Already-created labels (avoid these and close synonyms): {existing_str}\n\n"
+        "Sample student messages from the dataset:\n"
+        f"{sample}\n\n"
+        "Suggest 8-12 concise label names capturing distinct student behaviors or intents "
+        "visible in these messages. Return a JSON array only, no explanation:\n"
+        '[{"name": "label name", "description": "one sentence description"}, ...]'
+    )
+
+    response = client.models.generate_content(
+        model=_GENERATE_MODEL,
+        contents=prompt,
+        config=genai_types.GenerateContentConfig(temperature=0.3),
+    )
+
+    text = response.text.strip()
+    if "```" in text:
+        parts = text.split("```")
+        text = parts[1] if len(parts) > 1 else parts[0]
+        if text.startswith("json"):
+            text = text[4:]
+
+    raw: List[dict] = json.loads(text.strip())
+    suggestions = [
+        {"name": s["name"], "description": s.get("description", "")}
+        for s in raw
+        if isinstance(s, dict) and "name" in s
+    ]
+
+    # Cache the raw generated set before similarity filtering
+    _generated_cache = suggestions
+
+    if not existing_names or not suggestions:
+        return suggestions
+
+    try:
+        return filter_suggestions(
+            candidate_names=[s["name"] for s in suggestions],
+            candidate_descriptions=[s["description"] for s in suggestions],
+            existing_names=existing_names,
+        )
+    except Exception:
+        return suggestions

--- a/server/python/onboarding_service.py
+++ b/server/python/onboarding_service.py
@@ -105,7 +105,7 @@ def _ai_label_suggestions_for_turns(turns: list[tuple[int, str]]) -> Optional[di
             "one inner array per message in order."
         )
         response = explore_service._client_get().models.generate_content(
-            model="gemini-2.0-flash",
+            model="gemini-2.5-flash",
             contents=prompt,
         )
         raw = ""

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -488,6 +488,7 @@ def next_message_for_label(
     explore_fraction: Optional[float] = None,
     *,
     extra_decided: Optional[set[tuple[int, int]]] = None,
+    hint_chatlog_id: Optional[int] = None,
 ) -> Optional[dict]:
     eff_explore = (
         max(0.0, min(1.0, explore_fraction))
@@ -586,6 +587,21 @@ def next_message_for_label(
 
     in_progress.sort(key=lambda c: _shuffle_key(label_id, c))
     not_started.sort(key=lambda c: _shuffle_key(label_id, c))
+
+    # If the caller pinned a conversation (e.g. after a label switch), try it first.
+    if hint_chatlog_id is not None and hint_chatlog_id in conv:
+        tup = _first_pending_turn(hint_chatlog_id, conv[hint_chatlog_id], decided)
+        if tup:
+            midx, text, notebook = tup
+            sampling_meta = build_sampling_meta(
+                session, label_id, hint_chatlog_id, midx,
+                len(conv[hint_chatlog_id]), "round_robin",
+            )
+            return _build_focus_payload(
+                session, label_id, hint_chatlog_id, midx, text, notebook,
+                sampling_meta=sampling_meta,
+            )
+        # Hint conversation is fully decided for this label — fall through to normal pick.
 
     cid_pick, pick_mode = _select_next_chatlog_id(
         session,

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -593,9 +593,15 @@ def next_message_for_label(
         tup = _first_pending_turn(hint_chatlog_id, conv[hint_chatlog_id], decided)
         if tup:
             midx, text, notebook = tup
+            # Pinning the current conversation is a "continue"; let the display
+            # logic relabel it as "explore" if this conversation was originally
+            # surfaced by an explore pick (so the walk's provenance survives).
+            display_pick = _display_sampling_pick(
+                session, label_id, hint_chatlog_id, "continue"
+            )
             sampling_meta = build_sampling_meta(
                 session, label_id, hint_chatlog_id, midx,
-                len(conv[hint_chatlog_id]), "round_robin",
+                len(conv[hint_chatlog_id]), display_pick,
             )
             return _build_focus_payload(
                 session, label_id, hint_chatlog_id, midx, text, notebook,
@@ -775,6 +781,47 @@ def _build_focus_payload(
     if sampling_meta:
         out.update(sampling_meta)
     return out
+
+
+def focus_payload_for_message(
+    session: Session,
+    label_id: int,
+    chatlog_id: int,
+    message_index: int,
+) -> Optional[dict]:
+    """Build a focus payload for one specific (chatlog_id, message_index).
+
+    Used to re-focus the exact message an instructor just undid, instead of
+    letting the sampler pick a fresh (possibly different) conversation.
+    Returns None if the message is not in the cache.
+    """
+    row = session.exec(
+        select(MessageCache.message_text, MessageCache.notebook)
+        .where(MessageCache.chatlog_id == chatlog_id)
+        .where(MessageCache.message_index == message_index)
+    ).first()
+    if not row:
+        return None
+    text, notebook = row
+    total = len(
+        session.exec(
+            select(MessageCache.message_index).where(
+                MessageCache.chatlog_id == chatlog_id
+            )
+        ).all()
+    )
+    sampling_meta = build_sampling_meta(
+        session, label_id, chatlog_id, message_index, total, "round_robin"
+    )
+    return _build_focus_payload(
+        session,
+        label_id,
+        chatlog_id,
+        message_index,
+        text,
+        notebook,
+        sampling_meta=sampling_meta,
+    )
 
 
 def _fetch_full_thread(chatlog_id: int) -> list[dict]:

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -15,6 +15,7 @@ from sqlmodel import Session, select
 
 import assist_service
 import explore_service
+import study_scope
 from database import ext_engine
 from models import (
     ConversationCursor,
@@ -505,6 +506,16 @@ def next_message_for_label(
     if assignment_id is not None:
         cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
     cache_rows = session.exec(cache_q).all()
+
+    # Study lock: restrict to the week tied to this label's mode
+    # (single -> Week 8, multi/onboarding -> Week 3). Unconditional; the
+    # client assignment_id filter above only narrows further.
+    _label = session.get(LabelDefinition, label_id)
+    _scope = study_scope.scope_for_mode(_label.mode if _label else "multi")
+    cache_rows = [
+        row for row in cache_rows
+        if study_scope.notebook_in_scope(row[4], _scope)
+    ]
 
     decided = set(
         session.exec(

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -562,6 +562,10 @@ class NoteRequest(BaseModel):
     text: str  # empty string deletes the note
 
 
+class FlagRequest(BaseModel):
+    flagged: bool
+
+
 class LabelUpdateRequest(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None

--- a/server/python/study_scope.py
+++ b/server/python/study_scope.py
@@ -1,0 +1,43 @@
+"""Study fixture: hard-locked per-week assignment scopes for the user study.
+
+`/queue` (multi-label) is locked to DSC 10 Winter-2026 Week 3 (Lab 1 + HW 1);
+`/run` (single-label) is locked to Week 8 (Lab 5 + HW 5). Scope is expressed in
+canonical assignment names (the same vocabulary as assignment_service) so it does
+not depend on AssignmentMapping rows existing. Weeks come from
+https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
+data/milestones/dsc10_wi26.json).
+"""
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from assignment_service import _canonical_name
+from models import MessageCache
+
+QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
+RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
+
+
+def scope_for_mode(mode: str) -> set[str]:
+    """Single-label runs are Week 8; everything else (multi/onboarding) is Week 3."""
+    return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
+
+
+def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
+    return notebook is not None and _canonical_name(notebook) in names
+
+
+def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
+    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`."""
+    rows = session.exec(
+        select(
+            MessageCache.chatlog_id,
+            MessageCache.message_index,
+            MessageCache.notebook,
+        )
+    ).all()
+    return {
+        (cid, midx)
+        for cid, midx, nb in rows
+        if notebook_in_scope(nb, names)
+    }

--- a/server/python/study_scope.py
+++ b/server/python/study_scope.py
@@ -7,6 +7,7 @@ not depend on AssignmentMapping rows existing. Weeks come from
 https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
 data/milestones/dsc10_wi26.json).
 """
+import os
 from typing import Optional
 
 from sqlmodel import Session, select
@@ -18,17 +19,27 @@ QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
 RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
 
 
+def lock_enabled() -> bool:
+    """Whether the study week-lock is active. ON by default (production/study);
+    set CHATSIGHT_STUDY_LOCK=0 to disable (legacy test suite seeds unscoped data).
+    Read at call time so tests can toggle it via monkeypatch."""
+    return os.getenv("CHATSIGHT_STUDY_LOCK", "1") != "0"
+
+
 def scope_for_mode(mode: str) -> set[str]:
     """Single-label runs are Week 8; everything else (multi/onboarding) is Week 3."""
     return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
 
 
 def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
+    if not lock_enabled():
+        return True
     return notebook is not None and _canonical_name(notebook) in names
 
 
 def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
-    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`."""
+    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`.
+    When the lock is disabled, every cached message is considered in scope."""
     rows = session.exec(
         select(
             MessageCache.chatlog_id,

--- a/server/python/tests/conftest.py
+++ b/server/python/tests/conftest.py
@@ -5,6 +5,11 @@ import os
 # reads this env var at module load time.
 os.environ.setdefault("PG_PASSWORD", "test_dummy_password")
 
+# The study week-lock (study_scope) is ON by default in production. The legacy
+# test suite seeds unscoped MessageCache rows (notebook=None or other weeks), so
+# disable the lock here. test_study_scope.py re-enables it per-test to validate it.
+os.environ.setdefault("CHATSIGHT_STUDY_LOCK", "0")
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest

--- a/server/python/tests/test_name_suggestions.py
+++ b/server/python/tests/test_name_suggestions.py
@@ -1,0 +1,79 @@
+import math
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _emb(values):
+    e = MagicMock()
+    e.values = values
+    return e
+
+
+def _mock_embed(*batches):
+    """Return a mock embed_content that yields embeddings from `batches` in order."""
+    responses = []
+    for vecs in batches:
+        r = MagicMock()
+        r.embeddings = [_emb(v) for v in vecs]
+        responses.append(r)
+    m = MagicMock(side_effect=responses)
+    return m
+
+
+# ── _cosine_sim ──────────────────────────────────────────────────────────────
+
+def test_cosine_sim_identical_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_sim_orthogonal_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]) == pytest.approx(0.0)
+
+
+def test_cosine_sim_zero_vector_returns_zero():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([0.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == 0.0
+
+
+# ── filter_suggestions ───────────────────────────────────────────────────────
+
+def test_filter_removes_synonym(monkeypatch):
+    """'puzzled' should be filtered when 'confusion' exists (cos_sim ≈ 0.99 > 0.75)."""
+    import name_suggestion_service as svc
+
+    # candidates: ["puzzled", "code syntax help"], existing: ["confusion"]
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        result = svc.filter_suggestions(
+            candidate_names=["puzzled", "code syntax help"],
+            candidate_descriptions=["lost student", "syntax questions"],
+            existing_names=["confusion"],
+        )
+
+    names = [r["name"] for r in result]
+    assert "puzzled" not in names          # cos([0.99,0.14,0],[1,0,0]) ≈ 0.99 > 0.75
+    assert "code syntax help" in names     # cos([0,0,1],[1,0,0]) = 0.0 < 0.75
+
+
+def test_filter_returns_all_when_no_existing_labels():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=["error tracing"],
+        candidate_descriptions=["tracing errors"],
+        existing_names=[],
+    )
+    assert result == [{"name": "error tracing", "description": "tracing errors"}]
+
+
+def test_filter_returns_empty_when_no_candidates():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=[],
+        candidate_descriptions=[],
+        existing_names=["confusion"],
+    )
+    assert result == []

--- a/server/python/tests/test_name_suggestions.py
+++ b/server/python/tests/test_name_suggestions.py
@@ -1,4 +1,3 @@
-import math
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -61,12 +60,33 @@ def test_filter_removes_synonym(monkeypatch):
 
 def test_filter_returns_all_when_no_existing_labels():
     import name_suggestion_service as svc
-    result = svc.filter_suggestions(
-        candidate_names=["error tracing"],
-        candidate_descriptions=["tracing errors"],
-        existing_names=[],
-    )
+    with patch.object(svc.client.models, "embed_content") as mock_embed:
+        result = svc.filter_suggestions(
+            candidate_names=["error tracing"],
+            candidate_descriptions=["tracing errors"],
+            existing_names=[],
+        )
     assert result == [{"name": "error tracing", "description": "tracing errors"}]
+    mock_embed.assert_not_called()
+
+
+def test_filter_keeps_candidate_at_exact_threshold(monkeypatch):
+    """Candidate with sim == 0.75 must be kept (threshold is strictly >)."""
+    import math
+    import name_suggestion_service as svc
+
+    # cos_sim(a, b) = 0.75 when a=[0.75, sqrt(1-0.75^2), 0], b=[1,0,0]
+    a = [0.75, math.sqrt(1 - 0.75**2), 0.0]
+    b = [1.0, 0.0, 0.0]
+
+    mock = _mock_embed([a, b])
+    with patch.object(svc.client.models, "embed_content", mock):
+        result = svc.filter_suggestions(
+            candidate_names=["borderline"],
+            candidate_descriptions=["exactly at threshold"],
+            existing_names=["existing"],
+        )
+    assert result == [{"name": "borderline", "description": "exactly at threshold"}]
 
 
 def test_filter_returns_empty_when_no_candidates():

--- a/server/python/tests/test_name_suggestions.py
+++ b/server/python/tests/test_name_suggestions.py
@@ -97,3 +97,56 @@ def test_filter_returns_empty_when_no_candidates():
         existing_names=["confusion"],
     )
     assert result == []
+
+
+# ── endpoint ─────────────────────────────────────────────────────────────────
+
+def test_endpoint_returns_empty_when_no_candidates(client):
+    resp = client.get("/api/concepts/name-suggestions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_endpoint_filters_and_returns_suggestions(client, session):
+    from models import LabelDefinition, ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(LabelDefinition(name="confusion", mode="single", description=""))
+    session.add(ConceptCandidate(
+        name="puzzled", description="student seems lost",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.add(ConceptCandidate(
+        name="code syntax help", description="syntax questions",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    names = [s["name"] for s in resp.json()]
+    assert "puzzled" not in names
+    assert "code syntax help" in names
+
+
+def test_endpoint_returns_empty_on_gemini_error(client, session):
+    from models import LabelDefinition, ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(LabelDefinition(name="existing label", mode="single", description=""))
+    session.add(ConceptCandidate(
+        name="scope clarification", description="...",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    with patch.object(svc.client.models, "embed_content", side_effect=Exception("network")):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/server/python/tests/test_single_label_routes.py
+++ b/server/python/tests/test_single_label_routes.py
@@ -230,6 +230,120 @@ def test_undo_removes_last_decision(client, session):
     assert apps[0].message_index == 0
 
 
+def test_next_with_hint_chatlog_id_stays_in_same_conversation(client, session):
+    _seed_messages(session)
+    label = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{label['id']}/activate")
+    # No decisions yet: with a hint, the next message should come from the hinted
+    # conversation (202) rather than the label's own shuffled first pick.
+    r = client.get(
+        f"/api/single-labels/{label['id']}/next?hint_chatlog_id=202"
+    )
+    assert r.status_code == 200
+    assert r.json()["chatlog_id"] == 202
+
+
+def test_next_with_hint_falls_back_when_conversation_done(client, session):
+    _seed_messages(session, conversations=2, per_conv=2)
+    label = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{label['id']}/activate")
+    # Decide every message in conversation 200 so the hint is exhausted.
+    for i in range(2):
+        client.post(
+            f"/api/single-labels/{label['id']}/decide",
+            json={"chatlog_id": 200, "message_index": i, "value": "yes"},
+        )
+    r = client.get(
+        f"/api/single-labels/{label['id']}/next?hint_chatlog_id=200"
+    )
+    assert r.status_code == 200
+    # Hint conversation fully decided → falls through to a different conversation.
+    assert r.json()["chatlog_id"] == 201
+
+
+def test_undo_refocuses_the_undone_message(client, session):
+    _seed_messages(session)
+    label = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{label['id']}/activate")
+    client.post(
+        f"/api/single-labels/{label['id']}/decide",
+        json={"chatlog_id": 200, "message_index": 0, "value": "yes"},
+    )
+    client.post(
+        f"/api/single-labels/{label['id']}/decide",
+        json={"chatlog_id": 200, "message_index": 1, "value": "no"},
+    )
+    r = client.post(f"/api/single-labels/{label['id']}/undo")
+    assert r.status_code == 200
+    nxt = r.json()["next"]
+    # Undo lands back on the exact message just undone, not a fresh conversation.
+    assert nxt is not None
+    assert nxt["chatlog_id"] == 200
+    assert nxt["message_index"] == 1
+
+
+def test_decide_stays_in_same_conversation(client, session):
+    _seed_messages(session)
+    label = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{label['id']}/activate")
+    r = client.post(
+        f"/api/single-labels/{label['id']}/decide",
+        json={"chatlog_id": 201, "message_index": 0, "value": "yes"},
+    )
+    assert r.status_code == 200
+    nxt = r.json()["next"]
+    # After deciding, the next pick continues the same conversation (201) until
+    # its student turns are exhausted, rather than jumping elsewhere.
+    assert nxt is not None
+    assert nxt["chatlog_id"] == 201
+    assert nxt["message_index"] == 1
+
+
+def test_flag_endpoint_toggles_and_surfaces_in_filter(client, session):
+    _seed_messages(session)
+    label = client.post("/api/single-labels", json={"name": "help"}).json()
+    lid = label["id"]
+    client.post(f"/api/single-labels/{lid}/activate")
+    client.post(
+        f"/api/single-labels/{lid}/decide",
+        json={"chatlog_id": 200, "message_index": 0, "value": "yes"},
+    )
+    r = client.patch(
+        f"/api/single-labels/{lid}/applications/200/flag?message_index=0",
+        json={"flagged": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["flagged"] is True
+
+    row = session.exec(
+        select(LabelApplication).where(LabelApplication.chatlog_id == 200)
+    ).first()
+    assert row.flagged is True
+
+    listing = client.get(f"/api/single-labels/{lid}/messages?bucket=flagged")
+    assert listing.status_code == 200
+    items = listing.json()["items"]
+    assert any(it["chatlog_id"] == 200 for it in items)
+
+    # Unflag clears it from the bucket.
+    client.patch(
+        f"/api/single-labels/{lid}/applications/200/flag?message_index=0",
+        json={"flagged": False},
+    )
+    listing2 = client.get(f"/api/single-labels/{lid}/messages?bucket=flagged")
+    assert all(it["chatlog_id"] != 200 for it in listing2.json()["items"])
+
+
+def test_flag_endpoint_404_for_missing_row(client, session):
+    _seed_messages(session)
+    label = client.post("/api/single-labels", json={"name": "help"}).json()
+    r = client.patch(
+        f"/api/single-labels/{label['id']}/applications/999/flag?message_index=0",
+        json={"flagged": True},
+    )
+    assert r.status_code == 404
+
+
 def test_delete_single_label_removes_row(client, session):
     _seed_messages(session)
     label = client.post("/api/single-labels", json={"name": "help"}).json()

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -1,7 +1,16 @@
+import pytest
+
 import study_scope
 import queue_service
 import decision_service
 from models import MessageCache, LabelDefinition
+
+
+@pytest.fixture(autouse=True)
+def _force_study_lock(monkeypatch):
+    """These tests validate the lock itself, so force it ON regardless of the
+    suite-wide default set in conftest."""
+    monkeypatch.setenv("CHATSIGHT_STUDY_LOCK", "1")
 
 
 def _seed(session, chatlog_id, message_index, notebook):
@@ -69,3 +78,36 @@ def test_run_next_returns_only_week8(session):
             picks.add(payload["chatlog_id"])
     assert picks <= {10}
     assert 11 not in picks
+
+
+def test_readiness_total_convs_scoped_to_week8(session):
+    _seed(session, 20, 0, "lab5.ipynb")   # Week 8
+    _seed(session, 21, 0, "lab1.ipynb")   # Week 3
+    _seed(session, 22, 0, "lab2.ipynb")   # other
+    label = LabelDefinition(name="x", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+    state = decision_service.compute_readiness(session, label.id)
+    assert state["total_conversations"] == 1
+
+
+def test_classification_pending_excludes_out_of_scope(session, monkeypatch):
+    import main
+    _seed(session, 30, 0, "lab5.ipynb")   # Week 8 — should be classified
+    _seed(session, 31, 0, "lab1.ipynb")   # Week 3 — must be skipped
+    label = LabelDefinition(name="y", mode="single", phase="labeling",
+                            review_threshold=0.5)
+    session.add(label)
+    session.commit()
+
+    captured = {}
+
+    def fake_parallel(db, label, pending, yes_examples, no_examples):
+        captured["pending"] = pending
+        return ([], [])
+
+    monkeypatch.setattr(main, "_classify_in_parallel", fake_parallel)
+    main._do_classification(session, label)
+    keys = {(c, i) for (c, i, _t) in captured["pending"]}
+    assert (30, 0) in keys
+    assert (31, 0) not in keys

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -1,0 +1,34 @@
+import study_scope
+from models import MessageCache
+
+
+def _seed(session, chatlog_id, message_index, notebook):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id, message_index=message_index,
+        message_text=f"msg {chatlog_id}.{message_index}", notebook=notebook,
+    ))
+    session.commit()
+
+
+def test_queue_scope_matches_week3_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab1.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("lab01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw1.ipynb", study_scope.QUEUE_SCOPE)
+
+
+def test_run_scope_matches_week8_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab5.ipynb", study_scope.RUN_SCOPE)
+    assert study_scope.notebook_in_scope("hw05.ipynb", study_scope.RUN_SCOPE)
+
+
+def test_out_of_scope_and_none():
+    assert not study_scope.notebook_in_scope("lab2.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab15.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab1.ipynb", study_scope.RUN_SCOPE)
+    assert not study_scope.notebook_in_scope(None, study_scope.QUEUE_SCOPE)
+
+
+def test_scope_for_mode():
+    assert study_scope.scope_for_mode("single") == study_scope.RUN_SCOPE
+    assert study_scope.scope_for_mode("multi") == study_scope.QUEUE_SCOPE

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -32,3 +32,21 @@ def test_out_of_scope_and_none():
 def test_scope_for_mode():
     assert study_scope.scope_for_mode("single") == study_scope.RUN_SCOPE
     assert study_scope.scope_for_mode("multi") == study_scope.QUEUE_SCOPE
+
+
+def test_queue_returns_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")   # in scope (Week 3)
+    _seed(session, 2, 0, "lab5.ipynb")   # out of scope (Week 8)
+    _seed(session, 3, 0, "lab2.ipynb")   # out of scope
+    resp = client.get("/api/queue?limit=50")
+    assert resp.status_code == 200
+    ids = {row["chatlog_id"] for row in resp.json()}
+    assert ids == {1}
+
+
+def test_queue_stats_counts_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")
+    _seed(session, 2, 0, "hw1.ipynb")
+    _seed(session, 3, 0, "lab5.ipynb")
+    stats = client.get("/api/queue/stats").json()
+    assert stats["total_messages"] == 2

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -1,5 +1,7 @@
 import study_scope
-from models import MessageCache
+import queue_service
+import decision_service
+from models import MessageCache, LabelDefinition
 
 
 def _seed(session, chatlog_id, message_index, notebook):
@@ -50,3 +52,20 @@ def test_queue_stats_counts_only_week3(client, session):
     _seed(session, 3, 0, "lab5.ipynb")
     stats = client.get("/api/queue/stats").json()
     assert stats["total_messages"] == 2
+
+
+def test_run_next_returns_only_week8(session):
+    # Seed an in-scope (Week 8) and an out-of-scope conversation.
+    _seed(session, 10, 0, "lab5.ipynb")   # Week 8 — in scope for single mode
+    _seed(session, 11, 0, "lab1.ipynb")   # Week 3 — out of scope for single mode
+    label = LabelDefinition(name="needs help", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+
+    picks = set()
+    for _ in range(10):
+        payload = queue_service.next_message_for_label(session, label.id)
+        if payload:
+            picks.add(payload["chatlog_id"])
+    assert picks <= {10}
+    assert 11 not in picks

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -27,7 +27,6 @@ export function Navigation() {
     mode === 'single'
       ? [
           labelingLink,
-          { to: '/assignments', label: 'Assignments' },
           { to: '/summaries', label: 'Summaries' },
           { to: '/analysis', label: 'Analysis' },
         ]
@@ -35,7 +34,6 @@ export function Navigation() {
           labelingLink,
           { to: '/history', label: 'History' },
           { to: '/labels', label: 'Labels' },
-          { to: '/assignments', label: 'Assignments' },
           { to: '/summaries', label: 'Summaries' },
           { to: '/analysis', label: 'Analysis' },
         ]

--- a/src/components/decision/DecisionWorkspace.tsx
+++ b/src/components/decision/DecisionWorkspace.tsx
@@ -67,8 +67,12 @@ export function DecisionWorkspace({
         h.onSkip?.()
       } else if (pressedKey === k.undo) {
         h.onUndo?.()
-      } else if (pressedKey === 'enter' || rawKey === 'enter') {
-        h.onAcceptAi?.()
+      } else if (rawKey === 'enter') {
+        if (h.onAcceptAi) {
+          h.onAcceptAi()
+        } else {
+          h.onSkip?.()
+        }
       }
     }
     window.addEventListener('keydown', onKey)

--- a/src/components/decision/KeybindSettingsModal.tsx
+++ b/src/components/decision/KeybindSettingsModal.tsx
@@ -41,6 +41,13 @@ export function KeybindSettingsModal({ open, onClose }: KeybindSettingsModalProp
 
   const formatKey = (key: string) => {
     if (key === ' ') return 'Space'
+    if (key === 'arrowleft') return '← Left'
+    if (key === 'arrowright') return '→ Right'
+    if (key === 'arrowup') return '↑ Up'
+    if (key === 'arrowdown') return '↓ Down'
+    if (key === 'enter') return 'Enter'
+    if (key === 'backspace') return 'Backspace'
+    if (key === 'escape') return 'Escape'
     if (key.length === 1) return key.toUpperCase()
     return key
   }

--- a/src/components/queue/MessageCard.tsx
+++ b/src/components/queue/MessageCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
@@ -10,6 +10,19 @@ import type {
 	ConversationMessage,
 } from "../../types";
 import { ConversationPanel } from "./ConversationPanel";
+import { useKeybinds } from "../../hooks/useKeybinds";
+
+function fmtKey(key: string): string {
+	if (key === " ") return "Space";
+	if (key === "arrowleft") return "←";
+	if (key === "arrowright") return "→";
+	if (key === "arrowup") return "↑";
+	if (key === "arrowdown") return "↓";
+	if (key === "enter") return "↵";
+	if (key === "backspace") return "⌫";
+	if (key === "escape") return "Esc";
+	return key.toUpperCase();
+}
 
 function stripMarkdown(md: string): string {
 	return md
@@ -106,6 +119,7 @@ export function MessageCard({
 	onCreateLabelForMessage,
 	tutorialDisabled = false,
 }: Props) {
+	const { keybinds } = useKeybinds();
 	const [showRationale, setShowRationale] = useState(false);
 	const [beforeExpanded, setBeforeExpanded] = useState(false);
 	const [afterExpanded, setAfterExpanded] = useState(false);
@@ -177,14 +191,14 @@ export function MessageCard({
 								onToggleConversation?.()
 							}
 							disabled={conversationLoading || conversationError}
-							className={`flex items-center gap-1 text-[9px] transition-colors ${
+							className={`flex items-center gap-1.5 text-[11px] font-semibold border rounded px-2 py-1 transition-colors ${
 								conversationLoading
-									? "text-disabled cursor-default"
+									? "text-disabled border-edge cursor-default"
 									: conversationError
-										? "text-faint cursor-default"
+										? "text-faint border-edge cursor-default"
 										: showConversation
-											? "text-ochre hover:text-paper"
-											: "text-muted hover:text-ochre"
+											? "text-ochre border-ochre hover:text-paper hover:border-paper"
+											: "text-ochre border-ochre/50 hover:border-ochre"
 							}`}
 							title={
 								conversationError
@@ -192,7 +206,7 @@ export function MessageCard({
 									: "View full conversation"
 							}
 						>
-							<MessageSquare size={11} />
+							<MessageSquare size={13} />
 							<span>
 								{conversationError
 									? "Conversation unavailable"
@@ -256,7 +270,7 @@ export function MessageCard({
 						</span>
 					) : !aiUnlocked ? (
 						<span className="text-[8px] text-disabled bg-surface border border-edge-subtle rounded px-1.5 py-0.5">
-							AI unlocks at 20
+							AI unlocks at 10
 						</span>
 					) : null}
 				</div>
@@ -331,34 +345,40 @@ export function MessageCard({
 						{!isReviewing && !isRecalibrating && canGoBack && (
 							<button
 								onClick={onBack}
-								className="font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors"
+								className="font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors inline-flex items-center gap-1.5"
+								title={`Go back (${fmtKey(keybinds.undo)})`}
 							>
 								← Back
+								<Kbd>{fmtKey(keybinds.undo)}</Kbd>
 							</button>
 						)}
 						{!isReviewing && !isRecalibrating && (
 							<button
 								onClick={onSkip}
 								disabled={tutorialDisabled}
-								className={`font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors ${tutorialDisabled ? 'opacity-50 pointer-events-none' : ''}`}
+								className={`font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors inline-flex items-center gap-1.5 ${tutorialDisabled ? 'opacity-50 pointer-events-none' : ''}`}
+								title={`Skip this message (${fmtKey(keybinds.skip)})`}
 							>
 								Skip
+								<Kbd>{fmtKey(keybinds.skip)}</Kbd>
 							</button>
 						)}
 						<button
 							onClick={onNext}
 							disabled={(!isReviewing && !isRecalibrating && !hasLabelsApplied) || tutorialDisabled}
-							className={`font-serif text-xs rounded-sm px-3 py-1.5 disabled:opacity-40 disabled:cursor-not-allowed transition-all ${
+							className={`font-serif text-xs rounded-sm px-3 py-1.5 disabled:opacity-40 disabled:cursor-not-allowed transition-all inline-flex items-center gap-1.5 ${
 								isRecalibrating
 									? recalibrationPhase === 'reconcile'
 										? 'border border-warning bg-warning text-bg-warm hover:brightness-110'
 										: 'border border-ochre bg-ochre text-bg-warm hover:brightness-110'
 									: 'border border-ochre bg-ochre text-bg-warm hover:brightness-110'
 							}`}
+							title={isReviewing ? undefined : `Next message (${fmtKey(keybinds.yes)} or ↵)`}
 						>
 							{isReviewing ? "Back to queue" : isRecalibrating
 								? recalibrationPhase === 'reconcile' ? 'Confirm →' : 'Next →'
 								: "Next →"}
+							{!isReviewing && <Kbd className="opacity-70">{fmtKey(keybinds.yes)}</Kbd>}
 						</button>
 					</>
 				)}
@@ -379,5 +399,13 @@ export function MessageCard({
 					/>
 				)}
 		</div>
+	);
+}
+
+function Kbd({ children, className }: { children: React.ReactNode; className?: string }) {
+	return (
+		<span className={`font-mono text-[9px] border border-current/30 rounded px-[3px] py-px opacity-60 ${className ?? ''}`}>
+			{children}
+		</span>
 	);
 }

--- a/src/components/queue/NewLabelPopover.tsx
+++ b/src/components/queue/NewLabelPopover.tsx
@@ -20,6 +20,7 @@ export function NewLabelPopover({ onConfirm, onCancel }: Props) {
       <p className="font-serif text-xs text-paper mb-2">New label</p>
       <input
         autoFocus
+        autoComplete="off"
         value={name}
         onChange={e => setName(e.target.value)}
         onKeyDown={e => e.key === 'Enter' && handleConfirm()}

--- a/src/components/queue/NewLabelPopover.tsx
+++ b/src/components/queue/NewLabelPopover.tsx
@@ -20,7 +20,7 @@ export function NewLabelPopover({ onConfirm, onCancel }: Props) {
       <p className="font-serif text-xs text-paper mb-2">New label</p>
       <input
         autoFocus
-        autoComplete="off"
+        autoComplete="new-password"
         value={name}
         onChange={e => setName(e.target.value)}
         onKeyDown={e => e.key === 'Enter' && handleConfirm()}

--- a/src/components/queue/ProgressSidebar.tsx
+++ b/src/components/queue/ProgressSidebar.tsx
@@ -26,6 +26,8 @@ interface Props {
   onCreateAndApply: (name: string, description?: string) => void
   onUpdateLabel: (id: number, body: UpdateLabelRequest) => void
   onStartAutolabel: () => void
+  onClearAutolabel: () => void
+  onStopAutolabel: () => void
   autolabelStatus: AutolabelStatus | null
   remaining: number | null
   history: HistoryItem[]
@@ -154,7 +156,7 @@ function SortableLabelItem({
 export function ProgressSidebar({
   session: _session, labels, stats, skippedCount,
   appliedLabelIds, onToggleLabel, onCreateAndApply, onUpdateLabel,
-  onStartAutolabel, autolabelStatus, remaining, history, onSelectHistoryItem, reviewingKey, onReorderLabels,
+  onStartAutolabel, onClearAutolabel, onStopAutolabel, autolabelStatus, remaining, history, onSelectHistoryItem, reviewingKey, onReorderLabels,
   onDeleteLabel, candidates, onDiscover, onOpenDiscoverModal, discovering,
   recalibration, recalibrationStats,
   tutorialDisabled = false,
@@ -196,7 +198,7 @@ export function ProgressSidebar({
   const suggestPct = Math.min(100, Math.round((labeled / suggestThreshold) * 100))
   const suggestUnlocked = labeled >= suggestThreshold
 
-  const autolabelThreshold = Math.min(Math.ceil(total * 0.3), 20)
+  const autolabelThreshold = 25
   const autolabelPct = autolabelThreshold > 0 ? Math.min(100, Math.round((labeled / autolabelThreshold) * 100)) : 0
   const autolabelUnlocked = labeled >= autolabelThreshold && autolabelThreshold > 0
 
@@ -250,8 +252,9 @@ export function ProgressSidebar({
   }, [labels, onReorderLabels])
 
   return (
-    <aside className="w-52 shrink-0 border-r border-edge bg-canvas p-4 flex flex-col h-full min-h-0 gap-5">
-      <div className="shrink-0">
+    <aside className="w-52 shrink-0 border-r border-edge bg-canvas flex flex-col h-full min-h-0">
+      {/* Labeled — always pinned at top */}
+      <div className="shrink-0 p-4 pb-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-faint mb-2">Labeled</p>
         <div className="h-1.5 bg-elevated rounded-sm mb-1.5">
           <div className="h-1.5 bg-ochre rounded-sm transition-all" style={{ width: `${pct}%` }} />
@@ -265,7 +268,10 @@ export function ProgressSidebar({
         )}
       </div>
 
-      <div className="shrink-0 flex flex-col gap-3" data-tutorial="ai-milestones">
+      {/* Everything below scrolls as one unit */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-4 flex flex-col gap-5 [scrollbar-color:theme(colors.neutral.600)_transparent]">
+
+      <div className="flex flex-col gap-3" data-tutorial="ai-milestones">
         <div>
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-faint mb-1.5">AI suggestions</p>
           {suggestUnlocked ? (
@@ -283,24 +289,49 @@ export function ProgressSidebar({
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-faint mb-1.5">Auto-labeling</p>
           {autolabelStatus?.running ? (
             <>
-              <div className="h-1 bg-elevated rounded-full mb-1">
-                <div
-                  className="h-1 bg-ochre rounded-full transition-all"
-                  style={{ width: `${autolabelStatus.total > 0 ? Math.round((autolabelStatus.processed / autolabelStatus.total) * 100) : 0}%` }}
-                />
+              <div className="h-1 bg-elevated rounded-full mb-1 overflow-hidden">
+                {autolabelStatus.total > 0 && autolabelStatus.processed > 0 ? (
+                  <div
+                    className="h-1 bg-ochre rounded-full transition-all duration-500"
+                    style={{ width: `${Math.round((autolabelStatus.processed / autolabelStatus.total) * 100)}%` }}
+                  />
+                ) : (
+                  <div className="h-1 bg-ochre rounded-full w-full animate-pulse" />
+                )}
               </div>
-              <p className="text-[10px] text-ochre">
-                Labeling... {autolabelStatus.processed.toLocaleString()} / {autolabelStatus.total.toLocaleString()}
-              </p>
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[10px] text-ochre flex items-center gap-1">
+                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-ochre animate-ping shrink-0" />
+                  {autolabelStatus.total > 0
+                    ? `Labeling… ${autolabelStatus.processed.toLocaleString()} / ${autolabelStatus.total.toLocaleString()}`
+                    : 'Starting…'}
+                </p>
+                <button
+                  onClick={onStopAutolabel}
+                  title="Stop after current batch — saves progress"
+                  className="font-mono text-[9px] border border-edge text-faint rounded-sm px-1.5 py-0.5 hover:border-brick hover:text-brick transition-colors shrink-0"
+                >
+                  Stop
+                </button>
+              </div>
             </>
           ) : autolabelUnlocked ? (
             <>
-              <button
-                onClick={onStartAutolabel}
-                className="w-full font-mono text-[10px] border border-ochre bg-ochre text-bg-warm rounded-sm px-2 py-1.5 hover:brightness-110 transition-all"
-              >
-                Auto-label {(total - labeled).toLocaleString()} remaining
-              </button>
+              <div className="flex gap-1">
+                <button
+                  onClick={onStartAutolabel}
+                  className="flex-1 font-mono text-[10px] border border-ochre bg-ochre text-bg-warm rounded-sm px-2 py-1.5 hover:brightness-110 transition-all"
+                >
+                  Auto-label {(total - labeled).toLocaleString()} remaining
+                </button>
+                <button
+                  onClick={onClearAutolabel}
+                  title="Delete all AI-applied labels (reset for re-testing)"
+                  className="font-mono text-[10px] border border-edge text-faint rounded-sm px-2 py-1.5 hover:border-brick hover:text-brick transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
               {autolabelStatus?.error && (
                 <p className="text-[10px] text-danger-text mt-1">{autolabelStatus.error}</p>
               )}
@@ -327,14 +358,14 @@ export function ProgressSidebar({
         />
       </div>
 
-      <div className="flex-1 min-h-0 flex flex-col overflow-hidden" data-tutorial="label-list">
+      <div data-tutorial="label-list">
         <p className="text-[10px] uppercase tracking-widest text-faint mb-2">
           {recalibration?.phase === 'reconcile' ? 'Reconcile Labels' : 'Labels'}
         </p>
         {recalibration?.phase === 'reconcile' && (
           <p className="text-[10px] text-disabled mb-2">Toggle with 1-9 keys, {formatKey(keybinds.yes)} to confirm</p>
         )}
-        <div className="flex flex-col gap-1.5 overflow-y-auto flex-1 min-h-0">
+        <div className="flex flex-col gap-1.5">
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={labels.map(l => l.id)} strategy={verticalListSortingStrategy}>
               {labels.map((label, idx) => {
@@ -404,7 +435,7 @@ export function ProgressSidebar({
         </div>
       </div>
 
-      <div className="shrink-0 flex flex-col gap-3">
+      <div className="flex flex-col gap-3">
         <RecentHistory items={history} onSelect={onSelectHistoryItem} reviewingKey={reviewingKey} />
         {recalibrationStats && recalibrationStats.total_recalibrations > 0 && (
           <div className="border-t border-edge-subtle pt-3">
@@ -447,6 +478,7 @@ export function ProgressSidebar({
         </div>
         )}
       </div>
+      </div>{/* end scrollable area */}
       {contextMenu && (
         <LabelContextMenu
           x={contextMenu.x}

--- a/src/components/queue/ProgressSidebar.tsx
+++ b/src/components/queue/ProgressSidebar.tsx
@@ -191,11 +191,12 @@ export function ProgressSidebar({
   const total = stats?.total_messages ?? 0
   const pct = total > 0 ? Math.round((labeled / total) * 100) : 0
 
-  const suggestThreshold = 20
+  // Thresholds lowered for the week-scoped study build (small Week-3 pool).
+  const suggestThreshold = 10
   const suggestPct = Math.min(100, Math.round((labeled / suggestThreshold) * 100))
   const suggestUnlocked = labeled >= suggestThreshold
 
-  const autolabelThreshold = Math.min(Math.ceil(total * 0.4), 100)
+  const autolabelThreshold = Math.min(Math.ceil(total * 0.3), 20)
   const autolabelPct = autolabelThreshold > 0 ? Math.min(100, Math.round((labeled / autolabelThreshold) * 100)) : 0
   const autolabelUnlocked = labeled >= autolabelThreshold && autolabelThreshold > 0
 
@@ -318,7 +319,7 @@ export function ProgressSidebar({
       <div className="shrink-0">
         <DiscoverSection
           candidates={candidates}
-          aiUnlocked={(stats?.labeled_count ?? 0) >= 20}
+          aiUnlocked={(stats?.labeled_count ?? 0) >= 10}
           labeledCount={stats?.labeled_count ?? 0}
           onDiscover={onDiscover}
           onOpenModal={onOpenDiscoverModal}

--- a/src/components/run/DecisionDock.tsx
+++ b/src/components/run/DecisionDock.tsx
@@ -38,6 +38,13 @@ export function DecisionDock({
 
   const formatKey = (key: string) => {
     if (key === ' ') return '␣'
+    if (key === 'arrowleft') return '←'
+    if (key === 'arrowright') return '→'
+    if (key === 'arrowup') return '↑'
+    if (key === 'arrowdown') return '↓'
+    if (key === 'enter') return '↵'
+    if (key === 'backspace') return '⌫'
+    if (key === 'escape') return 'Esc'
     return key.toUpperCase()
   }
 
@@ -85,7 +92,7 @@ export function DecisionDock({
           </div>
         ) : skipOnly ? (
           <p className="mx-auto mt-3.5 max-w-[760px] text-center font-mono text-[10px] tracking-[0.08em] text-faint">
-            <KeyChip>{formatKey(keybinds.skip)}</KeyChip> next message ·{' '}
+            <KeyChip>{formatKey(keybinds.skip)}</KeyChip> or <KeyChip>↵</KeyChip> next message ·{' '}
             <KeyChip>⇧{formatKey(keybinds.skip)}</KeyChip> another conversation
           </p>
         ) : (
@@ -104,9 +111,9 @@ export function DecisionDock({
               type="button"
               onClick={onHandoff}
               className="hover:text-on-canvas transition-colors"
-              title="Open handoff readiness (Enter)"
+              title="Open handoff readiness"
             >
-              <KeyChip>⏎</KeyChip> hand off
+              hand off
             </button>
             <button
               onClick={() => setSettingsOpen(true)}
@@ -140,6 +147,10 @@ function RecentLine({
   const word = recent.value === 'yes' ? 'Yes' : recent.value === 'no' ? 'No' : 'Skip'
   const formatKey = (key: string) => {
     if (key === ' ') return 'Space'
+    if (key === 'arrowleft') return '←'
+    if (key === 'arrowright') return '→'
+    if (key === 'enter') return '↵'
+    if (key === 'backspace') return '⌫'
     return key.toUpperCase()
   }
 

--- a/src/components/run/HandoffReadyModal.tsx
+++ b/src/components/run/HandoffReadyModal.tsx
@@ -1,0 +1,44 @@
+interface HandoffReadyModalProps {
+  onHandoff: () => void
+  onDismiss: () => void
+}
+
+export function HandoffReadyModal({ onHandoff, onDismiss }: HandoffReadyModalProps) {
+  return (
+    <>
+      <div className="fixed inset-0 bg-overlay z-40" onClick={onDismiss} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(420px,92vw)] bg-bg-warm border border-edge rounded-md shadow-2xl z-50"
+      >
+        <div className="px-[22px] pt-[20px] pb-3 border-b border-edge-subtle">
+          <div className="font-mono text-[9px] tracking-[0.18em] uppercase text-moss mb-1.5">
+            ✦ Ready
+          </div>
+          <h3 className="font-serif font-medium text-[22px] text-paper m-0 tracking-[-0.014em] leading-[1.2]">
+            Handoff is ready
+          </h3>
+          <p className="mt-2 font-serif text-[13px] text-muted leading-[1.5]">
+            You've labeled enough examples for Gemini to take over the rest. You can hand off now
+            or keep labeling to improve accuracy.
+          </p>
+        </div>
+        <div className="flex items-center gap-3 px-[22px] py-[18px]">
+          <button
+            onClick={onDismiss}
+            className="appearance-none border border-edge bg-transparent text-on-surface px-4 py-[9px] rounded-sm cursor-pointer font-sans font-medium text-[13px] hover:text-on-canvas hover:border-faint transition-colors"
+          >
+            Keep labeling
+          </button>
+          <button
+            onClick={onHandoff}
+            className="appearance-none border border-moss bg-moss/10 text-moss px-4 py-[9px] rounded-sm cursor-pointer font-sans font-semibold text-[13px] hover:bg-moss/20 transition-colors"
+          >
+            Hand off to Gemini →
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react'
+import type { LabelNameSuggestion } from '../../types'
+
+interface LabelNameInputProps {
+  value: string
+  onChange: (value: string) => void
+  onCommit?: () => void
+  suggestions: LabelNameSuggestion[]
+  placeholder?: string
+  readOnly?: boolean
+  autoFocus?: boolean
+  className?: string
+  onBlur?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  'data-tutorial'?: string
+}
+
+export function LabelNameInput({
+  value,
+  onChange,
+  onCommit,
+  suggestions,
+  placeholder,
+  readOnly,
+  autoFocus,
+  className,
+  onBlur,
+  onKeyDown,
+  ...rest
+}: LabelNameInputProps) {
+  const [open, setOpen] = useState(false)
+  const [highlighted, setHighlighted] = useState(0)
+
+  const filtered = suggestions.filter(
+    (s) =>
+      value.length > 0 &&
+      s.name.toLowerCase().includes(value.toLowerCase()) &&
+      s.name.toLowerCase() !== value.toLowerCase()
+  )
+  const showDropdown = open && filtered.length > 0
+
+  useEffect(() => {
+    setHighlighted(0)
+  }, [value])
+
+  function select(name: string) {
+    onChange(name)
+    setOpen(false)
+    onCommit?.()
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (showDropdown) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setHighlighted((h) => Math.min(h + 1, filtered.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setHighlighted((h) => Math.max(h - 1, 0))
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        select(filtered[highlighted].name)
+        return
+      }
+      if (e.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+    }
+    onKeyDown?.(e)
+  }
+
+  return (
+    <div className="relative">
+      <input
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        type="text"
+        autoComplete="off"
+        value={value}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        className={className}
+        onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => { setTimeout(() => setOpen(false), 150); onBlur?.() }}
+        onKeyDown={handleKeyDown}
+        {...rest}
+      />
+      {showDropdown && (
+        <ul
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-lg"
+        >
+          {filtered.map((s, i) => (
+            <li
+              key={s.name}
+              role="option"
+              aria-selected={i === highlighted}
+              className={`cursor-pointer px-3 py-2 ${
+                i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
+              }`}
+              onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
+              onMouseEnter={() => setHighlighted(i)}
+            >
+              <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
+              {s.description && (
+                <div className="truncate text-xs text-muted">{s.description}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -13,6 +13,7 @@ interface LabelNameInputProps {
   onBlur?: () => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
   'data-tutorial'?: string
+  'data-note-input'?: string
 }
 
 export function LabelNameInput({

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -119,6 +119,7 @@ export function LabelNameInput({
 
   return (
     <>
+      <form autoComplete="off" onSubmit={(e) => e.preventDefault()} style={{ display: 'contents' }}>
       <input
         ref={inputRef}
         role="combobox"
@@ -138,6 +139,7 @@ export function LabelNameInput({
         onKeyDown={handleKeyDown}
         {...rest}
       />
+      </form>
       {dropdown}
     </>
   )

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import type { LabelNameSuggestion } from '../../types'
 
 interface LabelNameInputProps {
@@ -31,18 +32,26 @@ export function LabelNameInput({
 }: LabelNameInputProps) {
   const [open, setOpen] = useState(false)
   const [highlighted, setHighlighted] = useState(0)
+  const [dropdownRect, setDropdownRect] = useState<DOMRect | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const filtered = suggestions.filter(
     (s) =>
-      value.length > 0 &&
-      s.name.toLowerCase().includes(value.toLowerCase()) &&
-      s.name.toLowerCase() !== value.toLowerCase()
+      s.name.toLowerCase() !== value.toLowerCase() &&
+      (value.length === 0 || s.name.toLowerCase().includes(value.toLowerCase()))
   )
   const showDropdown = open && filtered.length > 0
 
   useEffect(() => {
     setHighlighted(0)
   }, [value])
+
+  // Measure input position whenever dropdown opens so the portal is positioned correctly
+  useEffect(() => {
+    if (showDropdown && inputRef.current) {
+      setDropdownRect(inputRef.current.getBoundingClientRect())
+    }
+  }, [showDropdown])
 
   function select(name: string) {
     onChange(name)
@@ -75,15 +84,49 @@ export function LabelNameInput({
     onKeyDown?.(e)
   }
 
+  const dropdown = showDropdown && dropdownRect ? createPortal(
+    <ul
+      role="listbox"
+      style={{
+        position: 'fixed',
+        top: dropdownRect.bottom + 2,
+        left: dropdownRect.left,
+        width: dropdownRect.width,
+        zIndex: 9999,
+      }}
+      className="max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-xl"
+    >
+      {filtered.map((s, i) => (
+        <li
+          key={s.name}
+          role="option"
+          aria-selected={i === highlighted}
+          className={`cursor-pointer px-3 py-2 ${
+            i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
+          }`}
+          onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
+          onMouseEnter={() => setHighlighted(i)}
+        >
+          <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
+          {s.description && (
+            <div className="truncate text-xs text-muted">{s.description}</div>
+          )}
+        </li>
+      ))}
+    </ul>,
+    document.body
+  ) : null
+
   return (
-    <div className="relative">
+    <>
       <input
+        ref={inputRef}
         role="combobox"
         aria-autocomplete="list"
         aria-expanded={showDropdown}
         aria-haspopup="listbox"
         type="text"
-        autoComplete="off"
+        autoComplete="new-password"
         value={value}
         readOnly={readOnly}
         autoFocus={autoFocus}
@@ -95,30 +138,7 @@ export function LabelNameInput({
         onKeyDown={handleKeyDown}
         {...rest}
       />
-      {showDropdown && (
-        <ul
-          role="listbox"
-          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-lg"
-        >
-          {filtered.map((s, i) => (
-            <li
-              key={s.name}
-              role="option"
-              aria-selected={i === highlighted}
-              className={`cursor-pointer px-3 py-2 ${
-                i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
-              }`}
-              onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
-              onMouseEnter={() => setHighlighted(i)}
-            >
-              <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
-              {s.description && (
-                <div className="truncate text-xs text-muted">{s.description}</div>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+      {dropdown}
+    </>
   )
 }

--- a/src/components/run/NoteLabelPopover.tsx
+++ b/src/components/run/NoteLabelPopover.tsx
@@ -1,19 +1,23 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { LabelNameInput } from './LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
 
 interface NoteLabelPopoverProps {
   open: boolean
   onClose: () => void
   onSubmit: (name: string, description: string) => void
+  suggestions?: LabelNameSuggestion[]
 }
 
-export function NoteLabelPopover({ open, onClose, onSubmit }: NoteLabelPopoverProps) {
+export function NoteLabelPopover({ open, onClose, onSubmit, suggestions = [] }: NoteLabelPopoverProps) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
-  const nameRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (open) {
-      requestAnimationFrame(() => nameRef.current?.focus())
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLInputElement>('[data-note-input]')?.focus()
+      })
     } else {
       setName('')
       setDescription('')
@@ -26,7 +30,10 @@ export function NoteLabelPopover({ open, onClose, onSubmit }: NoteLabelPopoverPr
       if (e.key === 'Escape') {
         e.preventDefault()
         onClose()
-      } else if (e.key === 'Enter' && document.activeElement === nameRef.current) {
+      } else if (
+        e.key === 'Enter' &&
+        (document.activeElement as HTMLElement)?.dataset?.noteInput !== undefined
+      ) {
         e.preventDefault()
         if (name.trim()) onSubmit(name.trim(), description.trim())
       }
@@ -62,14 +69,15 @@ export function NoteLabelPopover({ open, onClose, onSubmit }: NoteLabelPopoverPr
         </div>
         <div className="px-[22px] pt-4 pb-3 flex flex-col gap-3.5">
           <Field label="Name">
-            <input
-              ref={nameRef}
-              type="text"
-              autoComplete="off"
+            <LabelNameInput
+              data-note-input=""
+              autoFocus
               placeholder="e.g. frustration"
               value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="appearance-none bg-canvas border border-edge text-on-canvas px-[11px] py-[9px] rounded-sm font-sans text-[13px] focus:outline-none focus:border-ochre-dim"
+              suggestions={suggestions}
+              onChange={setName}
+              onCommit={() => { if (name.trim()) onSubmit(name.trim(), description.trim()) }}
+              className="appearance-none bg-canvas border border-edge text-on-canvas px-[11px] py-[9px] rounded-sm font-sans text-[13px] focus:outline-none focus:border-ochre-dim w-full"
             />
           </Field>
           <Field label="Description (optional)">

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount } from '../../types'
 import { api } from '../../services/api'
-import { AssignmentPicker } from './AssignmentPicker'
 import { ReadinessChip } from './ReadinessChip'
 import { HoverTip } from './HoverTip'
 import { isPlaceholderLabelName } from './labelPlaceholder'
@@ -34,10 +33,9 @@ export interface StripBarProps {
 export function StripBar({
   label,
   readiness,
-  assignments,
-  unmapped,
-  selectedAssignmentId,
-  onSelectAssignment,
+  // assignment-picker props (assignments/unmapped/selectedAssignmentId/
+  // onSelectAssignment) are intentionally unused: the route is week-locked
+  // server-side, so the picker is replaced by a static scope label.
   onHandoff,
   onLabelMetaUpdated,
   onSampleHandoff,
@@ -181,12 +179,10 @@ export function StripBar({
         {/* Conversations: assignment filter + explore sampling (menu portals) */}
         <div className="relative z-10 min-w-0 md:flex md:justify-end">
           <div className="flex w-max max-w-full flex-wrap items-center gap-6 md:justify-end">
-            <AssignmentPicker
-              assignments={assignments}
-              unmapped={unmapped}
-              selectedId={selectedAssignmentId}
-              onSelect={onSelectAssignment}
-            />
+            <span className="inline-flex items-center gap-2 font-mono text-[11px] text-muted">
+              <span className="text-[9px] tracking-[0.06em] uppercase text-faint">scope</span>
+              <span className="text-fg">Week 8 — Lab 5 &amp; HW 5</span>
+            </span>
             {!draftMode && onLabelMetaUpdated && (
               <div className="inline-flex items-center gap-2 font-mono text-[11px] text-muted">
                 <HoverTip

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -14,7 +14,6 @@ export interface StripBarProps {
   onSelectAssignment: (id: number | null) => void
   onHandoff?: () => void
   onLabelMetaUpdated?: () => void | Promise<void>
-  onSampleHandoff?: (n: number) => void
   readinessOpen?: boolean
   onReadinessOpenChange?: (open: boolean) => void
   labelNameDraft?: string
@@ -38,7 +37,6 @@ export function StripBar({
   // server-side, so the picker is replaced by a static scope label.
   onHandoff,
   onLabelMetaUpdated,
-  onSampleHandoff,
   readinessOpen,
   onReadinessOpenChange,
   labelNameDraft,
@@ -63,7 +61,6 @@ export function StripBar({
 
   const [explorePct, setExplorePct] = useState(0)
   const [exploreBusy, setExploreBusy] = useState(false)
-  const [sampleN, setSampleN] = useState(50)
 
   useEffect(() => {
     const eff = label.hybrid_explore_effective ?? 0.35
@@ -220,44 +217,6 @@ export function StripBar({
                     default
                   </button>
                 )}
-              </div>
-            )}
-            {!draftMode && import.meta.env.DEV && onSampleHandoff && (
-              <div className="inline-flex items-center gap-2 rounded-full border border-dashed border-edge px-2.5 py-1 font-mono text-[11px]">
-                <HoverTip
-                  label="dev · sample handoff"
-                  className="text-[9px] tracking-[0.06em] uppercase text-faint"
-                  tip={
-                    'Developer smoke test for the Hand off pipeline. The number is how many ' +
-                    'random unlabeled messages Gemini classifies, not a new conversation sample.'
-                  }
-                />
-                <input
-                  type="number"
-                  min={1}
-                  value={sampleN}
-                  onChange={(e) => setSampleN(parseInt(e.target.value, 10) || 0)}
-                  aria-label="Sample handoff message count"
-                  className="w-10 border-b border-edge bg-transparent text-center tabular-nums focus:outline-none"
-                />
-                <HoverTip
-                  label={
-                    <button
-                      type="button"
-                      disabled={!Number.isFinite(sampleN) || sampleN <= 0}
-                      onClick={() => onSampleHandoff(sampleN)}
-                      className="border-0 bg-transparent p-0 font-inherit text-inherit text-on-surface hover:text-ochre disabled:opacity-40 cursor-pointer"
-                    >
-                      Sample →
-                    </button>
-                  }
-                  className="normal-case tracking-normal"
-                  tip={
-                    'Runs Hand off on this label for N random pending messages, then deactivates it. ' +
-                    'Progress on Summaries. /run switches to the next queued label, or the draft ' +
-                    'screen if none is queued, not another explore pick.'
-                  }
-                />
               </div>
             )}
           </div>

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -125,7 +125,7 @@ export function StripBar({
                     if (draftMode || labelNameLocked) return
                     onLabelNameCommit?.()
                   }}
-                  placeholder="Label name…"
+                  placeholder="Type a label…"
                   className="box-border w-full min-w-[10rem] max-w-[18rem] rounded-sm border border-edge bg-surface px-2.5 py-1.5 font-sans text-sm text-on-canvas placeholder:text-faint focus:outline-none focus:border-ochre-dim disabled:opacity-70"
                 />
               ) : (

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -101,6 +101,7 @@ export function StripBar({
               {showNameInput ? (
                 <input
                   type="text"
+                  autoComplete="off"
                   data-tutorial="label-name"
                   value={labelNameDraft ?? ''}
                   readOnly={labelNameLocked}

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount } from '../../types'
+import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount, LabelNameSuggestion } from '../../types'
 import { api } from '../../services/api'
 import { ReadinessChip } from './ReadinessChip'
 import { HoverTip } from './HoverTip'
 import { isPlaceholderLabelName } from './labelPlaceholder'
+import { LabelNameInput } from './LabelNameInput'
 
 export interface StripBarProps {
   label: SingleLabel
@@ -27,6 +28,7 @@ export interface StripBarProps {
   onClearAll?: () => void
   onSwitchQueued?: (id: number) => void
   onRemoveQueued?: (id: number) => void
+  suggestions?: LabelNameSuggestion[]
 }
 
 export function StripBar({
@@ -50,6 +52,7 @@ export function StripBar({
   onClearAll,
   onSwitchQueued,
   onRemoveQueued,
+  suggestions = [],
 }: StripBarProps) {
   const showNameInput =
     draftMode ||
@@ -99,13 +102,18 @@ export function StripBar({
             <div className="flex min-w-0 max-w-full items-center gap-2.5">
               <span className="text-ochre text-[11px]">◆</span>
               {showNameInput ? (
-                <input
-                  type="text"
-                  autoComplete="off"
+                <LabelNameInput
                   data-tutorial="label-name"
                   value={labelNameDraft ?? ''}
                   readOnly={labelNameLocked}
-                  onChange={(e) => onLabelNameDraftChange?.(e.target.value)}
+                  suggestions={suggestions}
+                  onChange={(v) => onLabelNameDraftChange?.(v)}
+                  onCommit={() => {
+                    const name = (labelNameDraft ?? '').trim()
+                    if (name && !isPlaceholderLabelName(name) && !labelNameLocked) {
+                      commitName?.()
+                    }
+                  }}
                   onKeyDown={(e) => {
                     const name = (labelNameDraft ?? '').trim()
                     if (e.key === 'Enter' && name && !isPlaceholderLabelName(name) && !labelNameLocked) {

--- a/src/components/summaries/BrowseTab.tsx
+++ b/src/components/summaries/BrowseTab.tsx
@@ -106,6 +106,34 @@ export function BrowseTab({ label, onLabelChanged }: BrowseTabProps) {
     [activeKey, label.id],
   )
 
+  const toggleFlag = useCallback(async () => {
+    if (!activeKey || !detail) return
+    const next = !detail.flagged
+    const prev = detail
+    setDetail({ ...detail, flagged: next })
+    setItems((cur) =>
+      cur.map((it) =>
+        it.chatlog_id === activeKey.chatlog_id && it.message_index === activeKey.message_index
+          ? { ...it, flagged: next }
+          : it,
+      ),
+    )
+    try {
+      await api.setSingleLabelFlag(label.id, activeKey.chatlog_id, activeKey.message_index, next)
+    } catch {
+      setError('Flag failed — retry?')
+      setTimeout(() => setError(null), 4000)
+      setDetail(prev)
+      setItems((cur) =>
+        cur.map((it) =>
+          it.chatlog_id === activeKey.chatlog_id && it.message_index === activeKey.message_index
+            ? { ...it, flagged: prev.flagged }
+            : it,
+        ),
+      )
+    }
+  }, [activeKey, detail, label.id])
+
   return (
     <>
       <div className="flex-1 grid grid-cols-[5fr_6fr] min-h-0">
@@ -131,7 +159,7 @@ export function BrowseTab({ label, onLabelChanged }: BrowseTabProps) {
               reviewThreshold={label.review_threshold}
               onAccept={accept}
               onFlip={flip}
-              onFlag={() => { /* Phase 2 */ }}
+              onFlag={toggleFlag}
               onSaveNote={saveNote}
             />
           ) : (

--- a/src/components/summaries/FocusedMessage.tsx
+++ b/src/components/summaries/FocusedMessage.tsx
@@ -39,6 +39,7 @@ export function FocusedMessage({
         matchedPattern={detail.matched_pattern}
         rationale={detail.rationale}
         nearThreshold={nearThreshold}
+        flagged={detail.flagged}
         onAccept={onAccept}
         onFlip={onFlip}
         onFlag={onFlag}

--- a/src/components/summaries/VerdictBlock.tsx
+++ b/src/components/summaries/VerdictBlock.tsx
@@ -9,6 +9,7 @@ interface VerdictBlockProps {
   matchedPattern: string | null
   rationale: string | null
   nearThreshold: boolean
+  flagged: boolean
   onAccept: () => void
   onFlip: (newVerdict: 'yes' | 'no') => void
   onFlag: () => void
@@ -21,7 +22,7 @@ function badgeStyles(v: MessageVerdict | null) {
 }
 
 export function VerdictBlock({
-  verdict, confidence, appliedBy, matchedPattern, rationale, nearThreshold,
+  verdict, confidence, appliedBy, matchedPattern, rationale, nearThreshold, flagged,
   onAccept, onFlip, onFlag,
 }: VerdictBlockProps) {
   const [whyOpen, setWhyOpen] = useState(false)
@@ -66,7 +67,16 @@ export function VerdictBlock({
       <div className="mt-3 flex gap-1.5 flex-wrap">
         <button onClick={onAccept} className="px-3 py-1.5 rounded-sm bg-moss-dim border border-moss text-paper font-mono text-[10px] tracking-[0.08em] uppercase">✓ accept</button>
         <button onClick={() => onFlip(oppositeVerdict)} className="px-3 py-1.5 rounded-sm border border-edge text-on-surface font-mono text-[10px] tracking-[0.08em] uppercase hover:text-paper hover:border-paper">↺ flip</button>
-        <button onClick={onFlag} className="px-3 py-1.5 rounded-sm border border-ochre-dim text-ochre font-mono text-[10px] tracking-[0.08em] uppercase">⚑ flag</button>
+        <button
+          onClick={onFlag}
+          className={`px-3 py-1.5 rounded-sm font-mono text-[10px] tracking-[0.08em] uppercase ${
+            flagged
+              ? 'border border-ochre bg-[rgba(228,181,59,0.12)] text-ochre'
+              : 'border border-ochre-dim text-ochre'
+          }`}
+        >
+          ⚑ {flagged ? 'flagged' : 'flag'}
+        </button>
       </div>
     </div>
   )

--- a/src/hooks/useKeybinds.tsx
+++ b/src/hooks/useKeybinds.tsx
@@ -7,10 +7,10 @@ export type KeybindMap = Record<Action, string>
 const STORAGE_KEY = 'chatsight-keybinds'
 
 const DEFAULT_KEYBINDS: KeybindMap = {
-  yes: 'a',
+  yes: 'z',
   no: 'd',
-  skip: ' ', // Space
-  undo: 's',
+  skip: 'arrowright',
+  undo: 'arrowleft',
 }
 
 type KeybindContextValue = {

--- a/src/hooks/useLabelSuggestions.ts
+++ b/src/hooks/useLabelSuggestions.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react'
+import { api } from '../services/api'
+import type { LabelNameSuggestion } from '../types'
+
+export function useLabelSuggestions() {
+  const [suggestions, setSuggestions] = useState<LabelNameSuggestion[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getNameSuggestions()
+      .then(setSuggestions)
+      .catch(() => setSuggestions([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { suggestions, loading }
+}

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -538,17 +538,39 @@ export function LabelRunPage() {
   const handleSwitchToQueued = useCallback(
     async (id: number) => {
       if (busy) return
+      const hintChatlogId = focused?.chatlog_id
       setBusyMessage('Switching label…')
       setBusy(true)
       try {
         await api.switchToLabel(id)
         setBusyMessage('Loading label…')
-        await refresh()
+        // Use hintChatlogId so the new label opens on the same conversation.
+        // refresh() is still called but we override getNextFocused with the hint.
+        const [active, a, um] = await Promise.all([
+          api.getActiveSingleLabel(),
+          api.listAssignments(),
+          api.getUnmappedCount(),
+        ])
+        setAssignments(a)
+        setUnmapped(um)
+        if (active) {
+          const [next, ready, q] = await Promise.all([
+            api.getNextFocused(active.id, selectedAssignmentId ?? undefined, hintChatlogId),
+            api.getReadiness(active.id),
+            api.listSingleLabels({ phase: 'queued' }),
+          ])
+          setActiveLabel(active)
+          setFocused(next)
+          setReadiness(ready)
+          setQueued(q)
+          setReviewQueue(null)
+          setReviewIdx(0)
+        }
       } finally {
         setBusy(false)
       }
     },
-    [busy, refresh]
+    [busy, focused?.chatlog_id, selectedAssignmentId]
   )
 
   const progressActive = loading || busy || handoffPending

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -458,23 +458,6 @@ export function LabelRunPage() {
     }
   }, [activeLabel, handoffPending, refresh])
 
-  const handleSampleHandoff = useCallback(async (n: number) => {
-    if (!activeLabel || handoffPending) return
-    setHandoffPending(true)
-    setLoadError(null)
-    try {
-      await api.handoffSingleLabel(activeLabel.id, n)
-      await refresh()
-    } catch (e) {
-      console.error('sample handoff failed', e)
-      setLoadError(
-        e instanceof Error ? e.message : 'Sample handoff failed. Check the server logs.',
-      )
-    } finally {
-      setHandoffPending(false)
-    }
-  }, [activeLabel, handoffPending, refresh])
-
   const handleContinueToReview = useCallback(async () => {
     setSummaryOpen(false)
     if (!activeLabel) return
@@ -696,7 +679,6 @@ export function LabelRunPage() {
                 onSelectAssignment={() => {}}
                 onHandoff={handleHandoff}
                 onLabelMetaUpdated={refresh}
-                onSampleHandoff={handleSampleHandoff}
                 readinessOpen={readinessOpen}
                 onReadinessOpenChange={setReadinessOpen}
                 queued={queued}
@@ -776,7 +758,6 @@ export function LabelRunPage() {
               labelNameLocked={tutorialActive}
               onHandoff={draftMode ? undefined : handleHandoff}
               onLabelMetaUpdated={draftMode ? undefined : refresh}
-              onSampleHandoff={draftMode ? undefined : handleSampleHandoff}
               readinessOpen={readinessOpen}
               onReadinessOpenChange={setReadinessOpen}
               queued={queued}

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -20,6 +20,7 @@ import {
 import { DecisionDock } from '../components/run/DecisionDock'
 import { RunProgressOverlay } from '../components/run/RunProgressOverlay'
 import { NoteLabelPopover } from '../components/run/NoteLabelPopover'
+import { HandoffReadyModal } from '../components/run/HandoffReadyModal'
 import { SummaryModal } from '../components/run/SummaryModal'
 import { AbortConfirmModal } from '../components/run/AbortConfirmModal'
 import { DecisionWorkspace } from '../components/decision/DecisionWorkspace'
@@ -63,6 +64,9 @@ export function LabelRunPage() {
   const [assistNeighbors, setAssistNeighbors] = useState<AssistNeighbor[]>([])
   const [abortOpen, setAbortOpen] = useState(false)
   const [readinessOpen, setReadinessOpen] = useState(false)
+  const [handoffReadyOpen, setHandoffReadyOpen] = useState(false)
+  // Track which label IDs have already shown the handoff-ready popup so it only fires once.
+  const handoffReadyShownRef = useRef<Set<number>>(new Set())
   const [loadError, setLoadError] = useState<string | null>(null)
   const [tutorialStep, setTutorialStep] = useState<RunTutorialStep | null>(null)
   const [labelNameDraft, setLabelNameDraft] = useState('')
@@ -75,6 +79,20 @@ export function LabelRunPage() {
   useEffect(() => {
     activeLabelIdRef.current = activeLabel?.id ?? null
   }, [activeLabel?.id])
+
+  // Show handoff-ready popup once when readiness first hits green for this label.
+  useEffect(() => {
+    const labelId = activeLabel?.id
+    if (
+      labelId != null &&
+      readiness?.tier === 'green' &&
+      activeLabel?.phase === 'labeling' &&
+      !handoffReadyShownRef.current.has(labelId)
+    ) {
+      handoffReadyShownRef.current.add(labelId)
+      setHandoffReadyOpen(true)
+    }
+  }, [readiness?.tier, activeLabel?.id, activeLabel?.phase])
 
   const syncActiveLabelCounts = useCallback(
     (labelId: number, state: ReadinessState) => {
@@ -862,6 +880,12 @@ export function LabelRunPage() {
           noCount={activeLabel.no_count}
           onConfirm={handleAbortActive}
           onCancel={() => setAbortOpen(false)}
+        />
+      )}
+      {handoffReadyOpen && (
+        <HandoffReadyModal
+          onHandoff={() => { setHandoffReadyOpen(false); void handleHandoff() }}
+          onDismiss={() => setHandoffReadyOpen(false)}
         />
       )}
     </>

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -25,6 +25,7 @@ import { AbortConfirmModal } from '../components/run/AbortConfirmModal'
 import { DecisionWorkspace } from '../components/decision/DecisionWorkspace'
 import { AiReviewDock } from '../components/decision/AiReviewDock'
 import { useKeybinds } from '../hooks/useKeybinds'
+import { useLabelSuggestions } from '../hooks/useLabelSuggestions'
 import { api } from '../services/api'
 import type {
   DecisionValue,
@@ -532,6 +533,7 @@ export function LabelRunPage() {
   )
 
   const { keybinds } = useKeybinds()
+  const { suggestions } = useLabelSuggestions()
 
   const handleSwitchToQueued = useCallback(
     async (id: number) => {
@@ -686,6 +688,7 @@ export function LabelRunPage() {
                 onClearAll={handleClearQueue}
                 onSwitchQueued={(id) => void handleSwitchToQueued(id)}
                 onRemoveQueued={(id) => void handleRemoveQueued(id)}
+                suggestions={suggestions}
               />
               <ConversationMeta
                 chatlogId={item.chatlog_id}
@@ -721,6 +724,7 @@ export function LabelRunPage() {
           open={noteOpen}
           onClose={() => setNoteOpen(false)}
           onSubmit={handleNoteSubmit}
+          suggestions={suggestions}
         />
         {abortOpen && (
           <AbortConfirmModal
@@ -767,6 +771,7 @@ export function LabelRunPage() {
               onClearAll={handleClearQueue}
               onSwitchQueued={(id) => void handleSwitchToQueued(id)}
               onRemoveQueued={(id) => void handleRemoveQueued(id)}
+              suggestions={suggestions}
             />
             <ConversationMeta
               chatlogId={focused.chatlog_id}
@@ -819,6 +824,7 @@ export function LabelRunPage() {
         open={noteOpen}
         onClose={() => setNoteOpen(false)}
         onSubmit={handleNoteSubmit}
+        suggestions={suggestions}
       />
       <SummaryModal
         summary={summary}

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -563,7 +563,6 @@ export function LabelRunPage() {
         await api.switchToLabel(id)
         setBusyMessage('Loading label…')
         // Use hintChatlogId so the new label opens on the same conversation.
-        // refresh() is still called but we override getNextFocused with the hint.
         const [active, a, um] = await Promise.all([
           api.getActiveSingleLabel(),
           api.listAssignments(),

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -590,8 +590,9 @@ function SplitSessionModal({
           <div className="space-y-4">
             <div>
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category A (Left Arrow)</label>
-              <input 
+              <input
                 autoFocus
+                autoComplete="off"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Theory"
                 value={nameA}
@@ -601,7 +602,8 @@ function SplitSessionModal({
             </div>
             <div>
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category B (Right Arrow)</label>
-              <input 
+              <input
+                autoComplete="off"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Implementation"
                 value={nameB}

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -592,7 +592,7 @@ function SplitSessionModal({
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category A (Left Arrow)</label>
               <input
                 autoFocus
-                autoComplete="off"
+                autoComplete="new-password"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Theory"
                 value={nameA}
@@ -603,7 +603,7 @@ function SplitSessionModal({
             <div>
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category B (Right Arrow)</label>
               <input
-                autoComplete="off"
+                autoComplete="new-password"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Implementation"
                 value={nameB}

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -165,20 +165,18 @@ export function QueuePage() {
 		}
 	}, [displayedMessage?.chatlog_id, displayedMessage?.message_index, aiUnlocked, recalibration]);
 
-	// Show label review overlay once per browser session
+	// Keep label review items in sync whenever labels change
+	useEffect(() => {
+		if (loading) return;
+		api.getLabelReview().then(setLabelReviewItems).catch(() => {});
+	}, [labels, loading]);
+
+	// Show label review overlay once per browser session (after items are loaded)
 	useEffect(() => {
 		if (loading) return;
 		if (sessionStorage.getItem("label_review_shown")) return;
-		api
-			.getLabelReview()
-			.then((items) => {
-				if (items.length > 0) {
-					setLabelReviewItems(items);
-					setShowLabelReview(true);
-				}
-			})
-			.catch(() => {});
-	}, [loading]);
+		if (labelReviewItems.length > 0) setShowLabelReview(true);
+	}, [loading, labelReviewItems]);
 
 	// Enter review mode from ?review= query param (e.g., from /history page)
 	const [searchParams, setSearchParams] = useSearchParams();

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -736,7 +736,30 @@ export function QueuePage() {
 				handleUndo();
 				return;
 			}
-			// if (e.key === "Escape" && recalibration) { /* recalibration disabled */ }
+			if (e.key === "Escape" && recalibration) {
+				if (recalibration.phase === "blind") {
+					setRecalibration(null);
+					setAppliedLabelIds(new Set());
+				} else {
+					api
+						.saveRecalibration({
+							chatlog_id: recalibration.item.chatlog_id,
+							message_index: recalibration.item.message_index,
+							original_label_ids: recalibration.item.original_label_ids,
+							relabel_ids: [...recalibration.relabelIds],
+							final_label_ids: recalibration.item.original_label_ids,
+						})
+						.then(() => {
+							api
+								.getRecalibrationStats()
+								.then(setRecalibrationStats)
+								.catch(() => {});
+						});
+					setRecalibration(null);
+					setAppliedLabelIds(new Set());
+				}
+				return;
+			}
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
@@ -1013,7 +1036,71 @@ export function QueuePage() {
 				<span className="text-[9px] uppercase tracking-[0.06em] text-faint">scope</span>
 				<span className="text-fg">Week 3 — Lab 1 &amp; HW 1</span>
 			</div>
-			{/* Recalibration banners disabled */}
+			{recalibration && recalibration.phase === "blind" && (
+				<div className="bg-elevated border-b border-edge px-4 py-2 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<span className="bg-ochre text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
+							RECALIBRATION
+						</span>
+						<span className="text-muted text-xs">
+							Re-label this previously seen message to check consistency
+						</span>
+					</div>
+					<div className="flex gap-3 text-[10px] text-faint">
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
+							toggle
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">
+								{formatKey(keybinds.yes)}
+							</kbd>{" "}
+							submit
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
+							cancel
+						</span>
+					</div>
+				</div>
+			)}
+			{recalibration && recalibration.phase === "reconcile" && (
+				<div className="bg-warning-surface border-b border-warning-border px-4 py-2 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<span className="bg-warning text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
+							MISMATCH
+						</span>
+						<span className="text-warning-name text-xs">
+							Labels differ from original — toggle labels to reconcile, then
+							press {formatKey(keybinds.yes)}
+						</span>
+					</div>
+					<div className="flex gap-3 text-[10px] text-faint">
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
+							toggle
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">
+								{formatKey(keybinds.yes)}
+							</kbd>{" "}
+							confirm
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
+							keep original
+						</span>
+					</div>
+				</div>
+			)}
+			{recalibrationToast === "match" && (
+				<div className="bg-success-surface border-b border-success-border px-4 py-2 flex items-center gap-2">
+					<span className="text-success text-sm">✓</span>
+					<span className="text-success text-xs font-medium">
+						Consistent! Your labels matched your original labeling.
+					</span>
+				</div>
+			)}
 			<div className="flex-1 flex min-h-0">
 				<ProgressSidebar
 					session={session}
@@ -1038,8 +1125,18 @@ export function QueuePage() {
 					onDiscover={handleDiscover}
 					onOpenDiscoverModal={() => setDiscoverModalOpen(true)}
 					discovering={discovering}
-					recalibration={null /* recalibration disabled */}
-					recalibrationStats={null}
+					recalibration={
+						recalibration
+							? {
+									phase: recalibration.phase,
+									originalLabelIds: new Set(
+										recalibration.item.original_label_ids,
+									),
+									relabelIds: recalibration.relabelIds,
+								}
+							: null
+					}
+					recalibrationStats={recalibrationStats}
 					tutorialDisabled={tutorialActive}
 				/>
 				<div className="flex-1 flex flex-col min-h-0">

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -347,6 +347,23 @@ export function QueuePage() {
 	// Fetch applied labels and AI suggestion per message
 	useEffect(() => {
 		if (!displayedMessage) return;
+		const blindRecalibration = recalibration?.phase === "blind";
+		const reconcileRecalibration = recalibration?.phase === "reconcile";
+		if (blindRecalibration) {
+			// Blind check: don't load saved labels from the DB or the sidebar
+			// reveals the answer we're asking the instructor to reproduce.
+			setAppliedLabelIds(new Set());
+			setSuggestion(null);
+			setSuggestionLoading(false);
+			return;
+		}
+		if (reconcileRecalibration) {
+			// Keep the toggles from the blind attempt; the DB still holds the
+			// original labels, so don't overwrite the in-progress comparison.
+			setSuggestion(null);
+			setSuggestionLoading(false);
+			return;
+		}
 		api
 			.getAppliedLabels(
 				displayedMessage.chatlog_id,
@@ -380,6 +397,7 @@ export function QueuePage() {
 		displayedMessage?.chatlog_id,
 		displayedMessage?.message_index,
 		aiUnlocked,
+		recalibration?.phase,
 	]);
 
 	const advance = useCallback(() => {

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -491,55 +491,55 @@ export function QueuePage() {
 	};
 
 	const handleNextInner = useCallback(async () => {
-		// // Recalibration: blind phase → check match → reconcile or auto-advance
-		// if (recalibration && recalibration.phase === "blind") {
-		// 	const relabelIds = new Set(appliedLabelIds);
-		// 	const originalSet = new Set(recalibration.item.original_label_ids);
-		// 	const matched =
-		// 		relabelIds.size === originalSet.size &&
-		// 		[...relabelIds].every((id) => originalSet.has(id));
+		// Recalibration: blind phase → check match → reconcile or auto-advance
+		if (recalibration && recalibration.phase === "blind") {
+			const relabelIds = new Set(appliedLabelIds);
+			const originalSet = new Set(recalibration.item.original_label_ids);
+			const matched =
+				relabelIds.size === originalSet.size &&
+				[...relabelIds].every((id) => originalSet.has(id));
 
-		// 	if (matched) {
-		// 		await api.saveRecalibration({
-		// 			chatlog_id: recalibration.item.chatlog_id,
-		// 			message_index: recalibration.item.message_index,
-		// 			original_label_ids: recalibration.item.original_label_ids,
-		// 			relabel_ids: [...relabelIds],
-		// 			final_label_ids: [...relabelIds],
-		// 		});
-		// 		setRecalibration(null);
-		// 		setRecalibrationToast("match");
-		// 		setTimeout(() => setRecalibrationToast(null), 2000);
-		// 		setAppliedLabelIds(new Set());
-		// 		api
-		// 			.getRecalibrationStats()
-		// 			.then(setRecalibrationStats)
-		// 			.catch(() => {});
-		// 	} else {
-		// 		setRecalibration((prev) =>
-		// 			prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
-		// 		);
-		// 	}
-		// 	return;
-		// }
+			if (matched) {
+				await api.saveRecalibration({
+					chatlog_id: recalibration.item.chatlog_id,
+					message_index: recalibration.item.message_index,
+					original_label_ids: recalibration.item.original_label_ids,
+					relabel_ids: [...relabelIds],
+					final_label_ids: [...relabelIds],
+				});
+				setRecalibration(null);
+				setRecalibrationToast("match");
+				setTimeout(() => setRecalibrationToast(null), 2000);
+				setAppliedLabelIds(new Set());
+				api
+					.getRecalibrationStats()
+					.then(setRecalibrationStats)
+					.catch(() => {});
+			} else {
+				setRecalibration((prev) =>
+					prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
+				);
+			}
+			return;
+		}
 
-		// // Recalibration: reconcile phase → save final labels and exit
-		// if (recalibration && recalibration.phase === "reconcile") {
-		// 	await api.saveRecalibration({
-		// 		chatlog_id: recalibration.item.chatlog_id,
-		// 		message_index: recalibration.item.message_index,
-		// 		original_label_ids: recalibration.item.original_label_ids,
-		// 		relabel_ids: [...recalibration.relabelIds],
-		// 		final_label_ids: [...appliedLabelIds],
-		// 	});
-		// 	setRecalibration(null);
-		// 	setAppliedLabelIds(new Set());
-		// 	api
-		// 		.getRecalibrationStats()
-		// 		.then(setRecalibrationStats)
-		// 		.catch(() => {});
-		// 	return;
-		// }
+		// Recalibration: reconcile phase → save final labels and exit
+		if (recalibration && recalibration.phase === "reconcile") {
+			await api.saveRecalibration({
+				chatlog_id: recalibration.item.chatlog_id,
+				message_index: recalibration.item.message_index,
+				original_label_ids: recalibration.item.original_label_ids,
+				relabel_ids: [...recalibration.relabelIds],
+				final_label_ids: [...appliedLabelIds],
+			});
+			setRecalibration(null);
+			setAppliedLabelIds(new Set());
+			api
+				.getRecalibrationStats()
+				.then(setRecalibrationStats)
+				.catch(() => {});
+			return;
+		}
 
 		if (isBackNav) {
 			setNavPos(null);
@@ -588,16 +588,16 @@ export function QueuePage() {
 		api.getQueuePosition().then((p) => setRemaining(p.total_remaining));
 		api.getRecentHistory(5).then(setHistory);
 
-		// // Check if recalibration is due after advancing (disabled)
-		// api
-		// 	.getRecalibration()
-		// 	.then((item) => {
-		// 		if (item) {
-		// 			setRecalibration({ item, phase: "blind", relabelIds: new Set() });
-		// 			setAppliedLabelIds(new Set());
-		// 		}
-		// 	})
-		// 	.catch(() => {});
+		// Check if recalibration is due after advancing
+		api
+			.getRecalibration()
+			.then((item) => {
+				if (item) {
+					setRecalibration({ item, phase: "blind", relabelIds: new Set() });
+					setAppliedLabelIds(new Set());
+				}
+			})
+			.catch(() => {});
 	}, [
 		recalibration,
 		isBackNav,

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -1008,6 +1008,10 @@ export function QueuePage() {
 
 	return (
 		<div className="flex-1 flex flex-col min-h-0">
+			<div className="flex items-center gap-2 border-b border-edge-subtle px-4 py-1.5 font-mono text-[11px] text-muted">
+				<span className="text-[9px] uppercase tracking-[0.06em] text-faint">scope</span>
+				<span className="text-fg">Week 3 — Lab 1 &amp; HW 1</span>
+			</div>
 			{recalibration && recalibration.phase === "blind" && (
 				<div className="bg-elevated border-b border-edge px-4 py-2 flex items-center justify-between">
 					<div className="flex items-center gap-2">

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -158,7 +158,7 @@ export function QueuePage() {
 		};
 	})();
 	const isReviewing = displayMode === "history-review";
-	const aiUnlocked = (stats?.labeled_count ?? 0) >= 20;
+	const aiUnlocked = (stats?.labeled_count ?? 0) >= 10;
 
 	const loadQueue = useCallback(async () => {
 		const q = await api.getQueue(20);

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -119,8 +119,15 @@ export function QueuePage() {
 	const formatKey = (key: string) => {
 		if (key === " ") return "Space";
 		if (key === "enter") return "Enter";
+		if (key === "arrowleft") return "←";
+		if (key === "arrowright") return "→";
+		if (key === "arrowup") return "↑";
+		if (key === "arrowdown") return "↓";
+		if (key === "backspace") return "⌫";
+		if (key === "escape") return "Esc";
 		if (key.startsWith("shift+")) {
-			return "⇧" + key.split("+")[1].toUpperCase();
+			const base = key.split("+")[1];
+			return "⇧" + formatKey(base);
 		}
 		return key.toUpperCase();
 	};
@@ -466,55 +473,55 @@ export function QueuePage() {
 	};
 
 	const handleNextInner = useCallback(async () => {
-		// Recalibration: blind phase → check match → reconcile or auto-advance
-		if (recalibration && recalibration.phase === "blind") {
-			const relabelIds = new Set(appliedLabelIds);
-			const originalSet = new Set(recalibration.item.original_label_ids);
-			const matched =
-				relabelIds.size === originalSet.size &&
-				[...relabelIds].every((id) => originalSet.has(id));
+		// // Recalibration: blind phase → check match → reconcile or auto-advance
+		// if (recalibration && recalibration.phase === "blind") {
+		// 	const relabelIds = new Set(appliedLabelIds);
+		// 	const originalSet = new Set(recalibration.item.original_label_ids);
+		// 	const matched =
+		// 		relabelIds.size === originalSet.size &&
+		// 		[...relabelIds].every((id) => originalSet.has(id));
 
-			if (matched) {
-				await api.saveRecalibration({
-					chatlog_id: recalibration.item.chatlog_id,
-					message_index: recalibration.item.message_index,
-					original_label_ids: recalibration.item.original_label_ids,
-					relabel_ids: [...relabelIds],
-					final_label_ids: [...relabelIds],
-				});
-				setRecalibration(null);
-				setRecalibrationToast("match");
-				setTimeout(() => setRecalibrationToast(null), 2000);
-				setAppliedLabelIds(new Set());
-				api
-					.getRecalibrationStats()
-					.then(setRecalibrationStats)
-					.catch(() => {});
-			} else {
-				setRecalibration((prev) =>
-					prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
-				);
-			}
-			return;
-		}
+		// 	if (matched) {
+		// 		await api.saveRecalibration({
+		// 			chatlog_id: recalibration.item.chatlog_id,
+		// 			message_index: recalibration.item.message_index,
+		// 			original_label_ids: recalibration.item.original_label_ids,
+		// 			relabel_ids: [...relabelIds],
+		// 			final_label_ids: [...relabelIds],
+		// 		});
+		// 		setRecalibration(null);
+		// 		setRecalibrationToast("match");
+		// 		setTimeout(() => setRecalibrationToast(null), 2000);
+		// 		setAppliedLabelIds(new Set());
+		// 		api
+		// 			.getRecalibrationStats()
+		// 			.then(setRecalibrationStats)
+		// 			.catch(() => {});
+		// 	} else {
+		// 		setRecalibration((prev) =>
+		// 			prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
+		// 		);
+		// 	}
+		// 	return;
+		// }
 
-		// Recalibration: reconcile phase → save final labels and exit
-		if (recalibration && recalibration.phase === "reconcile") {
-			await api.saveRecalibration({
-				chatlog_id: recalibration.item.chatlog_id,
-				message_index: recalibration.item.message_index,
-				original_label_ids: recalibration.item.original_label_ids,
-				relabel_ids: [...recalibration.relabelIds],
-				final_label_ids: [...appliedLabelIds],
-			});
-			setRecalibration(null);
-			setAppliedLabelIds(new Set());
-			api
-				.getRecalibrationStats()
-				.then(setRecalibrationStats)
-				.catch(() => {});
-			return;
-		}
+		// // Recalibration: reconcile phase → save final labels and exit
+		// if (recalibration && recalibration.phase === "reconcile") {
+		// 	await api.saveRecalibration({
+		// 		chatlog_id: recalibration.item.chatlog_id,
+		// 		message_index: recalibration.item.message_index,
+		// 		original_label_ids: recalibration.item.original_label_ids,
+		// 		relabel_ids: [...recalibration.relabelIds],
+		// 		final_label_ids: [...appliedLabelIds],
+		// 	});
+		// 	setRecalibration(null);
+		// 	setAppliedLabelIds(new Set());
+		// 	api
+		// 		.getRecalibrationStats()
+		// 		.then(setRecalibrationStats)
+		// 		.catch(() => {});
+		// 	return;
+		// }
 
 		if (isBackNav) {
 			setNavPos(null);
@@ -563,16 +570,16 @@ export function QueuePage() {
 		api.getQueuePosition().then((p) => setRemaining(p.total_remaining));
 		api.getRecentHistory(5).then(setHistory);
 
-		// Check if recalibration is due after advancing
-		api
-			.getRecalibration()
-			.then((item) => {
-				if (item) {
-					setRecalibration({ item, phase: "blind", relabelIds: new Set() });
-					setAppliedLabelIds(new Set());
-				}
-			})
-			.catch(() => {});
+		// // Check if recalibration is due after advancing (disabled)
+		// api
+		// 	.getRecalibration()
+		// 	.then((item) => {
+		// 		if (item) {
+		// 			setRecalibration({ item, phase: "blind", relabelIds: new Set() });
+		// 			setAppliedLabelIds(new Set());
+		// 		}
+		// 	})
+		// 	.catch(() => {});
 	}, [
 		recalibration,
 		isBackNav,
@@ -686,9 +693,8 @@ export function QueuePage() {
 			const rawKey = e.key.toLowerCase();
 			const pressedKey = e.shiftKey ? `shift+${rawKey}` : rawKey;
 
-			// Submit/advance. `n` and Enter are convenience aliases for the
-			// configurable yes key. Deliberately NOT plain `z` — it would shadow
-			// the Ctrl+Z undo below (both have rawKey "z"), so Ctrl+Z never fired.
+			// Submit/advance. Enter and `n` are convenience aliases for the
+			// configurable yes key (default: z).
 			if (
 				pressedKey === keybinds.yes ||
 				rawKey === "enter" ||
@@ -704,38 +710,17 @@ export function QueuePage() {
 			if (pressedKey === keybinds.skip || rawKey === "s") {
 				if (!isReviewing && !isBackNav) {
 					if (rawKey === " ") e.preventDefault(); // prevent scroll if space is bound to skip
+					if (rawKey === "arrowright") e.preventDefault(); // prevent browser scroll
 					handleSkip();
 				}
 				return;
 			}
 			if (pressedKey === keybinds.undo || (e.ctrlKey && rawKey === "z")) {
+				if (rawKey === "arrowleft") e.preventDefault(); // prevent browser back navigation
 				handleUndo();
 				return;
 			}
-			if (e.key === "Escape" && recalibration) {
-				if (recalibration.phase === "blind") {
-					setRecalibration(null);
-					setAppliedLabelIds(new Set());
-				} else {
-					api
-						.saveRecalibration({
-							chatlog_id: recalibration.item.chatlog_id,
-							message_index: recalibration.item.message_index,
-							original_label_ids: recalibration.item.original_label_ids,
-							relabel_ids: [...recalibration.relabelIds],
-							final_label_ids: recalibration.item.original_label_ids,
-						})
-						.then(() => {
-							api
-								.getRecalibrationStats()
-								.then(setRecalibrationStats)
-								.catch(() => {});
-						});
-					setRecalibration(null);
-					setAppliedLabelIds(new Set());
-				}
-				return;
-			}
+			// if (e.key === "Escape" && recalibration) { /* recalibration disabled */ }
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
@@ -756,6 +741,18 @@ export function QueuePage() {
 	const handleUpdateLabel = async (id: number, body: UpdateLabelRequest) => {
 		const updated = await api.updateLabel(id, body);
 		setLabels((prev) => prev.map((l) => (l.id === id ? updated : l)));
+	};
+
+	const handleStopAutolabel = async () => {
+		await api.stopAutolabel().catch(() => {});
+	};
+
+	const handleClearAutolabel = async () => {
+		if (!confirm("Delete all AI-applied labels? This cannot be undone.")) return;
+		await api.clearAutolabelResults();
+		setAutolabelStatus(null);
+		const st = await api.getQueueStats();
+		setStats(st);
 	};
 
 	const handleStartAutolabel = async () => {
@@ -1000,71 +997,7 @@ export function QueuePage() {
 				<span className="text-[9px] uppercase tracking-[0.06em] text-faint">scope</span>
 				<span className="text-fg">Week 3 — Lab 1 &amp; HW 1</span>
 			</div>
-			{recalibration && recalibration.phase === "blind" && (
-				<div className="bg-elevated border-b border-edge px-4 py-2 flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<span className="bg-ochre text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
-							RECALIBRATION
-						</span>
-						<span className="text-muted text-xs">
-							Re-label this previously seen message to check consistency
-						</span>
-					</div>
-					<div className="flex gap-3 text-[10px] text-faint">
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
-							toggle
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">
-								{formatKey(keybinds.yes)}
-							</kbd>{" "}
-							submit
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
-							cancel
-						</span>
-					</div>
-				</div>
-			)}
-			{recalibration && recalibration.phase === "reconcile" && (
-				<div className="bg-warning-surface border-b border-warning-border px-4 py-2 flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<span className="bg-warning text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
-							MISMATCH
-						</span>
-						<span className="text-warning-name text-xs">
-							Labels differ from original — toggle labels to reconcile, then
-							press {formatKey(keybinds.yes)}
-						</span>
-					</div>
-					<div className="flex gap-3 text-[10px] text-faint">
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
-							toggle
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">
-								{formatKey(keybinds.yes)}
-							</kbd>{" "}
-							confirm
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
-							keep original
-						</span>
-					</div>
-				</div>
-			)}
-			{recalibrationToast === "match" && (
-				<div className="bg-success-surface border-b border-success-border px-4 py-2 flex items-center gap-2">
-					<span className="text-success text-sm">✓</span>
-					<span className="text-success text-xs font-medium">
-						Consistent! Your labels matched your original labeling.
-					</span>
-				</div>
-			)}
+			{/* Recalibration banners disabled */}
 			<div className="flex-1 flex min-h-0">
 				<ProgressSidebar
 					session={session}
@@ -1076,6 +1009,8 @@ export function QueuePage() {
 					onCreateAndApply={handleCreateAndApply}
 					onUpdateLabel={handleUpdateLabel}
 					onStartAutolabel={handleStartAutolabel}
+				onStopAutolabel={handleStopAutolabel}
+				onClearAutolabel={handleClearAutolabel}
 					autolabelStatus={autolabelStatus}
 					remaining={remaining}
 					history={history}
@@ -1087,18 +1022,8 @@ export function QueuePage() {
 					onDiscover={handleDiscover}
 					onOpenDiscoverModal={() => setDiscoverModalOpen(true)}
 					discovering={discovering}
-					recalibration={
-						recalibration
-							? {
-									phase: recalibration.phase,
-									originalLabelIds: new Set(
-										recalibration.item.original_label_ids,
-									),
-									relabelIds: recalibration.relabelIds,
-								}
-							: null
-					}
-					recalibrationStats={recalibrationStats}
+					recalibration={null /* recalibration disabled */}
+					recalibrationStats={null}
 					tutorialDisabled={tutorialActive}
 				/>
 				<div className="flex-1 flex flex-col min-h-0">

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -822,18 +822,6 @@ export function QueuePage() {
 		[labels],
 	);
 
-	const handleForceRecalibration = useCallback(async () => {
-		if (recalibration) return;
-		const item = await api.getRecalibration(true);
-		if (item) {
-			setRecalibration({ item, phase: "blind", relabelIds: new Set() });
-			setAppliedLabelIds(new Set());
-		} else {
-			console.warn(
-				"[DEV] Force recalibration returned null — no labeled messages yet?",
-			);
-		}
-	}, [recalibration]);
 
 	const handleDeleteLabel = useCallback(
 		(labelId: number) => {
@@ -1195,15 +1183,6 @@ export function QueuePage() {
 					onAdvance={advanceTutorial}
 					onSkip={finishTutorial}
 				/>
-			)}
-			{import.meta.env.DEV && !recalibration && (
-				<button
-					onClick={handleForceRecalibration}
-					className="fixed bottom-4 left-57 z-50 text-[10px] font-mono text-faint bg-surface border border-edge rounded-sm px-2.5 py-1.5 hover:border-ochre-dim hover:text-muted transition-colors"
-					title="Dev-only: force-trigger a recalibration round"
-				>
-					DEV · trigger recalibration
-				</button>
 			)}
 		</div>
 	);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -657,6 +657,18 @@ export const api = {
                  { method: 'PUT', ...json({ text }) },
                ),
 
+  setSingleLabelFlag: (
+    id: number,
+    chatlog_id: number,
+    message_index: number,
+    flagged: boolean,
+  ): Promise<{ ok: true; flagged: boolean }> =>
+    USE_MOCK ? Promise.resolve({ ok: true as const, flagged })
+             : req(
+                 `/api/single-labels/${id}/applications/${chatlog_id}/flag?message_index=${message_index}`,
+                 { method: 'PATCH', ...json({ flagged }) },
+               ),
+
   patchSingleLabel: (
     id: number,
     patch: {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -382,10 +382,15 @@ export const api = {
     USE_MOCK ? Promise.resolve({ ...mockActiveLabel, is_active: false, phase: 'complete' })
              : req(`/api/single-labels/${id}/close`, { method: 'POST' }),
 
-  getNextFocused: (id: number, assignmentId?: number): Promise<FocusedMessage | null> =>
-    USE_MOCK
+  getNextFocused: (id: number, assignmentId?: number, hintChatlogId?: number): Promise<FocusedMessage | null> => {
+    const params = new URLSearchParams()
+    if (assignmentId != null) params.set('assignment_id', String(assignmentId))
+    if (hintChatlogId != null) params.set('hint_chatlog_id', String(hintChatlogId))
+    const qs = params.toString()
+    return USE_MOCK
       ? Promise.resolve(mockFocusedMessage)
-      : req(`/api/single-labels/${id}/next${assignmentId ? `?assignment_id=${assignmentId}` : ''}`),
+      : req(`/api/single-labels/${id}/next${qs ? '?' + qs : ''}`)
+  },
 
   decide: (
     id: number,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -181,6 +181,14 @@ export const api = {
     USE_MOCK ? Promise.resolve({ ok: true })
              : req('/api/queue/autolabel', { method: 'POST' }),
 
+  clearAutolabelResults: (): Promise<{ ok: boolean; deleted: number }> =>
+    USE_MOCK ? Promise.resolve({ ok: true, deleted: 0 })
+             : req('/api/queue/autolabel/results', { method: 'DELETE' }),
+
+  stopAutolabel: (): Promise<{ ok: boolean }> =>
+    USE_MOCK ? Promise.resolve({ ok: true })
+             : req('/api/queue/autolabel/stop', { method: 'POST' }),
+
   getAutolabelStatus: (): Promise<{ running: boolean; processed: number; total: number; error: string | null }> =>
     USE_MOCK ? Promise.resolve({ running: false, processed: 0, total: 0, error: null })
              : req('/api/queue/autolabel/status'),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import type {
   LabelDefinition, QueueItem, LabelingSession, SuggestResponse,
   QueueStats, ApplyLabelRequest, CreateLabelRequest, UpdateLabelRequest,
   HistoryItem, LabelReviewItem,
-  ConceptCandidate, EmbedStatus, ConversationMessage, AnalysisSummary, TemporalAnalysis,
+  ConceptCandidate, LabelNameSuggestion, EmbedStatus, ConversationMessage, AnalysisSummary, TemporalAnalysis,
   LabelExample, SplitAutoLabelRequest, ApplyBatchRequest, ConciseResponse,
   RecalibrationItem, RecalibrationStats, SaveRecalibrationRequest, SaveRecalibrationResponse,
   SingleLabel, FocusedMessage, ReadinessState, DecideResult, DecisionValue,
@@ -129,6 +129,10 @@ export const api = {
   getCandidates: (): Promise<ConceptCandidate[]> =>
     USE_MOCK ? Promise.resolve([])
              : req('/api/concepts/candidates'),
+
+  getNameSuggestions: (): Promise<LabelNameSuggestion[]> =>
+    USE_MOCK ? Promise.resolve([])
+             : req('/api/concepts/name-suggestions'),
 
   resolveCandidate: (id: number, action: 'accept' | 'reject', name?: string): Promise<LabelDefinition | { ok: boolean }> =>
     USE_MOCK ? Promise.resolve({ ok: true })

--- a/src/tests/MessageCard.test.tsx
+++ b/src/tests/MessageCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from './test-utils'
 import { MessageCard } from '../components/queue/MessageCard'
 import { mockApi } from '../mocks'
 import type { QueueItem } from '../types'
@@ -32,7 +32,7 @@ test('renders student message text', () => {
 
 test('shows AI lock indicator when not unlocked', () => {
   render(<MessageCard {...defaultProps} />)
-  expect(screen.getByText(/AI unlocks at 20/i)).toBeInTheDocument()
+  expect(screen.getByText(/AI unlocks at 10/i)).toBeInTheDocument()
 })
 
 test('shows ghost tag when AI unlocked with suggestion', () => {

--- a/src/tests/ProgressSidebar.test.tsx
+++ b/src/tests/ProgressSidebar.test.tsx
@@ -42,8 +42,9 @@ test('shows skipped count when non-zero', () => {
 })
 
 test('shows AI suggestions unlock progress', () => {
-  render(<ProgressSidebar {...defaultProps} />)
-  expect(screen.getByText('14 / 20 to unlock')).toBeInTheDocument()
+  const stats = { total_messages: 100, labeled_count: 7, skipped_count: 0 }
+  render(<ProgressSidebar {...defaultProps} stats={stats} />)
+  expect(screen.getByText('7 / 10 to unlock')).toBeInTheDocument()
 })
 
 test('renders clickable label buttons', () => {

--- a/src/tests/Recalibration.test.tsx
+++ b/src/tests/Recalibration.test.tsx
@@ -7,10 +7,12 @@ const {
   mockGetRecalibration,
   mockSaveRecalibration,
   mockGetRecalibrationStats,
+  mockGetAppliedLabels,
 } = vi.hoisted(() => ({
   mockGetRecalibration: vi.fn().mockResolvedValue(null),
   mockSaveRecalibration: vi.fn().mockResolvedValue({ matched: true, trend: 'steady' }),
   mockGetRecalibrationStats: vi.fn().mockResolvedValue(null),
+  mockGetAppliedLabels: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('../services/api', () => ({
@@ -31,7 +33,7 @@ vi.mock('../services/api', () => ({
     getRecalibration: mockGetRecalibration,
     saveRecalibration: mockSaveRecalibration,
     getRecalibrationStats: mockGetRecalibrationStats,
-    getAppliedLabels: vi.fn().mockResolvedValue([]),
+    getAppliedLabels: mockGetAppliedLabels,
     applyLabel: vi.fn().mockResolvedValue(undefined),
     unapplyLabel: vi.fn().mockResolvedValue(undefined),
     skipMessage: vi.fn().mockResolvedValue(undefined),
@@ -88,15 +90,24 @@ beforeEach(() => {
   mockGetRecalibration.mockReset()
   mockSaveRecalibration.mockReset()
   mockGetRecalibrationStats.mockReset()
+  mockGetAppliedLabels.mockReset()
   mockGetRecalibration.mockResolvedValue(recalItem)
   mockSaveRecalibration.mockResolvedValue({ matched: true, trend: 'steady' })
   mockGetRecalibrationStats.mockResolvedValue(null)
+  mockGetAppliedLabels.mockResolvedValue([])
 })
 
 test('enters blind phase and shows the recalibration banner', async () => {
   await enterBlindPhase()
   expect(screen.getByText('RECALIBRATION')).toBeInTheDocument()
   expect(screen.getByText('Re-label this message')).toBeInTheDocument()
+})
+
+test('blind phase does not pre-select labels saved on the message', async () => {
+  await enterBlindPhase()
+  // In the blind phase the sidebar must not reveal the message's saved labels,
+  // so getAppliedLabels must not be queried for the recalibrated message (42).
+  expect(mockGetAppliedLabels).not.toHaveBeenCalledWith(42, 0)
 })
 
 test('matching labels saves a matched recalibration event and shows the match toast', async () => {

--- a/src/tests/decision/DecisionWorkspace.test.tsx
+++ b/src/tests/decision/DecisionWorkspace.test.tsx
@@ -106,7 +106,7 @@ beforeEach(() => {
 // The yes-key bindings (a / A) are covered in DecisionWorkspaceKeybinds.test.tsx.
 // This asserts the remaining default decision keys dispatch to their handlers,
 // including plain Enter -> onAcceptAi (only covered here).
-test('default keys dispatch handlers: no=d, skip=Space, undo=s, acceptAi=Enter', () => {
+test('default keys dispatch handlers: no=d, skip=ArrowRight, undo=ArrowLeft, acceptAi=Enter', () => {
   const onNo = vi.fn()
   const onSkip = vi.fn()
   const onUndo = vi.fn()
@@ -123,8 +123,8 @@ test('default keys dispatch handlers: no=d, skip=Space, undo=s, acceptAi=Enter',
     />,
   )
   fireEvent.keyDown(window, { key: 'd' })
-  fireEvent.keyDown(window, { key: ' ' })
-  fireEvent.keyDown(window, { key: 's' })
+  fireEvent.keyDown(window, { key: 'ArrowRight' })
+  fireEvent.keyDown(window, { key: 'ArrowLeft' })
   fireEvent.keyDown(window, { key: 'Enter' })
   expect(onNo).toHaveBeenCalledTimes(1)
   expect(onSkip).toHaveBeenCalledTimes(1)

--- a/src/tests/decision/DecisionWorkspaceKeybinds.test.tsx
+++ b/src/tests/decision/DecisionWorkspaceKeybinds.test.tsx
@@ -22,10 +22,10 @@ const renderWorkspace = (props = {}) => {
 }
 
 describe('DecisionWorkspace Keybinds', () => {
-  it('calls onYes when "a" is pressed (default)', () => {
+  it('calls onYes when "z" is pressed (default)', () => {
     const onYes = vi.fn()
     renderWorkspace({ onYes })
-    fireEvent.keyDown(window, { key: 'a' })
+    fireEvent.keyDown(window, { key: 'z' })
     expect(onYes).toHaveBeenCalled()
   })
 
@@ -36,33 +36,40 @@ describe('DecisionWorkspace Keybinds', () => {
     expect(onNo).toHaveBeenCalled()
   })
 
-  it('calls onSkip when " " (Space) is pressed (default)', () => {
+  it('calls onSkip when ArrowRight is pressed (default)', () => {
     const onSkip = vi.fn()
     renderWorkspace({ onSkip })
-    fireEvent.keyDown(window, { key: ' ' })
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
     expect(onSkip).toHaveBeenCalled()
   })
 
-  it('calls onUndo when "s" is pressed (default)', () => {
+  it('calls onSkip when Enter is pressed and no onAcceptAi handler', () => {
+    const onSkip = vi.fn()
+    renderWorkspace({ onSkip })
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(onSkip).toHaveBeenCalled()
+  })
+
+  it('calls onUndo when ArrowLeft is pressed (default)', () => {
     const onUndo = vi.fn()
     renderWorkspace({ onUndo })
-    fireEvent.keyDown(window, { key: 's' })
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
     expect(onUndo).toHaveBeenCalled()
   })
 
-  it('prevents default behavior when Space is pressed', () => {
+  it('does not call onSkip on Enter when onAcceptAi is provided', () => {
     const onSkip = vi.fn()
-    renderWorkspace({ onSkip })
-    const event = createEvent.keyDown(window, { key: ' ' })
-    vi.spyOn(event, 'preventDefault')
-    fireEvent(window, event)
-    expect(event.preventDefault).toHaveBeenCalled()
+    const onAcceptAi = vi.fn()
+    renderWorkspace({ onSkip, onAcceptAi })
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(onAcceptAi).toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
   })
 
   it('respects case-insensitivity', () => {
     const onYes = vi.fn()
     renderWorkspace({ onYes })
-    fireEvent.keyDown(window, { key: 'A' })
+    fireEvent.keyDown(window, { key: 'Z' })
     expect(onYes).toHaveBeenCalled()
   })
 

--- a/src/tests/run/LabelNameInput.test.tsx
+++ b/src/tests/run/LabelNameInput.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LabelNameInput } from '../../components/run/LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+
+const suggestions: LabelNameSuggestion[] = [
+  { name: 'confusion', description: 'Student shows confusion about a concept' },
+  { name: 'code help', description: 'Requesting help with code' },
+]
+
+describe('LabelNameInput', () => {
+  it('shows filtered suggestions when focused and typing', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('confusion')).toBeInTheDocument()
+    expect(screen.queryByText('code help')).not.toBeInTheDocument()
+  })
+
+  it('hides dropdown when typed value exactly matches a suggestion', () => {
+    render(<LabelNameInput value="confusion" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('calls onChange and onCommit when suggestion is clicked', () => {
+    const onChange = vi.fn()
+    const onCommit = vi.fn()
+    render(
+      <LabelNameInput value="con" onChange={onChange} onCommit={onCommit} suggestions={suggestions} />
+    )
+    fireEvent.focus(screen.getByRole('combobox'))
+    fireEvent.mouseDown(screen.getByText('confusion'))
+    expect(onChange).toHaveBeenCalledWith('confusion')
+    expect(onCommit).toHaveBeenCalled()
+  })
+
+  it('selects first suggestion on Enter when dropdown is open', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="con" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('confusion')
+  })
+
+  it('navigates to second suggestion with ArrowDown then selects with Enter', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="c" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('code help')
+  })
+
+  it('closes dropdown on Escape', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('passes unhandled keyDown events to the onKeyDown prop', () => {
+    const onKeyDown = vi.fn()
+    render(
+      <LabelNameInput value="" onChange={() => {}} suggestions={[]} onKeyDown={onKeyDown} />
+    )
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' })
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  it('renders as a plain input when suggestions is empty', () => {
+    render(<LabelNameInput value="any" onChange={() => {}} suggestions={[]} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,6 +200,11 @@ export interface ConceptCandidate {
   created_at: string
 }
 
+export interface LabelNameSuggestion {
+  name: string
+  description: string
+}
+
 export interface EmbedStatus {
   cached: number
   total_unlabeled: number


### PR DESCRIPTION
## Summary

- Merges `origin/single-study-fixes` (handoff-ready popup, hide assignments tab, label name suggestions, label-switch same conversation, study scope, autofill fixes).
- Adds local study bug fixes: single-label in-conversation sampling (decide/undo), Summaries flag endpoint, Gemini `2.5-flash` (retired 2.0 model), recalibration blind phase (no DB label leak).
- Re-enables full multi-label recalibration flow (handlers, banners, Escape, sidebar) that `single-study-fixes` had disabled.
- Merges `fix-recalibration-window` (DB-backed label review, force recalibration without DEV_MODE).

## Test plan

- [x] `uv run pytest` (367 passed)
- [x] `npm test` (180 passed)
- [x] `npx tsc --noEmit`
- [ ] Manual: `/run` yes/no/skip/undo stay in same conversation; switch label keeps convo
- [ ] Manual: multi-label recalibration blind + reconcile
- [ ] Manual: Summaries flag toggle + flagged filter
- [ ] Manual: handoff-ready popup when readiness hits green
- [ ] `kubectl port-forward` running (external DB thread fetch)

## Not included

- `fix/run-thread-and-explore-sampling` (heavy merge conflicts; most sampling backend already on branch). Can follow up if explore % tooltip / thread-leading-tutor fix is still wanted.


Made with [Cursor](https://cursor.com)