### PR TITLE
Fix blank screen, restore keybinds, fix build error

### DIFF
--- a/src/hooks/useKeybinds.tsx
+++ b/src/hooks/useKeybinds.tsx
@@ -7,10 +7,10 @@ export type KeybindMap = Record<Action, string>
 const STORAGE_KEY = 'chatsight-keybinds'
 
 const DEFAULT_KEYBINDS: KeybindMap = {
-  yes: 'z',
+  yes: 'a',
   no: 'd',
-  skip: 'arrowright',
-  undo: 'arrowleft',
+  skip: ' ',
+  undo: 's',
 }
 
 type KeybindContextValue = {

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -607,7 +607,6 @@ export function LabelRunPage() {
   const handleSwitchToQueued = useCallback(
     async (id: number) => {
       if (busy) return
-      const hintChatlogId = focused?.chatlog_id
       setBusyMessage('Switching label…')
       setBusy(true)
       // Capture the current position before switching so we can pin to it.

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -116,7 +116,7 @@ export function QueuePage() {
 
 	const currentMessage = queue[currentIdx] ?? null;
 
-	const formatKey = (key: string) => {
+	const formatKey = (key: string): string => {
 		if (key === " ") return "Space";
 		if (key === "enter") return "Enter";
 		if (key === "arrowleft") return "←";


### PR DESCRIPTION
- Remove duplicate `hintChatlogId` declaration in `LabelRunPage` that crashed the app
- Restore default keybinds to `a/d/Space/s` (study bundle had changed them to `z/ArrowRight/ArrowLeft`)
- Add explicit return type to `formatKey` in `QueuePage` to fix `tsc -b` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)