### PR TITLE
Single-label handoff ordering, study-scoped coverage, skip verdict, live summaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ npx tsc --noEmit     # type-check only
 - `PG_PASSWORD` — password for the `dsc10_tutor` PostgreSQL user (read from `.env` at repo root via `python-dotenv`)
 - `kubectl port-forward` to `localhost:5432` must be running before starting the backend (external DB is `dsc10_tutor_logs`)
 - Optional: `EXT_DB_URL` overrides the default PostgreSQL connection string
+- Optional: `CHATSIGHT_MULTILABEL_THRESHOLD` — minimum AI confidence (0.0–1.0, default 0.5) for a multi-label auto-label to be persisted in queue mode. Lower it (e.g. 0.3) if auto-labeling is too sparse.
 
 ## Architecture
 

--- a/docs/superpowers/plans/2026-06-01-week-scoped-routes.md
+++ b/docs/superpowers/plans/2026-06-01-week-scoped-routes.md
@@ -1,0 +1,559 @@
+# Week-Scoped Routes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hard-lock `/queue` (multi-label) to DSC 10 Winter-2026 Week 3 (Lab 1 + HW 1) and `/run` (single-label) to Week 8 (Lab 5 + HW 5), server-side, including the Gemini handoff classification.
+
+**Architecture:** A single source-of-truth module `study_scope.py` defines per-week assignment-name sets and reuses `assignment_service._canonical_name` to decide whether a `MessageCache.notebook` is in scope. Scope is keyed on label **mode** (multi → Week 3, single → Week 8) because `next_message_for_label` is shared. Enforcement is unconditional and ignores any client `assignment_id`.
+
+**Tech Stack:** FastAPI + SQLModel + SQLite (backend), pytest, React + TypeScript + Vite (frontend).
+
+---
+
+## File Structure
+
+- **Create** `server/python/study_scope.py` — scope constants + predicate helpers. One responsibility: "is this notebook in the locked week?".
+- **Create** `server/python/tests/test_study_scope.py` — unit + route tests.
+- **Modify** `server/python/queue_service.py` — scope `next_message_for_label` by mode.
+- **Modify** `server/python/decision_service.py` — scope `compute_readiness` denominator.
+- **Modify** `server/python/main.py` — scope `/api/queue`, `/api/queue/stats`, `/api/queue/position`, and `_do_classification`.
+- **Modify** `src/components/run/StripBar.tsx` — replace assignment picker with a fixed-scope label.
+- **Modify** `src/pages/QueuePage.tsx` — add a fixed-scope banner.
+
+---
+
+## Task 1: `study_scope` module
+
+**Files:**
+- Create: `server/python/study_scope.py`
+- Test: `server/python/tests/test_study_scope.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# server/python/tests/test_study_scope.py
+import study_scope
+
+
+def test_queue_scope_matches_week3_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab1.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("lab01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw1.ipynb", study_scope.QUEUE_SCOPE)
+
+
+def test_run_scope_matches_week8_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab5.ipynb", study_scope.RUN_SCOPE)
+    assert study_scope.notebook_in_scope("hw05.ipynb", study_scope.RUN_SCOPE)
+
+
+def test_out_of_scope_and_none():
+    assert not study_scope.notebook_in_scope("lab2.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab15.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab1.ipynb", study_scope.RUN_SCOPE)
+    assert not study_scope.notebook_in_scope(None, study_scope.QUEUE_SCOPE)
+
+
+def test_scope_for_mode():
+    assert study_scope.scope_for_mode("single") == study_scope.RUN_SCOPE
+    assert study_scope.scope_for_mode("multi") == study_scope.QUEUE_SCOPE
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'study_scope'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# server/python/study_scope.py
+"""Study fixture: hard-locked per-week assignment scopes for the user study.
+
+`/queue` (multi-label) is locked to DSC 10 Winter-2026 Week 3 (Lab 1 + HW 1);
+`/run` (single-label) is locked to Week 8 (Lab 5 + HW 5). Scope is expressed in
+canonical assignment names (the same vocabulary as assignment_service) so it does
+not depend on AssignmentMapping rows existing. Weeks come from
+https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
+data/milestones/dsc10_wi26.json).
+"""
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from assignment_service import _canonical_name
+from models import MessageCache
+
+QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
+RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
+
+
+def scope_for_mode(mode: str) -> set[str]:
+    """Single-label runs are Week 8; everything else (multi/onboarding) is Week 3."""
+    return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
+
+
+def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
+    return notebook is not None and _canonical_name(notebook) in names
+
+
+def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
+    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`."""
+    rows = session.exec(
+        select(
+            MessageCache.chatlog_id,
+            MessageCache.message_index,
+            MessageCache.notebook,
+        )
+    ).all()
+    return {
+        (cid, midx)
+        for cid, midx, nb in rows
+        if notebook_in_scope(nb, names)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/study_scope.py server/python/tests/test_study_scope.py
+git commit -m "feat: study_scope module locking weeks to assignment-name sets"
+```
+
+---
+
+## Task 2: Scope the multi-label `/queue` endpoints (Week 3)
+
+**Files:**
+- Modify: `server/python/main.py` (`get_queue`, `get_queue_stats`, `get_queue_position`)
+- Test: `server/python/tests/test_study_scope.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_study_scope.py`. This uses the existing test fixture pattern (see `server/python/tests/conftest.py`): `client` is a `TestClient` over the app with an in-memory DB and a `session` fixture for seeding.
+
+```python
+from models import MessageCache
+
+
+def _seed(session, chatlog_id, message_index, notebook):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id, message_index=message_index,
+        message_text=f"msg {chatlog_id}.{message_index}", notebook=notebook,
+    ))
+    session.commit()
+
+
+def test_queue_returns_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")   # in scope (Week 3)
+    _seed(session, 2, 0, "lab5.ipynb")   # out of scope (Week 8)
+    _seed(session, 3, 0, "lab2.ipynb")   # out of scope
+    resp = client.get("/api/queue?limit=50")
+    assert resp.status_code == 200
+    ids = {row["chatlog_id"] for row in resp.json()}
+    assert ids == {1}
+
+
+def test_queue_stats_counts_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")
+    _seed(session, 2, 0, "hw1.ipynb")
+    _seed(session, 3, 0, "lab5.ipynb")
+    stats = client.get("/api/queue/stats").json()
+    assert stats["total_messages"] == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -k queue -v`
+Expected: FAIL — `test_queue_returns_only_week3` sees `{1, 2, 3}`; `total_messages` is 3.
+
+- [ ] **Step 3: Implement — scope `get_queue` candidates**
+
+In `server/python/main.py`, add the import near the other service imports (next to `import assignment_service`):
+
+```python
+import study_scope
+```
+
+In `get_queue`, replace the candidate-building block:
+
+```python
+    # Query from cache instead of external DB CTE
+    all_cached = db.exec(select(MessageCache)).all()
+
+    candidates = [
+        c for c in all_cached
+        if (c.chatlog_id, c.message_index) not in excluded
+    ]
+```
+
+with:
+
+```python
+    # Query from cache instead of external DB CTE. Study lock: Week 3 only.
+    all_cached = db.exec(select(MessageCache)).all()
+
+    candidates = [
+        c for c in all_cached
+        if (c.chatlog_id, c.message_index) not in excluded
+        and study_scope.notebook_in_scope(c.notebook, study_scope.QUEUE_SCOPE)
+    ]
+```
+
+- [ ] **Step 4: Implement — scope `get_queue_stats`**
+
+Replace the body of `get_queue_stats` with an in-scope-keyed version:
+
+```python
+@app.get("/api/queue/stats")
+def get_queue_stats(db: Session = Depends(get_session)):
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
+    return {
+        "total_messages": len(in_scope),
+        "labeled_count": labeled_count,
+        "skipped_count": skipped_count,
+    }
+```
+
+- [ ] **Step 5: Implement — scope `get_queue_position`**
+
+Replace the body of `get_queue_position` with:
+
+```python
+@app.get("/api/queue/position")
+def get_queue_position(db: Session = Depends(get_session)):
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
+    total = len(in_scope)
+    total_remaining = max(0, total - labeled_count - skipped_count)
+    position = labeled_count + skipped_count + 1
+    return {"position": position, "total_remaining": total_remaining}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: PASS (all, including the two new queue tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/python/main.py server/python/tests/test_study_scope.py
+git commit -m "feat: lock /queue endpoints to Week 3 (Lab 1 + HW 1)"
+```
+
+---
+
+## Task 3: Scope single-label `next_message_for_label` (Week 8)
+
+**Files:**
+- Modify: `server/python/queue_service.py` (`next_message_for_label`)
+- Test: `server/python/tests/test_study_scope.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_study_scope.py`:
+
+```python
+import queue_service
+from models import LabelDefinition
+
+
+def test_run_next_returns_only_week8(session):
+    # Seed an in-scope (Week 8) and an out-of-scope conversation.
+    _seed(session, 10, 0, "lab5.ipynb")   # Week 8 — in scope for single mode
+    _seed(session, 11, 0, "lab1.ipynb")   # Week 3 — out of scope for single mode
+    label = LabelDefinition(name="needs help", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+
+    picks = set()
+    for _ in range(10):
+        payload = queue_service.next_message_for_label(session, label.id)
+        if payload:
+            picks.add(payload["chatlog_id"])
+    assert picks <= {10}
+    assert 11 not in picks
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py::test_run_next_returns_only_week8 -v`
+Expected: FAIL — conversation 11 is also picked.
+
+- [ ] **Step 3: Implement — filter `cache_rows` by mode scope**
+
+In `server/python/queue_service.py`, add the import at the top (with the other local imports):
+
+```python
+import study_scope
+```
+
+In `next_message_for_label`, find the cache query block:
+
+```python
+    if assignment_id is not None:
+        cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
+    cache_rows = session.exec(cache_q).all()
+```
+
+Replace it with (note: `cache_rows` columns are `(_id, cid, midx, text, notebook, assign)` — `notebook` is index 4):
+
+```python
+    if assignment_id is not None:
+        cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
+    cache_rows = session.exec(cache_q).all()
+
+    # Study lock: restrict to the week tied to this label's mode
+    # (single -> Week 8, multi/onboarding -> Week 3). Unconditional; the
+    # client assignment_id filter above only narrows further.
+    _label = session.get(LabelDefinition, label_id)
+    _scope = study_scope.scope_for_mode(_label.mode if _label else "multi")
+    cache_rows = [
+        row for row in cache_rows
+        if study_scope.notebook_in_scope(row[4], _scope)
+    ]
+```
+
+(`LabelDefinition` is already imported in `queue_service.py`; confirm with `grep "LabelDefinition" server/python/queue_service.py` — it is used later in the same function.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py::test_run_next_returns_only_week8 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/queue_service.py server/python/tests/test_study_scope.py
+git commit -m "feat: scope single-label /run selection to Week 8 by mode"
+```
+
+---
+
+## Task 4: Scope readiness denominator + handoff classification (Week 8)
+
+**Files:**
+- Modify: `server/python/decision_service.py` (`compute_readiness`)
+- Modify: `server/python/main.py` (`_do_classification`)
+- Test: `server/python/tests/test_study_scope.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_study_scope.py`:
+
+```python
+import decision_service
+
+
+def test_readiness_total_convs_scoped_to_week8(session):
+    _seed(session, 20, 0, "lab5.ipynb")   # Week 8
+    _seed(session, 21, 0, "lab1.ipynb")   # Week 3
+    _seed(session, 22, 0, "lab2.ipynb")   # other
+    label = LabelDefinition(name="x", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+    state = decision_service.compute_readiness(session, label.id)
+    assert state["total_conversations"] == 1
+
+
+def test_classification_pending_excludes_out_of_scope(session, monkeypatch):
+    import main
+    _seed(session, 30, 0, "lab5.ipynb")   # Week 8 — should be classified
+    _seed(session, 31, 0, "lab1.ipynb")   # Week 3 — must be skipped
+    label = LabelDefinition(name="y", mode="single", phase="labeling",
+                            review_threshold=0.5)
+    session.add(label)
+    session.commit()
+
+    captured = {}
+
+    def fake_parallel(db, label, pending, yes_examples, no_examples):
+        captured["pending"] = pending
+        return {"yes": 0, "no": 0, "skip": 0, "errors": 0}
+
+    monkeypatch.setattr(main, "_classify_in_parallel", fake_parallel)
+    # Force the inline parallel path (small job) by keeping pending tiny.
+    main._do_classification(session, label)
+    keys = {(c, i) for (c, i, _t) in captured["pending"]}
+    assert (30, 0) in keys
+    assert (31, 0) not in keys
+```
+
+NOTE: `_classify_in_parallel`'s real signature must be confirmed before writing the `fake_parallel` stub — open `server/python/main.py` at `def _classify_in_parallel(` and match its parameters exactly. If the small-job path calls a differently named function, stub that one instead. Adjust the stub signature to match; the assertion on `captured["pending"]` is the invariant that matters.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -k "readiness or classification" -v`
+Expected: FAIL — `total_conversations` is 3; classification pending includes `(31, 0)`.
+
+- [ ] **Step 3: Implement — scope `compute_readiness`**
+
+In `server/python/decision_service.py`, add the import at the top:
+
+```python
+import study_scope
+```
+
+Find:
+
+```python
+    total_convs = session.exec(
+        select(MessageCache.chatlog_id).distinct()
+    ).all()
+    total_convs_count = len(total_convs)
+```
+
+Replace with:
+
+```python
+    # Study lock: single-label runs are Week 8 — count only in-scope convs.
+    label = session.get(LabelDefinition, label_id)
+    scope = study_scope.scope_for_mode(label.mode if label else "single")
+    in_scope = study_scope.in_scope_keys(session, scope)
+    total_convs_count = len({cid for cid, _ in in_scope})
+```
+
+(`LabelDefinition` and `MessageCache` are already imported in `decision_service.py`; verify with `grep "^from models" server/python/decision_service.py`.)
+
+- [ ] **Step 4: Implement — scope `_do_classification`**
+
+In `server/python/main.py` (`study_scope` already imported in Task 2), find in `_do_classification`:
+
+```python
+    cached = db.exec(
+        select(MessageCache.chatlog_id, MessageCache.message_index, MessageCache.message_text)
+    ).all()
+    pending = [(c, i, t) for (c, i, t) in cached if (c, i) not in decided_keys]
+```
+
+Replace with:
+
+```python
+    cached = db.exec(
+        select(MessageCache.chatlog_id, MessageCache.message_index, MessageCache.message_text)
+    ).all()
+    # Study lock: only classify the week this label's mode is scoped to
+    # (single -> Week 8). Keeps Gemini handoff bounded and fast.
+    scope = study_scope.scope_for_mode(label.mode)
+    in_scope = study_scope.in_scope_keys(db, scope)
+    pending = [
+        (c, i, t) for (c, i, t) in cached
+        if (c, i) not in decided_keys and (c, i) in in_scope
+    ]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd server/python && uv run pytest tests/test_study_scope.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 6: Run the full backend suite (no regressions)**
+
+Run: `cd server/python && uv run pytest`
+Expected: PASS. If pre-existing unrelated tests assume the full corpus appears in `/queue` or `/run`, note them — they may need a scope-aware seed, but do not loosen the lock to make them pass without confirming with the spec.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/python/decision_service.py server/python/main.py server/python/tests/test_study_scope.py
+git commit -m "feat: bound readiness + Gemini handoff classification to Week 8"
+```
+
+---
+
+## Task 5: Frontend — replace assignment pickers with fixed-scope labels
+
+**Files:**
+- Modify: `src/components/run/StripBar.tsx`
+- Modify: `src/pages/QueuePage.tsx`
+
+- [ ] **Step 1: Replace the `/run` assignment picker with a scope label**
+
+In `src/components/run/StripBar.tsx`, find the `AssignmentPicker` usage:
+
+```tsx
+            <AssignmentPicker
+              assignments={assignments}
+              unmapped={unmapped}
+              selectedId={selectedAssignmentId}
+              onSelect={onSelectAssignment}
+            />
+```
+
+Replace with a static label (the server ignores `assignment_id` now):
+
+```tsx
+            <span className="inline-flex items-center gap-2 font-mono text-[11px] text-muted">
+              <span className="text-[9px] tracking-[0.06em] uppercase text-faint">scope</span>
+              <span className="text-fg">Week 8 — Lab 5 &amp; HW 5</span>
+            </span>
+```
+
+Leave the `AssignmentPicker` import in place only if still referenced elsewhere; if it becomes unused, remove the import to keep the type-check clean.
+
+- [ ] **Step 2: Add a fixed-scope banner to `/queue`**
+
+In `src/pages/QueuePage.tsx`, locate the top of the page's main returned JSX (the outermost container that holds the queue header). Add, as the first child inside that container:
+
+```tsx
+      <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-neutral-800 bg-neutral-900 px-3 py-1.5 font-mono text-[11px] text-neutral-300">
+        <span className="text-[9px] uppercase tracking-[0.06em] text-neutral-500">scope</span>
+        <span>Week 3 — Lab 1 &amp; HW 1</span>
+      </div>
+```
+
+(Place it where it reads naturally above the message card; match the surrounding indentation.)
+
+- [ ] **Step 3: Type-check and build**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. Then `npm run build` — expected: success.
+
+- [ ] **Step 4: Run frontend tests (no regressions)**
+
+Run: `npm test`
+Expected: PASS. If a StripBar test asserts the assignment picker is rendered, update it to assert the scope label instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/run/StripBar.tsx src/pages/QueuePage.tsx
+git commit -m "feat: show fixed week-scope label, drop assignment picker on locked routes"
+```
+
+---
+
+## Final verification
+
+- [ ] `cd server/python && uv run pytest` — all pass.
+- [ ] `npx tsc --noEmit && npm test` — all pass.
+- [ ] Manual smoke (optional, needs DB tunnel): start backend + frontend, confirm `/queue` shows only Lab 1 / HW 1 messages and `/run` shows only Lab 5 / HW 5, and that triggering handoff classifies only Week 8.

--- a/docs/superpowers/plans/2026-06-03-label-suggestions.md
+++ b/docs/superpowers/plans/2026-06-03-label-suggestions.md
@@ -1,0 +1,952 @@
+# Label Name Suggestions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace browser contact autofill on single-label name inputs with a custom autocomplete dropdown populated by concept candidates filtered to exclude semantically similar existing labels.
+
+**Architecture:** A new backend service (`name_suggestion_service.py`) embeds both concept candidate names and existing label names via `gemini-embedding-001`, filters candidates where cosine similarity to any existing label exceeds 0.75, and returns a clean list. A `useLabelSuggestions` hook fetches this once on mount in `LabelRunPage`. A reusable `LabelNameInput` component wraps `<input>` + dropdown and is wired into `StripBar` and `NoteLabelPopover` — the only two single-label name entry points. Multi-label components (`NewLabelPopover`, `LabelsPage`, `QueuePage`) are not touched.
+
+**Tech Stack:** Python/FastAPI, SQLModel, `google-genai` SDK, numpy (already installed), React 18, TypeScript, Tailwind v4, Vitest + React Testing Library
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `server/python/name_suggestion_service.py` | Cosine-similarity filtering + Gemini embedding call |
+| Modify | `server/python/main.py` | Add `GET /api/concepts/name-suggestions` endpoint |
+| Create | `server/python/tests/test_name_suggestions.py` | Backend unit + integration tests |
+| Modify | `src/types/index.ts` | Add `LabelNameSuggestion` interface |
+| Modify | `src/services/api.ts` | Add `getNameSuggestions` call |
+| Create | `src/hooks/useLabelSuggestions.ts` | Fetch + cache suggestions on mount |
+| Create | `src/components/run/LabelNameInput.tsx` | Input + filtered dropdown component |
+| Create | `src/tests/run/LabelNameInput.test.tsx` | Frontend component tests |
+| Modify | `src/components/run/StripBar.tsx` | Accept + forward suggestions; use LabelNameInput |
+| Modify | `src/components/run/NoteLabelPopover.tsx` | Accept + forward suggestions; use LabelNameInput |
+| Modify | `src/pages/LabelRunPage.tsx` | Call useLabelSuggestions; pass to StripBar + NoteLabelPopover |
+
+---
+
+## Task 1: Add `LabelNameSuggestion` type and `getNameSuggestions` API call
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/services/api.ts`
+
+- [ ] **Step 1: Add type to `src/types/index.ts`**
+
+Find the `ConceptCandidate` interface (around line 192) and add the new type immediately after it:
+
+```ts
+export interface LabelNameSuggestion {
+  name: string
+  description: string
+}
+```
+
+- [ ] **Step 2: Add API call to `src/services/api.ts`**
+
+Find the `getCandidates` entry (around line 131) and add the new call immediately after it:
+
+```ts
+  getNameSuggestions: (): Promise<LabelNameSuggestion[]> =>
+    USE_MOCK ? Promise.resolve([]) : req('/api/concepts/name-suggestions'),
+```
+
+Add `LabelNameSuggestion` to the import from `'../types'` at the top of `api.ts`.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/index.ts src/services/api.ts
+git commit -m "feat: add LabelNameSuggestion type and getNameSuggestions API call"
+```
+
+---
+
+## Task 2: Create `name_suggestion_service.py` (TDD)
+
+**Files:**
+- Create: `server/python/name_suggestion_service.py`
+- Create: `server/python/tests/test_name_suggestions.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/python/tests/test_name_suggestions.py`:
+
+```python
+import math
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _emb(values):
+    e = MagicMock()
+    e.values = values
+    return e
+
+
+def _mock_embed(*batches):
+    """Return a mock embed_content that yields embeddings from `batches` in order."""
+    responses = []
+    for vecs in batches:
+        r = MagicMock()
+        r.embeddings = [_emb(v) for v in vecs]
+        responses.append(r)
+    m = MagicMock(side_effect=responses)
+    return m
+
+
+# ── _cosine_sim ──────────────────────────────────────────────────────────────
+
+def test_cosine_sim_identical_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_sim_orthogonal_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]) == pytest.approx(0.0)
+
+
+def test_cosine_sim_zero_vector_returns_zero():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([0.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == 0.0
+
+
+# ── filter_suggestions ───────────────────────────────────────────────────────
+
+def test_filter_removes_synonym(monkeypatch):
+    """'puzzled' should be filtered when 'confusion' exists (cos_sim ≈ 0.99 > 0.75)."""
+    import name_suggestion_service as svc
+
+    # candidates: ["puzzled", "code syntax help"], existing: ["confusion"]
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        result = svc.filter_suggestions(
+            candidate_names=["puzzled", "code syntax help"],
+            candidate_descriptions=["lost student", "syntax questions"],
+            existing_names=["confusion"],
+        )
+
+    names = [r["name"] for r in result]
+    assert "puzzled" not in names          # cos([0.99,0.14,0],[1,0,0]) ≈ 0.99 > 0.75
+    assert "code syntax help" in names     # cos([0,0,1],[1,0,0]) = 0.0 < 0.75
+
+
+def test_filter_returns_all_when_no_existing_labels():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=["error tracing"],
+        candidate_descriptions=["tracing errors"],
+        existing_names=[],
+    )
+    assert result == [{"name": "error tracing", "description": "tracing errors"}]
+
+
+def test_filter_returns_empty_when_no_candidates():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=[],
+        candidate_descriptions=[],
+        existing_names=["confusion"],
+    )
+    assert result == []
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py -v
+```
+
+Expected: `ImportError: No module named 'name_suggestion_service'`
+
+- [ ] **Step 3: Implement `name_suggestion_service.py`**
+
+Create `server/python/name_suggestion_service.py`:
+
+```python
+import math
+import os
+from typing import List
+
+import numpy as np
+from google import genai
+
+SUGGESTION_SIMILARITY_THRESHOLD = 0.75
+_EMBED_MODEL = "gemini-embedding-001"
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+def _cosine_sim(a: List[float], b: List[float]) -> float:
+    va, vb = np.array(a, dtype=np.float32), np.array(b, dtype=np.float32)
+    denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(va, vb) / denom)
+
+
+def filter_suggestions(
+    candidate_names: List[str],
+    candidate_descriptions: List[str],
+    existing_names: List[str],
+) -> List[dict]:
+    """Return candidates not semantically similar to any existing label name.
+
+    Embeds all texts in one batch call: candidates first, then existing names.
+    Drops any candidate whose max cosine similarity to an existing label
+    exceeds SUGGESTION_SIMILARITY_THRESHOLD.
+    """
+    if not candidate_names:
+        return []
+    if not existing_names:
+        return [
+            {"name": n, "description": d}
+            for n, d in zip(candidate_names, candidate_descriptions)
+        ]
+
+    all_texts = candidate_names + existing_names
+    resp = client.models.embed_content(model=_EMBED_MODEL, contents=all_texts)
+    embeddings = [e.values for e in resp.embeddings]
+
+    cand_vecs = embeddings[: len(candidate_names)]
+    exist_vecs = embeddings[len(candidate_names) :]
+
+    result = []
+    for name, desc, vec in zip(candidate_names, candidate_descriptions, cand_vecs):
+        max_sim = max(_cosine_sim(vec, ex) for ex in exist_vecs)
+        if max_sim <= SUGGESTION_SIMILARITY_THRESHOLD:
+            result.append({"name": name, "description": desc})
+    return result
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py -v
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/name_suggestion_service.py server/python/tests/test_name_suggestions.py
+git commit -m "feat: add name_suggestion_service with cosine-similarity label filtering"
+```
+
+---
+
+## Task 3: Add `/api/concepts/name-suggestions` endpoint to `main.py`
+
+**Files:**
+- Modify: `server/python/main.py`
+- Modify: `server/python/tests/test_name_suggestions.py`
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+Append to `server/python/tests/test_name_suggestions.py`:
+
+```python
+# ── endpoint ─────────────────────────────────────────────────────────────────
+
+def test_endpoint_returns_empty_when_no_candidates(client):
+    resp = client.get("/api/concepts/name-suggestions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_endpoint_filters_and_returns_suggestions(client, session):
+    from models import LabelDefinition, ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(LabelDefinition(name="confusion", mode="single", description=""))
+    session.add(ConceptCandidate(
+        name="puzzled", description="student seems lost",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.add(ConceptCandidate(
+        name="code syntax help", description="syntax questions",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    names = [s["name"] for s in resp.json()]
+    assert "puzzled" not in names
+    assert "code syntax help" in names
+
+
+def test_endpoint_returns_empty_on_gemini_error(client, session):
+    from models import ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(ConceptCandidate(
+        name="scope clarification", description="...",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    with patch.object(svc.client.models, "embed_content", side_effect=Exception("network")):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+```
+
+- [ ] **Step 2: Run new tests — confirm they fail**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py::test_endpoint_returns_empty_when_no_candidates -v
+```
+
+Expected: `404 Not Found` (endpoint doesn't exist yet).
+
+- [ ] **Step 3: Add endpoint to `main.py`**
+
+Find the existing `GET /api/concepts/candidates` endpoint (around line 2067) and add the new endpoint immediately after it:
+
+```python
+@app.get("/api/concepts/name-suggestions")
+def get_name_suggestions(db: Session = Depends(get_session)):
+    """Return pending concept candidates filtered to exclude semantic duplicates of existing labels."""
+    import name_suggestion_service
+
+    candidates = db.exec(
+        select(ConceptCandidate).where(ConceptCandidate.status == "pending")
+    ).all()
+    if not candidates:
+        return []
+
+    existing_names = list(db.exec(select(LabelDefinition.name)).all())
+
+    try:
+        return name_suggestion_service.filter_suggestions(
+            candidate_names=[c.name for c in candidates],
+            candidate_descriptions=[c.description for c in candidates],
+            existing_names=existing_names,
+        )
+    except Exception:
+        return []
+```
+
+- [ ] **Step 4: Run all name suggestion tests**
+
+```bash
+cd server/python && uv run pytest tests/test_name_suggestions.py -v
+```
+
+Expected: 9 tests pass.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+cd server/python && uv run pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/python/main.py server/python/tests/test_name_suggestions.py
+git commit -m "feat: add GET /api/concepts/name-suggestions endpoint"
+```
+
+---
+
+## Task 4: Create `useLabelSuggestions` hook
+
+**Files:**
+- Create: `src/hooks/useLabelSuggestions.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `src/hooks/useLabelSuggestions.ts`:
+
+```ts
+import { useState, useEffect } from 'react'
+import { api } from '../services/api'
+import type { LabelNameSuggestion } from '../types'
+
+export function useLabelSuggestions() {
+  const [suggestions, setSuggestions] = useState<LabelNameSuggestion[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getNameSuggestions()
+      .then(setSuggestions)
+      .catch(() => setSuggestions([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { suggestions, loading }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useLabelSuggestions.ts
+git commit -m "feat: add useLabelSuggestions hook"
+```
+
+---
+
+## Task 5: Create `LabelNameInput` component (TDD)
+
+**Files:**
+- Create: `src/components/run/LabelNameInput.tsx`
+- Create: `src/tests/run/LabelNameInput.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/tests/run/LabelNameInput.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LabelNameInput } from '../../components/run/LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+
+const suggestions: LabelNameSuggestion[] = [
+  { name: 'confusion', description: 'Student shows confusion about a concept' },
+  { name: 'code help', description: 'Requesting help with code' },
+]
+
+describe('LabelNameInput', () => {
+  it('shows filtered suggestions when focused and typing', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('confusion')).toBeInTheDocument()
+    expect(screen.queryByText('code help')).not.toBeInTheDocument()
+  })
+
+  it('hides dropdown when typed value exactly matches a suggestion', () => {
+    render(<LabelNameInput value="confusion" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('calls onChange and onCommit when suggestion is clicked', () => {
+    const onChange = vi.fn()
+    const onCommit = vi.fn()
+    render(
+      <LabelNameInput value="con" onChange={onChange} onCommit={onCommit} suggestions={suggestions} />
+    )
+    fireEvent.focus(screen.getByRole('combobox'))
+    fireEvent.mouseDown(screen.getByText('confusion'))
+    expect(onChange).toHaveBeenCalledWith('confusion')
+    expect(onCommit).toHaveBeenCalled()
+  })
+
+  it('selects first suggestion on Enter when dropdown is open', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="con" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('confusion')
+  })
+
+  it('navigates to second suggestion with ArrowDown then selects with Enter', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="c" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('code help')
+  })
+
+  it('closes dropdown on Escape', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('passes unhandled keyDown events to the onKeyDown prop', () => {
+    const onKeyDown = vi.fn()
+    render(
+      <LabelNameInput value="" onChange={() => {}} suggestions={[]} onKeyDown={onKeyDown} />
+    )
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' })
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  it('renders as a plain input when suggestions is empty', () => {
+    render(<LabelNameInput value="any" onChange={() => {}} suggestions={[]} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+npm test -- run src/tests/run/LabelNameInput.test.tsx
+```
+
+Expected: `Cannot find module '../../components/run/LabelNameInput'`
+
+- [ ] **Step 3: Implement `LabelNameInput`**
+
+Create `src/components/run/LabelNameInput.tsx`:
+
+```tsx
+import { useState, useEffect, useRef } from 'react'
+import type { LabelNameSuggestion } from '../../types'
+
+interface LabelNameInputProps {
+  value: string
+  onChange: (value: string) => void
+  onCommit?: () => void
+  suggestions: LabelNameSuggestion[]
+  placeholder?: string
+  readOnly?: boolean
+  autoFocus?: boolean
+  className?: string
+  onBlur?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  'data-tutorial'?: string
+}
+
+export function LabelNameInput({
+  value,
+  onChange,
+  onCommit,
+  suggestions,
+  placeholder,
+  readOnly,
+  autoFocus,
+  className,
+  onBlur,
+  onKeyDown,
+  ...rest
+}: LabelNameInputProps) {
+  const [open, setOpen] = useState(false)
+  const [highlighted, setHighlighted] = useState(0)
+
+  const filtered = suggestions.filter(
+    (s) =>
+      value.length > 0 &&
+      s.name.toLowerCase().includes(value.toLowerCase()) &&
+      s.name.toLowerCase() !== value.toLowerCase()
+  )
+  const showDropdown = open && filtered.length > 0
+
+  // Reset highlight when the filtered list changes
+  useEffect(() => {
+    setHighlighted(0)
+  }, [value])
+
+  function select(name: string) {
+    onChange(name)
+    setOpen(false)
+    onCommit?.()
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (showDropdown) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setHighlighted((h) => Math.min(h + 1, filtered.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setHighlighted((h) => Math.max(h - 1, 0))
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        select(filtered[highlighted].name)
+        return
+      }
+      if (e.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+    }
+    onKeyDown?.(e)
+  }
+
+  return (
+    <div className="relative">
+      <input
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        type="text"
+        autoComplete="off"
+        value={value}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        className={className}
+        onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => { setTimeout(() => setOpen(false), 150); onBlur?.() }}
+        onKeyDown={handleKeyDown}
+        {...rest}
+      />
+      {showDropdown && (
+        <ul
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-lg"
+        >
+          {filtered.map((s, i) => (
+            <li
+              key={s.name}
+              role="option"
+              aria-selected={i === highlighted}
+              className={`cursor-pointer px-3 py-2 ${
+                i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
+              }`}
+              onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
+              onMouseEnter={() => setHighlighted(i)}
+            >
+              <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
+              {s.description && (
+                <div className="truncate text-xs text-muted">{s.description}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+npm test -- run src/tests/run/LabelNameInput.test.tsx
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/run/LabelNameInput.tsx src/tests/run/LabelNameInput.test.tsx
+git commit -m "feat: add LabelNameInput component with filtered autocomplete dropdown"
+```
+
+---
+
+## Task 6: Wire `LabelNameInput` into `StripBar.tsx`
+
+**Files:**
+- Modify: `src/components/run/StripBar.tsx`
+
+- [ ] **Step 1: Add `suggestions` to `StripBarProps` and destructure it**
+
+In `src/components/run/StripBar.tsx`, add to the `StripBarProps` interface (after `onRemoveQueued`):
+
+```ts
+  suggestions?: LabelNameSuggestion[]
+```
+
+Add to the imports at the top:
+
+```ts
+import { LabelNameInput } from './LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+```
+
+Add `suggestions = []` to the destructured props in `StripBar`:
+
+```ts
+export function StripBar({
+  // ...existing props...
+  suggestions = [],
+}: StripBarProps) {
+```
+
+- [ ] **Step 2: Replace the bare `<input>` with `LabelNameInput`**
+
+Find the `<input>` block inside `{showNameInput ? (` (around line 102). Replace the entire `<input ... />` element with:
+
+```tsx
+<LabelNameInput
+  data-tutorial="label-name"
+  value={labelNameDraft ?? ''}
+  readOnly={labelNameLocked}
+  suggestions={suggestions}
+  onChange={(v) => onLabelNameDraftChange?.(v)}
+  onCommit={() => {
+    const name = (labelNameDraft ?? '').trim()
+    if (name && !isPlaceholderLabelName(name) && !labelNameLocked) {
+      commitName?.()
+    }
+  }}
+  onKeyDown={(e) => {
+    const name = (labelNameDraft ?? '').trim()
+    if (e.key === 'Enter' && name && !isPlaceholderLabelName(name) && !labelNameLocked) {
+      e.preventDefault()
+      commitName?.()
+    }
+  }}
+  onBlur={() => {
+    if (draftMode || labelNameLocked) return
+    onLabelNameCommit?.()
+  }}
+  placeholder="Label name…"
+  className="box-border w-full min-w-[10rem] max-w-[18rem] rounded-sm border border-edge bg-surface px-2.5 py-1.5 font-sans text-sm text-on-canvas placeholder:text-faint focus:outline-none focus:border-ochre-dim disabled:opacity-70"
+/>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/run/StripBar.tsx
+git commit -m "feat: use LabelNameInput in StripBar for single-label name field"
+```
+
+---
+
+## Task 7: Wire `LabelNameInput` into `NoteLabelPopover.tsx`
+
+**Files:**
+- Modify: `src/components/run/NoteLabelPopover.tsx`
+
+- [ ] **Step 1: Add `suggestions` to `NoteLabelPopoverProps` and import**
+
+In `src/components/run/NoteLabelPopover.tsx`, update the imports and props:
+
+```tsx
+import { LabelNameInput } from './LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+
+interface NoteLabelPopoverProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (name: string, description: string) => void
+  suggestions?: LabelNameSuggestion[]
+}
+```
+
+Add `suggestions = []` to the destructured function args:
+
+```tsx
+export function NoteLabelPopover({ open, onClose, onSubmit, suggestions = [] }: NoteLabelPopoverProps) {
+```
+
+- [ ] **Step 2: Replace the bare `<input>` with `LabelNameInput`**
+
+Find the `<input ref={nameRef} ...>` (around line 65). Replace it with:
+
+```tsx
+<LabelNameInput
+  ref={nameRef as React.Ref<HTMLInputElement>}
+  autoFocus
+  autoComplete="off"
+  placeholder="e.g. frustration"
+  value={name}
+  suggestions={suggestions}
+  onChange={setName}
+  onCommit={() => { if (name.trim()) onSubmit(name.trim(), description.trim()) }}
+  className="appearance-none bg-canvas border border-edge text-on-canvas px-[11px] py-[9px] rounded-sm font-sans text-[13px] focus:outline-none focus:border-ochre-dim"
+/>
+```
+
+Since `LabelNameInput` wraps a `<div>`, remove the `ref={nameRef}` forwarding and instead focus the input a different way. Update the `useEffect` that focuses on open:
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null)
+
+useEffect(() => {
+  if (open) {
+    requestAnimationFrame(() => {
+      const input = document.querySelector<HTMLInputElement>('[data-note-input]')
+      input?.focus()
+    })
+  } else {
+    setName('')
+    setDescription('')
+  }
+}, [open])
+```
+
+And add `data-note-input` to the `LabelNameInput`:
+
+```tsx
+<LabelNameInput
+  data-note-input=""
+  autoFocus
+  ...
+/>
+```
+
+Also update the `onKey` handler that checks `document.activeElement === nameRef.current` — replace with a check on `data-note-input`:
+
+```tsx
+const onKey = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    onClose()
+  } else if (
+    e.key === 'Enter' &&
+    (document.activeElement as HTMLElement)?.dataset?.noteInput !== undefined
+  ) {
+    e.preventDefault()
+    if (name.trim()) onSubmit(name.trim(), description.trim())
+  }
+}
+```
+
+Remove the `nameRef` ref entirely.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/run/NoteLabelPopover.tsx
+git commit -m "feat: use LabelNameInput in NoteLabelPopover for single-label name field"
+```
+
+---
+
+## Task 8: Connect `useLabelSuggestions` in `LabelRunPage.tsx`
+
+**Files:**
+- Modify: `src/pages/LabelRunPage.tsx`
+
+- [ ] **Step 1: Call `useLabelSuggestions` in `LabelRunPage`**
+
+Add the import at the top of `LabelRunPage.tsx`:
+
+```ts
+import { useLabelSuggestions } from '../hooks/useLabelSuggestions'
+```
+
+Add the hook call near the top of the component body (alongside the other hooks):
+
+```ts
+const { suggestions } = useLabelSuggestions()
+```
+
+- [ ] **Step 2: Pass `suggestions` to `StripBar`**
+
+Find the `<StripBar ... />` usage in `LabelRunPage.tsx` (around line 754). Add:
+
+```tsx
+suggestions={suggestions}
+```
+
+- [ ] **Step 3: Pass `suggestions` to both `NoteLabelPopover` instances**
+
+There are two `<NoteLabelPopover` instances (around lines 720 and 818). Add `suggestions={suggestions}` to both:
+
+```tsx
+<NoteLabelPopover
+  open={noteOpen}
+  onClose={() => setNoteOpen(false)}
+  onSubmit={handleNoteSubmit}
+  suggestions={suggestions}
+/>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run full frontend test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run full backend test suite**
+
+```bash
+cd server/python && uv run pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/LabelRunPage.tsx
+git commit -m "feat: connect label name suggestions to single-label run page"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Backend embedding filter at 0.75 threshold → Task 2
+- ✅ Only `pending` candidates → Task 3 (`where status == "pending"`)
+- ✅ Fetch existing labels from `LabelDefinition` (all modes) → Task 3
+- ✅ Returns empty list on error → Task 3 (try/except)
+- ✅ `useLabelSuggestions` hook, fetch once on mount → Task 4
+- ✅ `LabelNameInput` with `autoComplete="off"`, ↑↓ navigation, Enter/Escape → Task 5
+- ✅ Shows description per suggestion → Task 5
+- ✅ Wired into `StripBar` → Task 6
+- ✅ Wired into `NoteLabelPopover` → Task 7
+- ✅ `useLabelSuggestions` called in `LabelRunPage`, passed to both components → Task 8
+- ✅ Multi-label components not touched — `NewLabelPopover`, `QueuePage`, `LabelsPage` absent from file map
+
+**Type consistency:**
+- `LabelNameSuggestion` defined in Task 1, used in Tasks 4, 5, 6, 7 ✅
+- `filter_suggestions` signature in Task 2 matches call in Task 3 ✅
+- `suggestions` prop on `StripBar` is `LabelNameSuggestion[]` with default `[]` ✅
+- `suggestions` prop on `NoteLabelPopover` is `LabelNameSuggestion[]` with default `[]` ✅

--- a/docs/superpowers/plans/2026-06-08-multilabel-autolabel.md
+++ b/docs/superpowers/plans/2026-06-08-multilabel-autolabel.md
@@ -1,0 +1,486 @@
+# Multi-label Auto-labeling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make multi-label queue auto-labeling assign zero, one, or many labels per message (above a confidence threshold), while leaving the label-split flow on its existing exactly-one-label behavior.
+
+**Architecture:** Add an opt-in `multi_select` flag to `autolabel_service.classify_batch` that swaps in a multi-label system instruction and prompt wording. The general auto-label flow (`main._run_autolabel`) calls it with `multi_select=True` and filters returned labels by a global env-configurable confidence threshold before persisting. The label-split flow (`main._run_label_split` region near line 1290) keeps the default `multi_select=False` and is left untouched.
+
+**Tech Stack:** Python, FastAPI, SQLModel, Google `gemini-2.5-flash` (function calling), pytest with in-memory SQLite.
+
+---
+
+## Background for the implementer
+
+- `server/python/autolabel_service.py` builds a `classify_messages` Gemini tool and a single `CONFIG` (a `types.GenerateContentConfig`) whose `system_instruction` currently says *"Assign exactly one label to each message."* `classify_batch(label_definitions, examples_by_label, messages)` returns a flat `list[{index, label, confidence}]`.
+- `server/python/main.py` calls `classify_batch` from two background functions:
+  - `_run_autolabel()` (~line 1364) — the **general** multi-label auto-label flow. Its consumer loop (~lines 1477-1505) writes one `LabelApplication(applied_by="ai", confidence=...)` per returned row, with a dedup check per `(label_id, chatlog_id, message_index)`. **This is the flow we are changing.**
+  - `_run_label_split(...)` region (~line 1290) — splits one label into two sub-labels; each message must go to **exactly one** new bucket. **Leave this on `multi_select=False`; do not add a threshold gate here.**
+- Tests live in `server/python/tests/`. They mock `autolabel_service.classify_batch` and call `main._run_autolabel()` directly. See `tests/test_autolabel_fixes.py` for the exact pattern (`_make_label`, `_seed_msg`, `monkeypatch.setattr(autolabel_service, "classify_batch", fake)`, `monkeypatch.setattr(main, "engine", engine)`).
+- Run a single test: `cd server/python && uv run pytest tests/test_<file>.py::test_<name> -v`.
+- Importing `main` requires `GEMINI_API_KEY` and `PG_PASSWORD`; `conftest.py` sets a dummy `PG_PASSWORD`, and `GEMINI_API_KEY` resolves from `.env`/shell. If pytest fails at import with a missing key, set a dummy: `GEMINI_API_KEY=x uv run pytest ...`.
+
+## File Structure
+
+- Modify: `server/python/autolabel_service.py` — add `MULTILABEL_THRESHOLD` constant, two system-instruction configs, and `multi_select` params on `build_prompt` + `classify_batch`.
+- Modify: `server/python/main.py` — `_run_autolabel` calls `classify_batch(..., multi_select=True)` and applies the threshold gate in its consumer loop. (`_run_label_split` region: no change.)
+- Create: `server/python/tests/test_multilabel_autolabel.py` — unit tests for the service-level config selection and the `_run_autolabel` consumer behavior.
+
+---
+
+## Task 1: Add the threshold constant and multi-select config in `autolabel_service.py`
+
+**Files:**
+- Modify: `server/python/autolabel_service.py:48-63` (CONFIG block) and `:15`
+- Test: `server/python/tests/test_multilabel_autolabel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/python/tests/test_multilabel_autolabel.py`:
+
+```python
+"""Tests for multi-label auto-labeling (multi_select + confidence threshold)."""
+from datetime import datetime
+from unittest.mock import patch
+
+import autolabel_service
+
+
+def test_multilabel_threshold_default_is_half(monkeypatch):
+    monkeypatch.delenv("CHATSIGHT_MULTILABEL_THRESHOLD", raising=False)
+    # Re-read the env the same way the module does at import.
+    import importlib
+    importlib.reload(autolabel_service)
+    assert autolabel_service.MULTILABEL_THRESHOLD == 0.5
+
+
+def test_multilabel_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("CHATSIGHT_MULTILABEL_THRESHOLD", "0.3")
+    import importlib
+    importlib.reload(autolabel_service)
+    assert autolabel_service.MULTILABEL_THRESHOLD == 0.3
+    # Restore default so later tests are not affected by the reloaded module.
+    monkeypatch.delenv("CHATSIGHT_MULTILABEL_THRESHOLD", raising=False)
+    importlib.reload(autolabel_service)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py -v`
+Expected: FAIL with `AttributeError: module 'autolabel_service' has no attribute 'MULTILABEL_THRESHOLD'`
+
+- [ ] **Step 3: Add the constant and a multi-select config**
+
+In `server/python/autolabel_service.py`, just after the `client = genai.Client(...)` line (~line 15), add:
+
+```python
+MULTILABEL_THRESHOLD = float(os.environ.get("CHATSIGHT_MULTILABEL_THRESHOLD", "0.5"))
+```
+
+Then replace the existing single `CONFIG` (lines ~48-63) with two configs that share the tool but differ in system instruction:
+
+```python
+_SINGLE_SELECT_INSTRUCTION = (
+    "You are classifying student messages from AI tutoring conversations. "
+    "You will be given label definitions with example messages, then a batch "
+    "of unlabeled messages to classify. Assign exactly one label to each message. "
+    "Use the label names exactly as provided. Rate your confidence from 0.0 (very uncertain) to 1.0 (very certain)."
+)
+
+_MULTI_SELECT_INSTRUCTION = (
+    "You are classifying student messages from AI tutoring conversations. "
+    "You will be given label definitions with example messages, then a batch "
+    "of unlabeled messages to classify. Assign EVERY label that applies to a "
+    "message — a message may match several labels, exactly one, or none. Emit a "
+    "SEPARATE classification entry for each applicable label, reusing the same "
+    "index for every label that applies to that message. If a message matches no "
+    "label, emit no entry for it. "
+    "Use the label names exactly as provided. Rate your confidence from 0.0 (very uncertain) to 1.0 (very certain)."
+)
+
+
+def _make_config(system_instruction: str) -> types.GenerateContentConfig:
+    return types.GenerateContentConfig(
+        system_instruction=system_instruction,
+        temperature=0,
+        tools=[TOOL],
+        tool_config=types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(
+                mode="ANY",
+                allowed_function_names=["classify_messages"],
+            )
+        ),
+    )
+
+
+CONFIG = _make_config(_SINGLE_SELECT_INSTRUCTION)            # default / split flow
+MULTI_SELECT_CONFIG = _make_config(_MULTI_SELECT_INSTRUCTION)  # general auto-label
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py -v`
+Expected: PASS (both threshold tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/python/autolabel_service.py server/python/tests/test_multilabel_autolabel.py
+git commit -m "feat(autolabel): add MULTILABEL_THRESHOLD + multi-select Gemini config"
+```
+
+---
+
+## Task 2: Thread `multi_select` through `build_prompt` and `classify_batch`
+
+**Files:**
+- Modify: `server/python/autolabel_service.py:66-92` (`build_prompt`), `:95-137` (`classify_batch`), `:23-46` (tool item description)
+- Test: `server/python/tests/test_multilabel_autolabel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_multilabel_autolabel.py`:
+
+```python
+def test_build_prompt_multi_select_wording():
+    label_defs = [{"name": "confused", "description": "student is confused"}]
+    messages = [{"message_text": "I don't get it", "message_index": 0, "chatlog_id": 1}]
+    single = autolabel_service.build_prompt(label_defs, {}, messages, multi_select=False)
+    multi = autolabel_service.build_prompt(label_defs, {}, messages, multi_select=True)
+    assert "each message" in single
+    # Multi prompt must tell the model multiple/zero labels are allowed.
+    assert "all that apply" in multi.lower() or "every label" in multi.lower()
+
+
+def test_classify_batch_uses_multi_config(monkeypatch):
+    captured = {}
+
+    class _FakeFn:
+        name = "classify_messages"
+        args = {"classifications": [{"index": 0, "label": "confused", "confidence": 0.9}]}
+
+    class _FakePart:
+        function_call = _FakeFn()
+
+    class _FakeContent:
+        parts = [_FakePart()]
+
+    class _FakeCandidate:
+        content = _FakeContent()
+
+    class _FakeResp:
+        candidates = [_FakeCandidate()]
+
+    def fake_generate(model, contents, config):
+        captured["config"] = config
+        return _FakeResp()
+
+    monkeypatch.setattr(autolabel_service.client.models, "generate_content", fake_generate)
+
+    label_defs = [{"name": "confused", "description": ""}]
+    messages = [{"message_text": "huh", "message_index": 0, "chatlog_id": 1}]
+
+    autolabel_service.classify_batch(label_defs, {}, messages, multi_select=True)
+    assert captured["config"] is autolabel_service.MULTI_SELECT_CONFIG
+
+    autolabel_service.classify_batch(label_defs, {}, messages, multi_select=False)
+    assert captured["config"] is autolabel_service.CONFIG
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py -k "multi_select or multi_config" -v`
+Expected: FAIL with `TypeError: build_prompt() got an unexpected keyword argument 'multi_select'`
+
+- [ ] **Step 3: Add the parameters**
+
+In `build_prompt` (line ~66), change the signature and the closing instruction:
+
+```python
+def build_prompt(
+    label_definitions: List[Dict[str, Any]],
+    examples_by_label: Dict[str, List[str]],
+    messages: List[Dict[str, Any]],
+    multi_select: bool = False,
+) -> str:
+```
+
+Replace the closing `parts.append(...)` block (lines ~88-91) with:
+
+```python
+    if multi_select:
+        parts.append(
+            "Call `classify_messages` with one entry per (message, applicable label). "
+            "Assign all that apply: a message may get several labels, one, or none. "
+            "Reuse the same index for each label that applies to that message; omit "
+            "messages that match no label. Use label names exactly as defined above."
+        )
+    else:
+        parts.append(
+            "Call `classify_messages` with the index and label for each message. "
+            "Use label names exactly as defined above."
+        )
+    return "\n".join(parts)
+```
+
+In `classify_batch` (line ~95), change the signature, prompt call, and config selection:
+
+```python
+def classify_batch(
+    label_definitions: List[Dict[str, Any]],
+    examples_by_label: Dict[str, List[str]],
+    messages: List[Dict[str, Any]],
+    multi_select: bool = False,
+) -> List[Dict[str, Any]]:
+    """Classify a batch of messages. Returns list of {index, label, confidence}.
+
+    When multi_select is True the model may return multiple entries per index
+    (one per applicable label) or none; otherwise exactly one label per message.
+    """
+    prompt = build_prompt(label_definitions, examples_by_label, messages, multi_select)
+
+    response = client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=prompt,
+        config=MULTI_SELECT_CONFIG if multi_select else CONFIG,
+    )
+```
+
+(Leave the rest of `classify_batch`'s response-parsing body unchanged.)
+
+Also update the `classifications` item description in `TOOL` (line ~30-41) to note repeats are allowed, by changing the `index` field description to:
+
+```python
+                            "index": {"type": "integer", "description": "Index in the input messages array. The same index may appear in multiple entries when several labels apply."},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py -v`
+Expected: PASS (all tests so far)
+
+- [ ] **Step 5: Run the existing autolabel test to confirm no regression**
+
+Run: `cd server/python && uv run pytest tests/test_autolabel_fixes.py -v`
+Expected: PASS (the existing `fake_classify(label_defs, examples_by_label, messages)` mocks still work because `multi_select` is keyword-only-with-default at the call site; `main` will pass it as a keyword in Task 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/python/autolabel_service.py server/python/tests/test_multilabel_autolabel.py
+git commit -m "feat(autolabel): thread multi_select through build_prompt + classify_batch"
+```
+
+---
+
+## Task 3: Make `_run_autolabel` multi-select and gate by confidence
+
+**Files:**
+- Modify: `server/python/main.py:1467` (classify_batch call) and `:1477-1505` (consumer loop)
+- Test: `server/python/tests/test_multilabel_autolabel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/python/tests/test_multilabel_autolabel.py`:
+
+```python
+from sqlmodel import select
+import main
+import autolabel_service as _als
+from models import LabelApplication, LabelDefinition, MessageCache
+
+
+def _make_label(session, name):
+    lbl = LabelDefinition(name=name, mode="multi", archived_at=None)
+    session.add(lbl)
+    session.commit()
+    session.refresh(lbl)
+    return lbl
+
+
+def _seed_msg(session, chatlog_id, message_index, notebook, text):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id,
+        message_index=message_index,
+        message_text=text,
+        notebook=notebook,
+    ))
+    session.commit()
+
+
+def test_run_autolabel_applies_multiple_labels_and_gates(session, engine, monkeypatch):
+    monkeypatch.setattr(main, "engine", engine)
+    monkeypatch.setattr(_als, "MULTILABEL_THRESHOLD", 0.5)
+
+    a = _make_label(session, "label-a")
+    b = _make_label(session, "label-b")
+    c = _make_label(session, "label-c")
+    _seed_msg(session, 1, 0, "lab01.ipynb", "msg one")
+    _seed_msg(session, 2, 0, "lab01.ipynb", "msg two")
+
+    multi_select_seen = {}
+
+    def fake_classify(label_defs, examples_by_label, messages, multi_select=False):
+        multi_select_seen["value"] = multi_select
+        # message index 0 -> two labels above threshold + one below; index 1 -> none
+        return [
+            {"index": 0, "label": "label-a", "confidence": 0.9},
+            {"index": 0, "label": "label-b", "confidence": 0.8},
+            {"index": 0, "label": "label-c", "confidence": 0.2},  # below threshold
+        ]
+
+    monkeypatch.setattr(_als, "classify_batch", fake_classify)
+    main._run_autolabel()
+
+    assert multi_select_seen["value"] is True, "general autolabel must call with multi_select=True"
+
+    ai_apps = session.exec(
+        select(LabelApplication).where(LabelApplication.applied_by == "ai")
+    ).all()
+    by_label = {app.label_id for app in ai_apps}
+    assert a.id in by_label, "label-a (0.9) should be applied"
+    assert b.id in by_label, "label-b (0.8) should be applied"
+    assert c.id not in by_label, "label-c (0.2) below threshold must NOT be applied"
+    # Message index 1 got no entries -> stays unlabeled.
+    assert all(app.chatlog_id == 1 for app in ai_apps), "only message 1 should be labeled"
+    assert main._autolabel_status["error"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py::test_run_autolabel_applies_multiple_labels_and_gates -v`
+Expected: FAIL — either `multi_select` is `False` (assert fails) or `label-c` is persisted because no gate exists.
+
+- [ ] **Step 3: Update the call site**
+
+In `server/python/main.py` line ~1467, change:
+
+```python
+                results = classify_batch(label_defs, examples_by_label, batch)
+```
+
+to:
+
+```python
+                results = classify_batch(label_defs, examples_by_label, batch, multi_select=True)
+```
+
+- [ ] **Step 4: Add the confidence gate in the consumer loop**
+
+In `_run_autolabel`'s consumer loop, replace the existing persist block (lines ~1492-1504) — the `if not existing:` body — with a version that clamps and gates before writing:
+
+```python
+                    if not existing:
+                        conf = r.get("confidence")
+                        if isinstance(conf, (int, float)):
+                            conf = max(0.0, min(1.0, float(conf)))
+                        else:
+                            conf = None
+                        # Multi-select gate: only persist labels the model is
+                        # confident enough about. Missing/non-numeric confidence
+                        # is treated as below threshold (not persisted).
+                        if conf is None or conf < autolabel_service.MULTILABEL_THRESHOLD:
+                            continue
+                        db.add(LabelApplication(
+                            label_id=label_map[label_name],
+                            chatlog_id=msg["chatlog_id"],
+                            message_index=msg["message_index"],
+                            applied_by="ai",
+                            confidence=conf,
+                        ))
+```
+
+Confirm `autolabel_service` is imported in `main.py`. The function uses `from autolabel_service import classify_batch` locally (line ~1366); add a module-level reference at the top of `_run_autolabel`'s body so the constant resolves:
+
+```python
+    from autolabel_service import classify_batch
+    import autolabel_service
+```
+
+(The `import autolabel_service` line lets `autolabel_service.MULTILABEL_THRESHOLD` resolve and lets tests monkeypatch it.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py::test_run_autolabel_applies_multiple_labels_and_gates -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/python/main.py server/python/tests/test_multilabel_autolabel.py
+git commit -m "feat(autolabel): multi-select general autolabel with confidence gate"
+```
+
+---
+
+## Task 4: Confirm the split flow is unchanged
+
+**Files:**
+- Test: `server/python/tests/test_multilabel_autolabel.py`
+- Reference only (no change): `server/python/main.py:~1290-1345`
+
+- [ ] **Step 1: Write a guard test**
+
+Append to `server/python/tests/test_multilabel_autolabel.py`:
+
+```python
+import inspect
+
+
+def test_split_flow_calls_classify_batch_single_select():
+    """The label-split background function must NOT pass multi_select=True;
+    splits are a 1-of-2 partition and must keep exactly-one-label semantics."""
+    src = inspect.getsource(main)
+    # Find the split function body region and assert it does not opt into multi_select.
+    # The general flow is the only multi_select=True call site.
+    assert src.count("multi_select=True") == 1, (
+        "Exactly one call site (the general autolabel) should pass multi_select=True"
+    )
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd server/python && uv run pytest tests/test_multilabel_autolabel.py::test_split_flow_calls_classify_batch_single_select -v`
+Expected: PASS (only `_run_autolabel` opts in; the split flow uses the default).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/python/tests/test_multilabel_autolabel.py
+git commit -m "test(autolabel): guard split flow stays single-select"
+```
+
+---
+
+## Task 5: Full suite + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (Required environment section — add the new optional env var)
+
+- [ ] **Step 1: Run the entire backend test suite**
+
+Run: `cd server/python && uv run pytest`
+Expected: PASS (all tests, including the new file and `test_autolabel_fixes.py`).
+
+- [ ] **Step 2: Document the env var**
+
+In `CLAUDE.md`, find the `## Required environment` bullet list (it ends with the `EXT_DB_URL` line: `- Optional: \`EXT_DB_URL\` overrides the default PostgreSQL connection string`). Add a new optional bullet directly after it:
+
+```
+- Optional: `CHATSIGHT_MULTILABEL_THRESHOLD` — minimum AI confidence (0.0–1.0, default 0.5) for a multi-label auto-label to be persisted in queue mode. Lower it (e.g. 0.3) if auto-labeling is too sparse.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document CHATSIGHT_MULTILABEL_THRESHOLD"
+```
+
+---
+
+## Notes / risks
+
+- **Module reload in Task 1 tests:** `importlib.reload(autolabel_service)` re-runs the module, which reconstructs the Gemini `client`. This is fine in tests (a dummy key is set), but the two reload tests must restore the default at the end (the second test does). Keep these two tests self-contained; do not let them run after the `_run_autolabel` test in a way that leaves a reloaded module — they are ordered first in the file.
+- **`autolabel_service.MULTILABEL_THRESHOLD` is read at import.** Tests that need a specific threshold should `monkeypatch.setattr(autolabel_service, "MULTILABEL_THRESHOLD", X)` (as Task 3 does) rather than setting the env var, to avoid reload churn.
+- The split flow (`_run_label_split`) is intentionally untouched; Task 4 is a regression guard, not a behavior change.

--- a/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
+++ b/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
@@ -1,0 +1,118 @@
+# Week-scoped routes (user-study branch)
+
+**Date:** 2026-06-01
+**Branch:** `study/week-scoped-routes` (off `main`)
+**Status:** Design approved, pending spec review
+
+## Motivation
+
+For the upcoming user study we want each labeling interface scoped to a single
+week of DSC 10 (Winter 2026) coursework, so participants label a bounded,
+comparable slice of conversations. A secondary goal: when an instructor triggers
+**handoff** in single-label mode, Gemini should only classify the in-scope week,
+not the entire chatlog corpus — keeping auto-labeling fast during sessions.
+
+## Scope mapping
+
+Weeks come from the Winter 2026 schedule
+(<https://dsc-courses.github.io/dsc10-2026-wi/>), cross-checked against the
+repo's own `server/python/data/milestones/dsc10_wi26.json`:
+
+| Route   | Mode         | Week | Assignments       |
+|---------|--------------|------|-------------------|
+| `/queue`| multi-label  | 3    | Lab 1 + HW 1      |
+| `/run`  | single-label | 8    | Lab 5 + HW 5      |
+
+(Week 3 = "Histograms and Functions": Lab 1 due Jan 20, HW 1 due Jan 21.
+Week 8 = "Hypothesis and Permutation Testing": Lab 5 due Feb 23, HW 5 due Feb 25.)
+
+Quizzes and discussions are excluded — only graded notebook assignments (Lab/HW)
+map to `MessageCache.notebook` filenames.
+
+## Design
+
+### Key constraint
+
+The two routes need **different** scopes, and the message-selection code is
+shared: `queue_service.next_message_for_label` backs both single-label `/run`
+and multi-label onboarding-browse. So scope is keyed on **label mode**
+(multi → Week 3, single → Week 8), not a single global filter.
+
+### 1. New module `server/python/study_scope.py`
+
+Single source of truth. Reuses `assignment_service._canonical_name` so scope is
+expressed in the same vocabulary as the rest of the app, and does **not** depend
+on `AssignmentMapping` rows having been created by the instructor.
+
+```python
+QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
+RUN_SCOPE   = {"Lab 5", "Homework 5"}   # Week 8 — single-label
+
+def notebook_in_scope(notebook: str | None, names: set[str]) -> bool:
+    return notebook is not None and _canonical_name(notebook) in names
+
+def scope_for_mode(mode: str) -> set[str]:
+    return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
+
+def in_scope_keys(session, names) -> set[tuple[int, int]]:
+    """(chatlog_id, message_index) pairs whose notebook is in scope."""
+```
+
+`_canonical_name` maps `hw01.ipynb` → `"Homework 1"`, `lab5.ipynb` → `"Lab 5"`,
+etc. (`hw`/`homework` → `Homework`).
+
+### 2. Hard lock — server-side enforcement
+
+The lock is server-side and unconditional: any client-supplied `assignment_id`
+is ignored on the locked routes. Enforcement points:
+
+**Queue (Week 3):**
+- `/api/queue` — filter `all_cached` candidates to `notebook_in_scope(..., QUEUE_SCOPE)`.
+- `/api/queue/stats` and `/api/queue/position` — restrict `total`/`labeled`/`skipped`
+  denominators to in-scope keys so progress numbers match the bounded queue.
+
+**Run (Week 8):**
+- `queue_service.next_message_for_label` — filter `cache_rows` by the label's
+  mode-derived scope (single → `RUN_SCOPE`). Multi-mode callers
+  (onboarding-browse) get `QUEUE_SCOPE`.
+- `decision_service.compute_readiness` — `total_conversations` counts only
+  in-scope conversations, so the readiness denominator reflects Week 8.
+- `main._do_classification` — restrict the `pending` set to in-scope keys, so
+  the Gemini handoff classifies only Week 8 (the performance goal).
+
+### 3. Frontend
+
+Since the server now ignores `assignment_id` on these routes, the assignment
+picker becomes a no-op and should be hidden/disabled to avoid confusion:
+- `/run`: hide the assignment picker in `StripBar`.
+- `/queue`: hide the assignment picker if present.
+- Each page shows a small fixed-scope label, e.g. "Week 3 — Lab 1 & HW 1" /
+  "Week 8 — Lab 5 & HW 5".
+
+### 4. Tests
+
+Backend (`pytest`, in-memory SQLite):
+- `study_scope.notebook_in_scope` — Lab 1 / HW 1 / Homework 1 notebooks match
+  `QUEUE_SCOPE`; Lab 5 matches `RUN_SCOPE`; Lab 2 / unmapped match neither.
+- `/api/queue` returns only Week-3 messages; a seeded Week-5 message never appears.
+- single-label `next_message_for_label` (single mode) returns only Week-8 messages.
+- `_do_classification` pending set excludes out-of-scope messages (Gemini call
+  mocked).
+
+## Out of scope / non-goals
+
+- No DB schema change; no new migration. Scope is computed from existing
+  `MessageCache.notebook`.
+- No change to the labeling pipeline, AI prompt construction, or analysis pages.
+- Week numbers are hardcoded constants for this study branch (not configurable
+  via env/UI) — intentional, since the study fixes them.
+- This branch is not intended to merge to `main` as-is; it is a study fixture.
+
+## Success criteria
+
+- `/queue` surfaces only Week-3 (Lab 1 / HW 1) messages; stats/position reflect
+  that bounded set.
+- `/run` surfaces only Week-8 (Lab 5 / HW 5) messages; readiness denominator and
+  Gemini handoff classification are both bounded to Week 8.
+- Assignment pickers no longer present a choice on either route.
+- Backend tests pass.

--- a/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
+++ b/docs/superpowers/specs/2026-06-01-week-scoped-routes-design.md
@@ -104,8 +104,11 @@ Backend (`pytest`, in-memory SQLite):
 - No DB schema change; no new migration. Scope is computed from existing
   `MessageCache.notebook`.
 - No change to the labeling pipeline, AI prompt construction, or analysis pages.
-- Week numbers are hardcoded constants for this study branch (not configurable
-  via env/UI) — intentional, since the study fixes them.
+- Week→assignment mappings are hardcoded constants for this study branch (not
+  configurable via UI) — intentional, since the study fixes them. The lock as a
+  whole is gated by `CHATSIGHT_STUDY_LOCK` (default ON); it exists only so the
+  legacy test suite (which seeds unscoped data) can disable it via
+  `conftest.py`. Production/study runs leave it ON.
 - This branch is not intended to merge to `main` as-is; it is a study fixture.
 
 ## Success criteria

--- a/docs/superpowers/specs/2026-06-03-label-suggestions-design.md
+++ b/docs/superpowers/specs/2026-06-03-label-suggestions-design.md
@@ -1,0 +1,136 @@
+# Label Name Suggestions — Design Spec
+
+**Date:** 2026-06-03  
+**Scope:** Single-label mode only (`/run`). Multi-label queue is explicitly out of scope — do not touch `NewLabelPopover.tsx`, `LabelsPage.tsx`, or any queue-mode component.
+
+---
+
+## Problem
+
+Browser autofill on label name inputs was injecting contact names from participants' computers during user studies. `autoComplete="off"` is not reliably respected by Chrome/Safari. The fix is a custom dropdown that replaces browser suggestions entirely — and since we're building one, it should surface actually useful suggestions: concept candidate names discovered from the chatlog data, filtered to exclude labels that are semantically redundant with ones the instructor already has.
+
+---
+
+## Filtering requirement
+
+Filtering must work at the synonym level, not just string matching. If "confusion" exists as a label, the dropdown must not suggest "Confusion", "confused", "puzzled", "unsure", or other near-synonyms. Simple case-insensitive string comparison is not sufficient.
+
+---
+
+## Architecture
+
+### Backend: `GET /api/concepts/name-suggestions`
+
+New endpoint in `main.py`. Logic:
+
+1. Fetch all `ConceptCandidate` rows where `status == "pending"` from SQLite
+2. Fetch all existing label names from `LabelDefinition` (all rows, both `mode='multi'` and `mode='single'` — they share one table)
+3. Batch-embed both sets of names using `gemini-embedding-001`
+4. For each candidate, compute cosine similarity against every existing label name
+5. Drop any candidate where `max_similarity > SUGGESTION_SIMILARITY_THRESHOLD` (constant, default `0.75`)
+6. Return `[{ name: str, description: str }]`
+
+The threshold `0.75` is where true synonyms converge in embedding space. Expose as a backend constant (`SUGGESTION_SIMILARITY_THRESHOLD`) so it can be tuned after testing.
+
+If no concept candidates exist, or if the Gemini embedding call fails, return an empty list — do not error.
+
+### Frontend: `useLabelSuggestions` hook
+
+**File:** `src/hooks/useLabelSuggestions.ts`
+
+- Calls `GET /api/concepts/name-suggestions` once on mount
+- Returns `{ suggestions: { name: string; description: string }[], loading: boolean }`
+- On error: sets `suggestions = []`, does not throw or surface to UI
+- No polling or refetching within a session
+
+### Frontend: `LabelNameInput` component
+
+**File:** `src/components/run/LabelNameInput.tsx`  
+(Placed in `run/` since it is single-label only.)
+
+Props:
+```ts
+interface LabelNameInputProps {
+  value: string
+  onChange: (value: string) => void
+  onCommit?: () => void
+  suggestions: { name: string; description: string }[]
+  placeholder?: string
+  readOnly?: boolean
+  className?: string
+  // forwarded: autoFocus, onBlur, onKeyDown, data-*, etc.
+}
+```
+
+Behavior:
+- `autoComplete="off"` on the underlying `<input>`
+- Dropdown appears when: input is focused AND typed value is non-empty AND at least one suggestion contains the typed string (case-insensitive)
+- Client-side filter: suggestions where `name.toLowerCase().includes(typed.toLowerCase())`
+- Dropdown does not appear if typed value is an exact case-insensitive match to a suggestion (user already has it)
+- ↑↓ keys navigate highlighted row; Enter selects highlighted row (calls `onChange` with the name, then `onCommit`); Escape closes dropdown
+- Clicking a suggestion fills the input and calls `onCommit`
+- Each row: suggestion name (bold, `text-on-canvas`) + description (muted, truncated to one line)
+- If `suggestions` is empty, component behaves as a plain `<input>` — no dropdown ever renders
+
+### Wiring
+
+`useLabelSuggestions` is called in `LabelRunPage.tsx`. The resulting `suggestions` array is passed as a prop down to:
+
+- `StripBar.tsx` — replaces the bare `<input>` in the label name slot with `LabelNameInput`
+- `NoteLabelPopover.tsx` — replaces the bare `<input>` for the name field with `LabelNameInput`
+
+**Do not wire into any multi-label component.**
+
+---
+
+## Data flow
+
+```
+LabelRunPage mounts
+  → useLabelSuggestions fires once
+  → GET /api/concepts/name-suggestions
+      → fetch pending ConceptCandidates
+      → fetch existing label names (single + multi)
+      → embed both with gemini-embedding-001
+      → cosine filter at 0.75 threshold
+      → return [{name, description}]
+  → suggestions stored in hook state
+  → passed as prop to StripBar + NoteLabelPopover
+  → LabelNameInput renders dropdown on focus+type
+```
+
+---
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| No concept candidates | Returns `[]`, input is a plain text field |
+| Gemini embedding call fails | Returns `[]`, input is a plain text field |
+| All candidates filtered out | Returns `[]`, input is a plain text field |
+| Frontend fetch error | `suggestions = []`, no error shown |
+
+The input must never be broken or degraded by a failed suggestion fetch.
+
+---
+
+## Testing
+
+**Backend:**
+- Unit test `cosine_similarity` filter: confirm "confusion" (existing) suppresses "confused", "puzzled", "unsure" as candidates; confirm unrelated candidates (e.g., "code syntax help") pass through
+- Mock `gemini-embedding-001` call — return pre-computed vectors
+- Test empty-candidate and Gemini-error paths return `[]` gracefully
+
+**Frontend:**
+- `LabelNameInput` is pure props-driven UI — no fetch logic to test separately
+- Verify dropdown appears/hides at correct conditions via existing vitest + RTL setup
+- `useLabelSuggestions` is a thin fetch wrapper; covered by integration if needed
+
+---
+
+## Out of scope
+
+- Multi-label queue (`NewLabelPopover`, `QueuePage`, `LabelsPage`) — do not touch
+- The label split dialog in `LabelsPage.tsx` — intentionally shows existing labels, leave as-is
+- Suggestion ranking or sorting beyond the existing candidate order
+- Re-fetching suggestions after a new label is created within the session

--- a/docs/superpowers/specs/2026-06-08-multilabel-autolabel-design.md
+++ b/docs/superpowers/specs/2026-06-08-multilabel-autolabel-design.md
@@ -29,6 +29,18 @@ The `classify_messages` tool returns a **flat** `classifications` array of
 `(label_id, chatlog_id, message_index)`. So the data structures already support
 multiple rows per message index — only the prompt prevents it.
 
+**Important constraint:** `classify_batch` is shared by two flows:
+- `_run_autolabel` — general multi-label auto-labeling (the target of this change).
+- `_run_label_split` (`main.py:~1290`) — splits one label into two sub-labels by
+  redistributing each orphaned message into **exactly one** of two new buckets,
+  then deletes the original label. This is a 1-of-2 **partition**, not a
+  multi-label assignment. Making it multi-select would let a message land in
+  both or neither bucket — and "neither" silently drops the message when the
+  original label is deleted.
+
+Therefore the new behavior must be **opt-in per call**, leaving the split flow
+on today's exactly-one-label semantics.
+
 ## Decisions
 
 | Decision | Choice |
@@ -48,35 +60,44 @@ Rejected alternatives:
 
 ## Design
 
-### 1. `autolabel_service.py` — allow 0..N labels per message
+### 1. `autolabel_service.py` — opt-in multi-select
 
-- **System instruction** (line ~53): replace *"Assign exactly one label to each
-  message"* with an instruction to assign **every** label that applies, emitting
-  a **separate** entry per applicable label for the same `index`, and to emit
-  **no** entry for a message that fits no label.
-- **Tool description** (`classify_messages`, line ~26) and the `classifications`
-  item description: clarify that the same `index` may appear multiple times (once
-  per applicable label) or be absent entirely.
-- **`build_prompt`** closing instruction (lines ~88-91): mirror the
-  "all that apply / none is allowed" wording.
+- Add a `multi_select: bool = False` parameter to both `build_prompt` and
+  `classify_batch`. Default `False` preserves today's exactly-one behavior for
+  the split flow.
+- Provide **two** system-instruction strings (single vs. multi) and select the
+  matching `GenerateContentConfig` inside `classify_batch` based on
+  `multi_select`. The multi variant instructs the model to assign **every**
+  label that applies, emitting a **separate** entry per applicable label for the
+  same `index`, and to emit **no** entry for a message that fits no label.
+- **Tool description** (`classify_messages`) and the `classifications` item
+  description: clarify that the same `index` may appear multiple times (once per
+  applicable label) or be absent entirely. (Shared by both modes; the per-call
+  system instruction governs how many labels are emitted.)
+- **`build_prompt`** closing instruction: when `multi_select`, mirror the
+  "all that apply / none is allowed" wording; otherwise keep the existing
+  one-label wording.
 - **`classify_batch`** return shape is **unchanged**: still a flat
   `list[{index, label, confidence}]`, now possibly with repeated or missing
-  indices.
+  indices when `multi_select=True`.
 - Add module-level constant:
   `MULTILABEL_THRESHOLD = float(os.environ.get("CHATSIGHT_MULTILABEL_THRESHOLD", "0.5"))`.
 
 ### 2. Confidence threshold gate (consumer side)
 
-Applied in `main.py` at **both** auto-label consumer sites:
-- `_run_autolabel` (line ~1364) — main multi-label flow.
-- The split-flow autolabel consumer (line ~1290).
+Applied in `main.py` **only** at the general flow `_run_autolabel`
+(line ~1364), which now calls `classify_batch(..., multi_select=True)`.
 
 After clamping `conf` to `[0.0, 1.0]`:
 - If `conf` is `None` / non-numeric, treat as **below** threshold → do not persist.
-- If `conf < MULTILABEL_THRESHOLD`, do not persist.
+- If `conf < autolabel_service.MULTILABEL_THRESHOLD`, do not persist.
 - Otherwise persist the `LabelApplication` (with existing dedup check).
 
 A label only lands when the model is explicitly confident enough.
+
+The split-flow consumer (`main.py:~1290`) calls `classify_batch` with the
+default `multi_select=False` and **does not** apply the gate — it keeps today's
+exactly-one-label partition behavior, fully unchanged.
 
 ### 3. Zero-label outcome
 
@@ -100,7 +121,8 @@ reporting is unaffected.
     `LabelApplication` rows written for that message.
   - a sub-threshold entry → assert it is **not** persisted.
   - an `index` with no entries → assert the message stays unlabeled.
-- Verify both consumer sites (`_run_autolabel` and the split flow) apply the gate.
+- Verify the split flow (`classify_batch` with default `multi_select=False`)
+  still produces exactly one label per message and does **not** apply the gate.
 
 ## Trade-offs / risks
 

--- a/docs/superpowers/specs/2026-06-08-multilabel-autolabel-design.md
+++ b/docs/superpowers/specs/2026-06-08-multilabel-autolabel-design.md
@@ -1,0 +1,109 @@
+# Multi-label Auto-labeling Design
+
+**Date:** 2026-06-08
+**Status:** Approved (pending implementation plan)
+**Branch:** study/week-scoped-routes
+
+## Problem
+
+In multi-label queue mode, a human instructor can apply **multiple** labels to a
+single student message (toggle several labels on, then advance). But when the
+instructor hands off to Gemini's batch auto-labeler, each message receives
+**exactly one** label. The auto-label output is therefore strictly less
+expressive than human labeling in the same mode.
+
+Auto-label should match the human capability: a message can carry zero, one, or
+many AI labels.
+
+## Root cause
+
+The single-label-per-message behavior is not a schema limitation — it is forced
+by the prompt. In `server/python/autolabel_service.py`:
+
+- The system instruction says *"Assign exactly one label to each message."*
+- `build_prompt` reinforces one-label-per-index.
+
+The `classify_messages` tool returns a **flat** `classifications` array of
+`{index, label, confidence}`. The consumer loops in `main.py` already write one
+`LabelApplication` per `(label, message)` and dedup per
+`(label_id, chatlog_id, message_index)`. So the data structures already support
+multiple rows per message index — only the prompt prevents it.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| How labels are chosen | Multi-select in one batch call, each label carrying a confidence; only persist labels above a threshold |
+| Zero labels allowed? | Yes — a message that fits no label (above threshold) stays unlabeled |
+| Threshold source | Global env var `CHATSIGHT_MULTILABEL_THRESHOLD`, default `0.5` |
+
+Rejected alternatives:
+- **Binary per label** (N independent yes/no passes): most accurate but N× API
+  cost; rejected for cost.
+- **Per-label threshold override + env fallback**: more flexible but needs a
+  model column + migration; rejected as unnecessary for now (YAGNI).
+- **Hardcoded constant**: not tunable without redeploy; rejected.
+- **Always ≥1 label (best-fit fallback)**: rejected — conflicts with faithful
+  multi-label semantics where some messages genuinely fit no label.
+
+## Design
+
+### 1. `autolabel_service.py` — allow 0..N labels per message
+
+- **System instruction** (line ~53): replace *"Assign exactly one label to each
+  message"* with an instruction to assign **every** label that applies, emitting
+  a **separate** entry per applicable label for the same `index`, and to emit
+  **no** entry for a message that fits no label.
+- **Tool description** (`classify_messages`, line ~26) and the `classifications`
+  item description: clarify that the same `index` may appear multiple times (once
+  per applicable label) or be absent entirely.
+- **`build_prompt`** closing instruction (lines ~88-91): mirror the
+  "all that apply / none is allowed" wording.
+- **`classify_batch`** return shape is **unchanged**: still a flat
+  `list[{index, label, confidence}]`, now possibly with repeated or missing
+  indices.
+- Add module-level constant:
+  `MULTILABEL_THRESHOLD = float(os.environ.get("CHATSIGHT_MULTILABEL_THRESHOLD", "0.5"))`.
+
+### 2. Confidence threshold gate (consumer side)
+
+Applied in `main.py` at **both** auto-label consumer sites:
+- `_run_autolabel` (line ~1364) — main multi-label flow.
+- The split-flow autolabel consumer (line ~1290).
+
+After clamping `conf` to `[0.0, 1.0]`:
+- If `conf` is `None` / non-numeric, treat as **below** threshold → do not persist.
+- If `conf < MULTILABEL_THRESHOLD`, do not persist.
+- Otherwise persist the `LabelApplication` (with existing dedup check).
+
+A label only lands when the model is explicitly confident enough.
+
+### 3. Zero-label outcome
+
+Falls out naturally: a message with no surviving entries gets no
+`LabelApplication` and stays unlabeled. No best-fit fallback.
+`_autolabel_status["processed"]` continues advancing per batch, so progress
+reporting is unaffected.
+
+## What does NOT change
+
+- DB schema, `models.py`, migrations — none.
+- The multi-write guard (`_assert_multi_write`), Week 3 scope filtering
+  (`QUEUE_SCOPE`), dedup logic, batch size (30), and stop-flag handling.
+- Single-label `/run` mode and `binary_autolabel_service.py`.
+- `classify_batch`'s public return type.
+
+## Testing
+
+- Mock Gemini so `classify_batch` returns, for one batch:
+  - multiple entries for a single `index` (above threshold) → assert multiple
+    `LabelApplication` rows written for that message.
+  - a sub-threshold entry → assert it is **not** persisted.
+  - an `index` with no entries → assert the message stays unlabeled.
+- Verify both consumer sites (`_run_autolabel` and the split flow) apply the gate.
+
+## Trade-offs / risks
+
+- With a `0.5` default and "zero allowed", cautious model output may under-label
+  early runs. `CHATSIGHT_MULTILABEL_THRESHOLD` is the tuning knob — lower toward
+  `0.3` if coverage is too sparse.

--- a/server/python/analysis_single_label.py
+++ b/server/python/analysis_single_label.py
@@ -29,6 +29,7 @@ except ImportError:  # pragma: no cover
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
+import study_scope
 from database import get_session
 from models import AssignmentMapping, LabelApplication, LabelDefinition, MessageCache
 
@@ -442,8 +443,12 @@ def get_run_detail(run_id: int, session: Session = Depends(get_session)) -> dict
     # "Touched by AI" = pending AI rows + reviewed-human rows with a snapshot.
     ai_touched: set[tuple[int, int]] = {(a.chatlog_id, a.message_index) for a in ais}
     ai_touched.update((a.chatlog_id, a.message_index) for a in reviewed)
-    total_msgs = session.exec(select(MessageCache)).all()
-    total = len(total_msgs)
+    # Denominator is the in-scope study sample (Week 8 for single-label runs),
+    # matching the scope `_do_classification` classifies over. Counting the whole
+    # MessageCache understates coverage to a tiny fraction. When the study lock is
+    # off, `in_scope_keys` returns every cached message, preserving prior behavior.
+    in_scope = study_scope.in_scope_keys(session, study_scope.scope_for_mode(ld.mode))
+    total = len(in_scope)
     ai_coverage = {
         "covered": len(ai_touched),
         "total": total,

--- a/server/python/autolabel_service.py
+++ b/server/python/autolabel_service.py
@@ -34,7 +34,7 @@ TOOL = types.Tool(function_declarations=[
                     "items": {
                         "type": "object",
                         "properties": {
-                            "index": {"type": "integer", "description": "Index in the input messages array"},
+                            "index": {"type": "integer", "description": "Index in the input messages array. The same index may appear in multiple entries when several labels apply."},
                             "label": {"type": "string", "description": "The label name to assign"},
                             "confidence": {"type": "number", "description": "Your confidence in this classification, 0.0 to 1.0"},
                         },
@@ -88,6 +88,7 @@ def build_prompt(
     label_definitions: List[Dict[str, Any]],
     examples_by_label: Dict[str, List[str]],
     messages: List[Dict[str, Any]],
+    multi_select: bool = False,
 ) -> str:
     """Build the classification prompt with definitions, examples, and messages."""
     parts = ["## Label Definitions\n"]
@@ -106,10 +107,18 @@ def build_prompt(
             ctx += f" [preceding AI: ...{msg['context_before'][-100:]}]"
         parts.append(f"{i}. \"{msg['message_text']}\"{ctx}")
     parts.append("")
-    parts.append(
-        "Call `classify_messages` with the index and label for each message. "
-        "Use label names exactly as defined above."
-    )
+    if multi_select:
+        parts.append(
+            "Call `classify_messages` with one entry per (message, applicable label). "
+            "Assign all that apply: a message may get several labels, one, or none. "
+            "Reuse the same index for each label that applies to that message; omit "
+            "messages that match no label. Use label names exactly as defined above."
+        )
+    else:
+        parts.append(
+            "Call `classify_messages` with the index and label for each message. "
+            "Use label names exactly as defined above."
+        )
     return "\n".join(parts)
 
 
@@ -117,14 +126,19 @@ def classify_batch(
     label_definitions: List[Dict[str, Any]],
     examples_by_label: Dict[str, List[str]],
     messages: List[Dict[str, Any]],
+    multi_select: bool = False,
 ) -> List[Dict[str, Any]]:
-    """Classify a batch of messages. Returns list of {index, label}."""
-    prompt = build_prompt(label_definitions, examples_by_label, messages)
+    """Classify a batch of messages. Returns list of {index, label, confidence}.
+
+    When multi_select is True the model may return multiple entries per index
+    (one per applicable label) or none; otherwise exactly one label per message.
+    """
+    prompt = build_prompt(label_definitions, examples_by_label, messages, multi_select)
 
     response = client.models.generate_content(
         model="gemini-2.5-flash",
         contents=prompt,
-        config=CONFIG,
+        config=MULTI_SELECT_CONFIG if multi_select else CONFIG,
     )
 
     if (

--- a/server/python/autolabel_service.py
+++ b/server/python/autolabel_service.py
@@ -14,6 +14,8 @@ log = logging.getLogger(__name__)
 
 client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
 
+MULTILABEL_THRESHOLD = float(os.environ.get("CHATSIGHT_MULTILABEL_THRESHOLD", "0.5"))
+
 
 class ClassifyToolMissing(RuntimeError):
     """Gemini did not return the classify_messages tool call.
@@ -45,22 +47,41 @@ TOOL = types.Tool(function_declarations=[
     )
 ])
 
-CONFIG = types.GenerateContentConfig(
-    system_instruction=(
-        "You are classifying student messages from AI tutoring conversations. "
-        "You will be given label definitions with example messages, then a batch "
-        "of unlabeled messages to classify. Assign exactly one label to each message. "
-        "Use the label names exactly as provided. Rate your confidence from 0.0 (very uncertain) to 1.0 (very certain)."
-    ),
-    temperature=0,
-    tools=[TOOL],
-    tool_config=types.ToolConfig(
-        function_calling_config=types.FunctionCallingConfig(
-            mode="ANY",
-            allowed_function_names=["classify_messages"],
-        )
-    ),
+_SINGLE_SELECT_INSTRUCTION = (
+    "You are classifying student messages from AI tutoring conversations. "
+    "You will be given label definitions with example messages, then a batch "
+    "of unlabeled messages to classify. Assign exactly one label to each message. "
+    "Use the label names exactly as provided. Rate your confidence from 0.0 (very uncertain) to 1.0 (very certain)."
 )
+
+_MULTI_SELECT_INSTRUCTION = (
+    "You are classifying student messages from AI tutoring conversations. "
+    "You will be given label definitions with example messages, then a batch "
+    "of unlabeled messages to classify. Assign EVERY label that applies to a "
+    "message — a message may match several labels, exactly one, or none. Emit a "
+    "SEPARATE classification entry for each applicable label, reusing the same "
+    "index for every label that applies to that message. If a message matches no "
+    "label, emit no entry for it. "
+    "Use the label names exactly as provided. Rate your confidence from 0.0 (very uncertain) to 1.0 (very certain)."
+)
+
+
+def _make_config(system_instruction: str) -> types.GenerateContentConfig:
+    return types.GenerateContentConfig(
+        system_instruction=system_instruction,
+        temperature=0,
+        tools=[TOOL],
+        tool_config=types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(
+                mode="ANY",
+                allowed_function_names=["classify_messages"],
+            )
+        ),
+    )
+
+
+CONFIG = _make_config(_SINGLE_SELECT_INSTRUCTION)            # default / split flow
+MULTI_SELECT_CONFIG = _make_config(_MULTI_SELECT_INSTRUCTION)  # general auto-label
 
 
 def build_prompt(

--- a/server/python/autolabel_service.py
+++ b/server/python/autolabel_service.py
@@ -101,7 +101,7 @@ def classify_batch(
     prompt = build_prompt(label_definitions, examples_by_label, messages)
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=CONFIG,
     )
@@ -136,7 +136,7 @@ def summarize_message(message_text: str) -> str:
     )
     
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=message_text,
         config=config,
     )

--- a/server/python/autolabel_service.py
+++ b/server/python/autolabel_service.py
@@ -106,6 +106,21 @@ def classify_batch(
         config=CONFIG,
     )
 
+    if (
+        not response.candidates
+        or not response.candidates[0].content
+        or not response.candidates[0].content.parts
+    ):
+        text_reply = getattr(response, "text", None)
+        log.warning(
+            "classify_batch: empty or blocked candidates; n_messages=%d text=%r",
+            len(messages),
+            (text_reply or "")[:200],
+        )
+        raise ClassifyToolMissing(
+            f"Gemini returned no candidates (n={len(messages)})"
+        )
+
     for part in response.candidates[0].content.parts:
         if part.function_call and part.function_call.name == "classify_messages":
             args = dict(part.function_call.args)

--- a/server/python/binary_autolabel_service.py
+++ b/server/python/binary_autolabel_service.py
@@ -19,7 +19,7 @@ client = genai.Client(
     http_options=types.HttpOptions(timeout=GEMINI_REQUEST_TIMEOUT_MS),
 )
 
-CLASSIFY_MODEL = "gemini-2.0-flash"
+CLASSIFY_MODEL = "gemini-2.5-flash"
 
 CLASSIFY_SYSTEM_INSTRUCTION = (
     "You are classifying student messages from AI-tutoring conversations as yes/no for "
@@ -128,7 +128,7 @@ def classify_binary(
         return []
     prompt = _build_classify_prompt(label_name, label_description, yes_examples, no_examples, messages, guidance)
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=CLASSIFY_CONFIG,
     )
@@ -248,7 +248,7 @@ def summarize_batch(
             parts.append(f"- {m}")
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents="\n".join(parts),
         config=SUMMARY_CONFIG,
     )

--- a/server/python/concept_service.py
+++ b/server/python/concept_service.py
@@ -294,7 +294,7 @@ def discover_concepts(
     # 5. Call Gemini
     prompt = _build_discovery_prompt(samples_by_cluster, existing, rejected)
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=SUGGEST_CONFIG,
     )

--- a/server/python/database.py
+++ b/server/python/database.py
@@ -99,6 +99,28 @@ def _migrate_label_definition(conn, inspect, text):
         conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN onboarding_seed_chatlog_id INTEGER"))
     if "onboarding_seed_message_index" not in cols:
         conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN onboarding_seed_message_index INTEGER"))
+    if "handed_off_at" not in cols:
+        conn.execute(text("ALTER TABLE labeldefinition ADD COLUMN handed_off_at DATETIME"))
+        _backfill_handed_off_at(conn, text)
+
+
+def _backfill_handed_off_at(conn, text):
+    """One-time: populate handed_off_at for already-handed-off single labels using
+    the most-recent AI-applied row's created_at as a proxy for when the handoff
+    ran, falling back to the label's own created_at when no AI rows exist. Only
+    touches NULL rows in a handed-off phase, so it's safe to re-run."""
+    conn.execute(text(
+        """
+        UPDATE labeldefinition
+        SET handed_off_at = COALESCE(
+            (SELECT MAX(la.created_at) FROM labelapplication la
+             WHERE la.label_id = labeldefinition.id AND la.applied_by = 'ai'),
+            created_at)
+        WHERE mode = 'single'
+          AND handed_off_at IS NULL
+          AND phase IN ('classifying', 'handed_off', 'reviewing', 'complete', 'failed')
+        """
+    ))
 
 
 def _migrate_onboarding_starter_cache(conn, inspect, text):

--- a/server/python/decision_service.py
+++ b/server/python/decision_service.py
@@ -4,6 +4,8 @@ from typing import Optional, Tuple
 
 from sqlmodel import Session, select
 
+import study_scope
+
 from models import (
     ConversationCursor,
     LabelApplication,
@@ -146,10 +148,11 @@ def compute_readiness(session: Session, label_id: int) -> dict:
 
     walked = len({c for _, c in rows})
 
-    total_convs = session.exec(
-        select(MessageCache.chatlog_id).distinct()
-    ).all()
-    total_convs_count = len(total_convs)
+    # Study lock: single-label runs are Week 8 — count only in-scope convs.
+    label = session.get(LabelDefinition, label_id)
+    scope = study_scope.scope_for_mode(label.mode if label else "single")
+    in_scope = study_scope.in_scope_keys(session, scope)
+    total_convs_count = len({cid for cid, _ in in_scope})
 
     if yes == 0 or no == 0:
         tier = "gray"

--- a/server/python/definition_service.py
+++ b/server/python/definition_service.py
@@ -31,7 +31,7 @@ An example is 'Responds to AI question or message'. It does not restate any of t
         prompt += f"\n\nAdditional guidance from the instructor: {guidance}\n\nRevise the definition to incorporate this guidance while remaining grounded in the examples above."
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=types.GenerateContentConfig(temperature=0),
     )
@@ -59,7 +59,7 @@ The following student messages have been labeled "{label_name}" by human instruc
 Which single message best exemplifies the description above? It should be the message that most explicitly shows this description. If there are messages that are equally related the description, prioritize the shorter message. Reply with only the number of that message (e.g. "3"). Nothing else."""
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=prompt,
         config=types.GenerateContentConfig(temperature=0),
     )

--- a/server/python/explore_service.py
+++ b/server/python/explore_service.py
@@ -603,7 +603,7 @@ def _summarize_conversation_gemini(
     for i, t in enumerate(student_texts[:12]):
         parts.append(f"{i + 1}. {t[:500]}")
     response = _client_get().models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents="\n".join(parts),
         config=_SUMMARY_CONFIG,
     )

--- a/server/python/label_service.py
+++ b/server/python/label_service.py
@@ -64,7 +64,7 @@ For each student-AI interaction turn, identify:
 Call the `generate_labels` tool with a JSON array of label objects. Label every meaningful interaction turn (typically every 1-3 message pairs)."""
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=user_message,
         config=GENERATE_CONFIG,
     )

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3736,6 +3736,24 @@ def post_undo(
     return _decide_response(db, label_id, assignment_id)
 
 
+@app.get("/api/single-labels/{label_id}/decisions")
+def get_human_decisions(label_id: int, db: Session = Depends(get_session)):
+    """Return all human decisions for a label in chronological order.
+    Used by the frontend to seed the undo history after a page reload."""
+    label = db.get(LabelDefinition, label_id)
+    if not label or label.mode != "single":
+        raise HTTPException(status_code=404, detail="Single-label not found")
+    rows = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .where(
+            LabelApplication.label_id == label_id,
+            LabelApplication.applied_by == "human",
+        )
+        .order_by(LabelApplication.created_at.asc())
+    ).all()
+    return [{"chatlog_id": cid, "message_index": midx} for cid, midx in rows]
+
+
 @app.get("/api/single-labels/{label_id}/readiness", response_model=ReadinessResponse)
 def get_readiness(label_id: int, db: Session = Depends(get_session)):
     label = db.get(LabelDefinition, label_id)

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3752,7 +3752,14 @@ def _do_classification(
     cached = db.exec(
         select(MessageCache.chatlog_id, MessageCache.message_index, MessageCache.message_text)
     ).all()
-    pending = [(c, i, t) for (c, i, t) in cached if (c, i) not in decided_keys]
+    # Study lock: only classify the week this label's mode is scoped to
+    # (single -> Week 8). Keeps Gemini handoff bounded and fast.
+    scope = study_scope.scope_for_mode(label.mode)
+    in_scope = study_scope.in_scope_keys(db, scope)
+    pending = [
+        (c, i, t) for (c, i, t) in cached
+        if (c, i) not in decided_keys and (c, i) in in_scope
+    ]
 
     if sample_size is not None:
         pending = random.sample(pending, min(sample_size, len(pending)))

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1370,10 +1370,12 @@ def _run_autolabel():
 
     try:
         with Session(engine) as db:
-            # Multi-label flow: only consider mode='multi' labels here so the
-            # AI batch never writes value-bearing rows to single-mode labels.
+            # Multi-label flow: only consider active (non-archived) mode='multi'
+            # labels so the AI batch never writes to archived or single-mode labels.
             labels = db.exec(
-                select(LabelDefinition).where(LabelDefinition.mode == "multi")
+                select(LabelDefinition)
+                .where(LabelDefinition.mode == "multi")
+                .where(LabelDefinition.archived_at == None)  # noqa: E711
             ).all()
             if not labels:
                 _autolabel_status = {
@@ -1389,7 +1391,8 @@ def _run_autolabel():
                 {"name": l.name, "description": l.description} for l in labels
             ]
 
-            # Get human-labeled examples for each label
+            # Get human-labeled examples for each label — use MessageCache
+            # (populated at startup) to avoid slow external-DB round-trips.
             examples_by_label: dict[str, list[str]] = {}
             for label in labels:
                 apps = db.exec(
@@ -1399,32 +1402,14 @@ def _run_autolabel():
                         _is_multi_application(),
                     )
                 ).all()
-                # We need message text — fetch from external DB
-                if apps:
-                    pairs = [(a.chatlog_id, a.message_index) for a in apps[:10]]
-                    with ext_engine.connect() as conn:
-                        for cid, midx in pairs:
-                            row = conn.execute(
-                                text("""
-                                WITH student AS (
-                                    SELECT payload->>'question' AS msg,
-                                           (ROW_NUMBER() OVER (
-                                               PARTITION BY payload->>'conversation_id' ORDER BY id
-                                           )) - 1 AS idx
-                                    FROM events
-                                    WHERE event_type = 'tutor_query'
-                                      AND payload->>'conversation_id' = (
-                                          SELECT payload->>'conversation_id' FROM events WHERE id = :cid LIMIT 1
-                                      )
-                                )
-                                SELECT msg FROM student WHERE idx = :midx
-                            """),
-                                {"cid": cid, "midx": midx},
-                            ).first()
-                            if row and row[0]:
-                                examples_by_label.setdefault(label.name, []).append(
-                                    row[0]
-                                )
+                for a in apps[:10]:
+                    cached_text = db.exec(
+                        select(MessageCache.message_text)
+                        .where(MessageCache.chatlog_id == a.chatlog_id)
+                        .where(MessageCache.message_index == a.message_index)
+                    ).first()
+                    if cached_text:
+                        examples_by_label.setdefault(label.name, []).append(cached_text)
 
             # Get unlabeled messages (multi-label scope — single-label /run
             # decisions on the same message must not exclude it from the
@@ -1439,43 +1424,33 @@ def _run_autolabel():
             }
             excluded = labeled_set | skipped_set
 
-        # Fetch all student messages from external DB
-        with ext_engine.connect() as conn:
-            rows = (
-                conn.execute(
-                    text("""
-                WITH student AS (
-                    SELECT id,
-                           payload->>'conversation_id' AS conv_id,
-                           payload->>'question' AS message_text,
-                           (ROW_NUMBER() OVER (
-                               PARTITION BY payload->>'conversation_id' ORDER BY id
-                           )) - 1 AS message_index
-                    FROM events WHERE event_type = 'tutor_query'
-                ),
-                chatlog_ids AS (
-                    SELECT payload->>'conversation_id' AS conv_id, MIN(id) AS chatlog_id
-                    FROM events
-                    WHERE event_type IN ('tutor_query', 'tutor_response')
-                    GROUP BY payload->>'conversation_id'
+            # Fetch candidates from MessageCache (already populated at startup
+            # from the external DB). Filter to Week 3 scope (QUEUE_SCOPE) so
+            # autolabel stays within the study boundary — same as the live queue.
+            cache_rows = db.exec(
+                select(
+                    MessageCache.chatlog_id,
+                    MessageCache.message_index,
+                    MessageCache.message_text,
+                    MessageCache.context_before,
+                    MessageCache.notebook,
                 )
-                SELECT s.message_text, s.message_index, ci.chatlog_id,
-                    (SELECT e2.payload->>'response' FROM events e2
-                     WHERE e2.payload->>'conversation_id' = s.conv_id
-                       AND e2.event_type = 'tutor_response' AND e2.id < s.id
-                     ORDER BY e2.id DESC LIMIT 1) AS context_before
-                FROM student s
-                JOIN chatlog_ids ci ON s.conv_id = ci.conv_id
-            """)
-                )
-                .mappings()
-                .all()
-            )
+            ).all()
+
+        in_scope_rows = [
+            row for row in cache_rows
+            if study_scope.notebook_in_scope(row[4], study_scope.QUEUE_SCOPE)
+        ]
 
         unlabeled = [
-            dict(r)
-            for r in rows
-            if (r["chatlog_id"], r["message_index"]) not in excluded
+            {
+                "chatlog_id": row[0],
+                "message_index": row[1],
+                "message_text": row[2],
+                "context_before": row[3],
+            }
+            for row in in_scope_rows
+            if (row[0], row[1]) not in excluded
         ]
         _autolabel_status["total"] = len(unlabeled)
 

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2086,21 +2086,37 @@ def get_candidates(db: Session = Depends(get_session)):
 
 @app.get("/api/concepts/name-suggestions")
 def get_name_suggestions(db: Session = Depends(get_session)):
-    """Return pending concept candidates filtered to exclude semantic duplicates of existing labels."""
+    """Return label name suggestions filtered to exclude semantic duplicates of existing labels.
+
+    Primary source: pending concept candidates (populated by the Discover flow).
+    Fallback: generate suggestions on-demand from a sample of cached student messages.
+    """
     import name_suggestion_service
 
     candidates = db.exec(
         select(ConceptCandidate).where(ConceptCandidate.status == "pending")
     ).all()
-    if not candidates:
-        return []
 
     existing_names = list(db.exec(select(LabelDefinition.name)).all())
 
+    if candidates:
+        try:
+            return name_suggestion_service.filter_suggestions(
+                candidate_names=[c.name for c in candidates],
+                candidate_descriptions=[c.description for c in candidates],
+                existing_names=existing_names,
+            )
+        except Exception:
+            return []
+
+    # No concept candidates yet — generate from message cache
+    message_texts = list(db.exec(select(MessageCache.message_text).limit(50)).all())
+    if not message_texts:
+        return []
+
     try:
-        return name_suggestion_service.filter_suggestions(
-            candidate_names=[c.name for c in candidates],
-            candidate_descriptions=[c.description for c in candidates],
+        return name_suggestion_service.generate_from_messages(
+            message_texts=message_texts,
             existing_names=existing_names,
         )
     except Exception:

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1267,6 +1267,7 @@ def get_queue_history(
 # ── Auto-labeling ────────────────────────────────────────────────────────────
 
 _autolabel_status = {"running": False, "processed": 0, "total": 0, "error": None}
+_autolabel_stop_requested = False
 
 
 def _run_split_autolabel(
@@ -1478,9 +1479,14 @@ def _run_autolabel():
         ]
         _autolabel_status["total"] = len(unlabeled)
 
-        # Process in batches of 30
+        # Process in batches of 30; check stop flag between each batch
         BATCH_SIZE = 30
+        global _autolabel_stop_requested
         for i in range(0, len(unlabeled), BATCH_SIZE):
+            if _autolabel_stop_requested:
+                _autolabel_stop_requested = False
+                _autolabel_status["running"] = False
+                return
             batch = unlabeled[i : i + BATCH_SIZE]
             try:
                 results = classify_batch(label_defs, examples_by_label, batch)
@@ -1548,6 +1554,33 @@ def start_autolabel(db: Session = Depends(get_session)):
 @app.get("/api/queue/autolabel/status")
 def get_autolabel_status():
     return _autolabel_status
+
+
+@app.post("/api/queue/autolabel/stop")
+def stop_autolabel():
+    global _autolabel_stop_requested
+    if not _autolabel_status["running"]:
+        raise HTTPException(status_code=409, detail="Auto-labeling is not running")
+    _autolabel_stop_requested = True
+    return {"ok": True, "message": "Stop requested — will halt after current batch"}
+
+
+@app.delete("/api/queue/autolabel/results")
+def clear_autolabel_results(db: Session = Depends(get_session)):
+    """Delete all AI-applied multi-label applications so autolabel can be re-run."""
+    if _autolabel_status["running"]:
+        raise HTTPException(status_code=409, detail="Auto-labeling is currently running")
+    deleted = db.exec(
+        select(LabelApplication).where(
+            LabelApplication.applied_by == "ai",
+            _is_multi_application(),
+        )
+    ).all()
+    count = len(deleted)
+    for row in deleted:
+        db.delete(row)
+    db.commit()
+    return {"ok": True, "deleted": count}
 
 
 # ── Stub routes (feature tracks implement these) ──────────────────────────────

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3790,6 +3790,15 @@ CLASSIFICATION_CHUNK_SIZE = 50
 # per-project quota in the first second of a fresh run. The retry-on-429
 # logic in `_classify_in_parallel` self-throttles below this when needed.
 PARALLEL_CONCURRENCY = 3
+# Process-wide gate: only one inline classification runs at a time. Concurrent
+# handoffs would each spawn PARALLEL_CONCURRENCY workers, multiplying the Gemini
+# request rate past the quota PARALLEL_CONCURRENCY was tuned to sit under (see
+# above), causing retry/backoff thrashing that is slower than running serially.
+# Serializing whole inline jobs keeps aggregate concurrency at the tuned value
+# and lets each label finish — and become usable — before the next starts. The
+# Batch API path is intentionally NOT gated: Google manages its throughput
+# asynchronously, so local serialization would only stall progress.
+_INLINE_CLASSIFY_LOCK = threading.Lock()
 # Retry settings for the chunk-classifier when Gemini returns 429. Other
 # error classes fail-fast so genuine bugs surface immediately.
 PARALLEL_RETRY_MAX_ATTEMPTS = 4   # initial try + 3 retries
@@ -3897,9 +3906,12 @@ def _do_classification(
             db, label, pending, yes_examples, no_examples
         )
     else:
-        yes_msgs, no_msgs = _classify_in_parallel(
-            db, label, pending, yes_examples, no_examples
-        )
+        # Serialize inline jobs process-wide so N concurrent handoffs don't
+        # multiply Gemini request rate past quota. See _INLINE_CLASSIFY_LOCK.
+        with _INLINE_CLASSIFY_LOCK:
+            yes_msgs, no_msgs = _classify_in_parallel(
+                db, label, pending, yes_examples, no_examples
+            )
 
     summary = binary_autolabel_service.summarize_batch(
         label_name=label.name,
@@ -4446,6 +4458,7 @@ def handoff_single_label(
 
     label.phase = "classifying"
     label.is_active = False
+    label.handed_off_at = datetime.utcnow()
     db.add(label)
 
     next_q = db.exec(
@@ -4494,6 +4507,10 @@ def retry_handoff_single_label(
 
     label.phase = "classifying"
     label.summary_json = None
+    # A retry resumes the original handoff, so keep the original handed_off_at;
+    # only stamp it if it was never set (e.g. a pre-migration row).
+    if label.handed_off_at is None:
+        label.handed_off_at = datetime.utcnow()
     # Keep classified_count / classification_total — they're cumulative across
     # retries. _do_classification extends them by the new pending set's size.
     db.add(label)
@@ -4979,7 +4996,9 @@ def list_handoff_summaries(db: Session = Depends(get_session)):
         .where(LabelDefinition.phase.in_(  # type: ignore[attr-defined]
             ["classifying", "handed_off", "reviewing", "complete", "failed"]
         ))
-        .order_by(LabelDefinition.id.desc())
+        # Most-recently handed-off first. id.desc() is a stable tiebreaker and
+        # also orders any rows that predate the handed_off_at backfill (nulls last).
+        .order_by(LabelDefinition.handed_off_at.desc().nulls_last(), LabelDefinition.id.desc())
     ).all()
 
     out: list[HandoffSummaryListItem] = []

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1329,7 +1329,7 @@ def _run_split_autolabel(
             for r in results:
                 idx = r.get("index")
                 label_name = r.get("label")
-                if idx is None or idx >= len(batch) or label_name not in label_map:
+                if idx is None or idx < 0 or idx >= len(batch) or label_name not in label_map:
                     continue
                 msg = batch[idx]
                 db.add(
@@ -1363,6 +1363,7 @@ def _run_split_autolabel(
 
 def _run_autolabel():
     """Background task: classify all unlabeled messages using Gemini."""
+    # module import (not from-import) so tests can monkeypatch autolabel_service.MULTILABEL_THRESHOLD
     import autolabel_service
 
     global _autolabel_status
@@ -1477,7 +1478,7 @@ def _run_autolabel():
                 for r in results:
                     idx = r.get("index")
                     label_name = r.get("label")
-                    if idx is None or idx >= len(batch) or label_name not in label_map:
+                    if idx is None or idx < 0 or idx >= len(batch) or label_name not in label_map:
                         continue
                     msg = batch[idx]
                     # Check for duplicate

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1364,6 +1364,7 @@ def _run_split_autolabel(
 def _run_autolabel():
     """Background task: classify all unlabeled messages using Gemini."""
     from autolabel_service import classify_batch
+    import autolabel_service
 
     global _autolabel_status
     _autolabel_status = {"running": True, "processed": 0, "total": 0, "error": None}
@@ -1464,7 +1465,7 @@ def _run_autolabel():
                 return
             batch = unlabeled[i : i + BATCH_SIZE]
             try:
-                results = classify_batch(label_defs, examples_by_label, batch)
+                results = classify_batch(label_defs, examples_by_label, batch, multi_select=True)
             except Exception as e:
                 _autolabel_status["error"] = f"Gemini error at batch {i}: {str(e)}"
                 continue
@@ -1495,6 +1496,11 @@ def _run_autolabel():
                             conf = max(0.0, min(1.0, float(conf)))
                         else:
                             conf = None
+                        # Multi-select gate: only persist labels the model is
+                        # confident enough about. Missing/non-numeric confidence
+                        # is treated as below threshold (not persisted).
+                        if conf is None or conf < autolabel_service.MULTILABEL_THRESHOLD:
+                            continue
                         db.add(LabelApplication(
                             label_id=label_map[label_name],
                             chatlog_id=msg["chatlog_id"],

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -69,6 +69,7 @@ import onboarding_service
 import queue_service
 import binary_autolabel_service
 import assignment_service
+import study_scope
 from models import AssignmentMapping
 
 REVIEW_THRESHOLD = 0.75
@@ -1036,12 +1037,13 @@ def get_queue(limit: int = 20, seed: Optional[int] = None, db: Session = Depends
     ).all()
     excluded = {(cid, midx) for cid, midx in labeled_pairs} | {(cid, midx) for cid, midx in skipped_pairs}
 
-    # Query from cache instead of external DB CTE
+    # Query from cache instead of external DB CTE. Study lock: Week 3 only.
     all_cached = db.exec(select(MessageCache)).all()
 
     candidates = [
         c for c in all_cached
         if (c.chatlog_id, c.message_index) not in excluded
+        and study_scope.notebook_in_scope(c.notebook, study_scope.QUEUE_SCOPE)
     ]
 
     # Apply seed-based deterministic ordering or random shuffle
@@ -1068,20 +1070,21 @@ def get_queue(limit: int = 20, seed: Optional[int] = None, db: Session = Depends
 
 @app.get("/api/queue/stats")
 def get_queue_stats(db: Session = Depends(get_session)):
-    labeled_count = db.exec(
-        select(func.count()).select_from(
-            select(LabelApplication.chatlog_id, LabelApplication.message_index)
-            .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
-            .where(LabelDefinition.archived_at == None)  # noqa: E711
-            .where(_is_multi_application())
-            .distinct()
-            .subquery()
-        )
-    ).one()
-    skipped_count = db.exec(select(func.count(SkippedMessage.id))).one()
-    total = db.exec(select(func.count(MessageCache.id))).one() or 0
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
     return {
-        "total_messages": total,
+        "total_messages": len(in_scope),
         "labeled_count": labeled_count,
         "skipped_count": skipped_count,
     }
@@ -1089,18 +1092,20 @@ def get_queue_stats(db: Session = Depends(get_session)):
 
 @app.get("/api/queue/position")
 def get_queue_position(db: Session = Depends(get_session)):
-    labeled_count = db.exec(
-        select(func.count()).select_from(
-            select(LabelApplication.chatlog_id, LabelApplication.message_index)
-            .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
-            .where(LabelDefinition.archived_at == None)  # noqa: E711
-            .where(_is_multi_application())
-            .distinct()
-            .subquery()
-        )
-    ).one()
-    skipped_count = db.exec(select(func.count(SkippedMessage.id))).one()
-    total = db.exec(select(func.count(MessageCache.id))).one() or 0
+    in_scope = study_scope.in_scope_keys(db, study_scope.QUEUE_SCOPE)
+    labeled_pairs = db.exec(
+        select(LabelApplication.chatlog_id, LabelApplication.message_index)
+        .join(LabelDefinition, LabelApplication.label_id == LabelDefinition.id)
+        .where(LabelDefinition.archived_at == None)  # noqa: E711
+        .where(_is_multi_application())
+        .distinct()
+    ).all()
+    skipped_pairs = db.exec(
+        select(SkippedMessage.chatlog_id, SkippedMessage.message_index)
+    ).all()
+    labeled_count = len({(c, i) for c, i in labeled_pairs} & in_scope)
+    skipped_count = len({(c, i) for c, i in skipped_pairs} & in_scope)
+    total = len(in_scope)
     total_remaining = max(0, total - labeled_count - skipped_count)
     position = labeled_count + skipped_count + 1
     return {"position": position, "total_remaining": total_remaining}

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -1363,7 +1363,6 @@ def _run_split_autolabel(
 
 def _run_autolabel():
     """Background task: classify all unlabeled messages using Gemini."""
-    from autolabel_service import classify_batch
     import autolabel_service
 
     global _autolabel_status
@@ -1465,7 +1464,7 @@ def _run_autolabel():
                 return
             batch = unlabeled[i : i + BATCH_SIZE]
             try:
-                results = classify_batch(label_defs, examples_by_label, batch, multi_select=True)
+                results = autolabel_service.classify_batch(label_defs, examples_by_label, batch, multi_select=True)
             except Exception as e:
                 _autolabel_status["error"] = f"Gemini error at batch {i}: {str(e)}"
                 continue

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -3594,9 +3594,15 @@ def close_single_label(label_id: int, db: Session = Depends(get_session)):
 def get_next_focused(
     label_id: int,
     assignment_id: Optional[int] = None,
+    hint_chatlog_id: Optional[int] = None,
     db: Session = Depends(get_session),
 ):
-    """Walk the next focused message for the active labeling label."""
+    """Walk the next focused message for the active labeling label.
+
+    hint_chatlog_id: if provided, try to return the first undecided message
+    from that conversation before falling back to normal queue ordering.
+    Used after label switches to keep the instructor in the same conversation.
+    """
     label = db.get(LabelDefinition, label_id)
     if not label or label.mode != "single":
         raise HTTPException(status_code=404, detail="Single-label not found")
@@ -3607,6 +3613,7 @@ def get_next_focused(
         label_id,
         assignment_id,
         explore_fraction=_effective_hybrid_explore_fraction(label),
+        hint_chatlog_id=hint_chatlog_id,
     )
     db.commit()
     if not payload:

--- a/server/python/main.py
+++ b/server/python/main.py
@@ -2084,6 +2084,29 @@ def get_candidates(db: Session = Depends(get_session)):
     ]
 
 
+@app.get("/api/concepts/name-suggestions")
+def get_name_suggestions(db: Session = Depends(get_session)):
+    """Return pending concept candidates filtered to exclude semantic duplicates of existing labels."""
+    import name_suggestion_service
+
+    candidates = db.exec(
+        select(ConceptCandidate).where(ConceptCandidate.status == "pending")
+    ).all()
+    if not candidates:
+        return []
+
+    existing_names = list(db.exec(select(LabelDefinition.name)).all())
+
+    try:
+        return name_suggestion_service.filter_suggestions(
+            candidate_names=[c.name for c in candidates],
+            candidate_descriptions=[c.description for c in candidates],
+            existing_names=existing_names,
+        )
+    except Exception:
+        return []
+
+
 @app.put("/api/concepts/candidates/{candidate_id}")
 def resolve_candidate(candidate_id: int, req: ResolveCandidateRequest, db: Session = Depends(get_session)):
     candidate = db.get(ConceptCandidate, candidate_id)

--- a/server/python/models.py
+++ b/server/python/models.py
@@ -20,6 +20,9 @@ class LabelDefinition(SQLModel, table=True):
     summary_json: Optional[str] = Field(default=None)  # cached AI summary blob
     classified_count: Optional[int] = Field(default=None)  # progress: rows AI has classified
     classification_total: Optional[int] = Field(default=None)  # progress: total to classify
+    # When the handoff was initiated (phase → classifying). Drives Summaries
+    # ordering (most-recent handoff first). Set on /handoff; preserved on retry.
+    handed_off_at: Optional[datetime] = Field(default=None)
     # Sequential/composable: a mode='single' label promoted from a mode='multi' label
     # carries a back-reference here. Populated by POST /api/labels/{multi_id}/promote.
     paired_label_id: Optional[int] = Field(

--- a/server/python/name_suggestion_service.py
+++ b/server/python/name_suggestion_service.py
@@ -1,4 +1,3 @@
-import math
 import os
 from typing import List
 

--- a/server/python/name_suggestion_service.py
+++ b/server/python/name_suggestion_service.py
@@ -1,0 +1,53 @@
+import math
+import os
+from typing import List
+
+import numpy as np
+from google import genai
+
+SUGGESTION_SIMILARITY_THRESHOLD = 0.75
+_EMBED_MODEL = "gemini-embedding-001"
+
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+
+def _cosine_sim(a: List[float], b: List[float]) -> float:
+    va, vb = np.array(a, dtype=np.float32), np.array(b, dtype=np.float32)
+    denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(va, vb) / denom)
+
+
+def filter_suggestions(
+    candidate_names: List[str],
+    candidate_descriptions: List[str],
+    existing_names: List[str],
+) -> List[dict]:
+    """Return candidates not semantically similar to any existing label name.
+
+    Embeds all texts in one batch call: candidates first, then existing names.
+    Drops any candidate whose max cosine similarity to an existing label
+    exceeds SUGGESTION_SIMILARITY_THRESHOLD.
+    """
+    if not candidate_names:
+        return []
+    if not existing_names:
+        return [
+            {"name": n, "description": d}
+            for n, d in zip(candidate_names, candidate_descriptions)
+        ]
+
+    all_texts = candidate_names + existing_names
+    resp = client.models.embed_content(model=_EMBED_MODEL, contents=all_texts)
+    embeddings = [e.values for e in resp.embeddings]
+
+    cand_vecs = embeddings[: len(candidate_names)]
+    exist_vecs = embeddings[len(candidate_names) :]
+
+    result = []
+    for name, desc, vec in zip(candidate_names, candidate_descriptions, cand_vecs):
+        max_sim = max(_cosine_sim(vec, ex) for ex in exist_vecs)
+        if max_sim <= SUGGESTION_SIMILARITY_THRESHOLD:
+            result.append({"name": name, "description": desc})
+    return result

--- a/server/python/name_suggestion_service.py
+++ b/server/python/name_suggestion_service.py
@@ -1,13 +1,19 @@
+import json
 import os
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from google import genai
+from google.genai import types as genai_types
 
 SUGGESTION_SIMILARITY_THRESHOLD = 0.75
 _EMBED_MODEL = "gemini-embedding-001"
+_GENERATE_MODEL = "gemini-2.5-flash"
 
 client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY", ""))
+
+# Module-level cache so the on-demand generation only runs once per server session
+_generated_cache: Optional[List[dict]] = None
 
 
 def _cosine_sim(a: List[float], b: List[float]) -> float:
@@ -50,3 +56,82 @@ def filter_suggestions(
         if max_sim <= SUGGESTION_SIMILARITY_THRESHOLD:
             result.append({"name": name, "description": desc})
     return result
+
+
+def generate_from_messages(
+    message_texts: List[str],
+    existing_names: List[str],
+) -> List[dict]:
+    """Generate label name suggestions from a sample of messages.
+
+    Asks Gemini to propose label concepts visible in the data, then filters
+    them through cosine similarity to drop anything too close to existing labels.
+    Result is cached in _generated_cache so subsequent calls skip the Gemini call.
+    """
+    global _generated_cache
+    if _generated_cache is not None:
+        # Re-filter cached suggestions against current existing labels in case new
+        # labels were created since the cache was populated.
+        if not existing_names:
+            return _generated_cache
+        try:
+            return filter_suggestions(
+                candidate_names=[s["name"] for s in _generated_cache],
+                candidate_descriptions=[s["description"] for s in _generated_cache],
+                existing_names=existing_names,
+            )
+        except Exception:
+            return _generated_cache
+
+    if not message_texts:
+        return []
+
+    existing_str = (
+        ", ".join(f'"{n}"' for n in existing_names) if existing_names else "none yet"
+    )
+    sample = "\n".join(f"- {m[:200]}" for m in message_texts[:40])
+
+    prompt = (
+        "You are helping an instructor create labels for student-AI tutoring conversations.\n\n"
+        f"Already-created labels (avoid these and close synonyms): {existing_str}\n\n"
+        "Sample student messages from the dataset:\n"
+        f"{sample}\n\n"
+        "Suggest 8-12 concise label names capturing distinct student behaviors or intents "
+        "visible in these messages. Return a JSON array only, no explanation:\n"
+        '[{"name": "label name", "description": "one sentence description"}, ...]'
+    )
+
+    response = client.models.generate_content(
+        model=_GENERATE_MODEL,
+        contents=prompt,
+        config=genai_types.GenerateContentConfig(temperature=0.3),
+    )
+
+    text = response.text.strip()
+    if "```" in text:
+        parts = text.split("```")
+        text = parts[1] if len(parts) > 1 else parts[0]
+        if text.startswith("json"):
+            text = text[4:]
+
+    raw: List[dict] = json.loads(text.strip())
+    suggestions = [
+        {"name": s["name"], "description": s.get("description", "")}
+        for s in raw
+        if isinstance(s, dict) and "name" in s
+    ]
+
+    # Cache the raw generated set before similarity filtering
+    _generated_cache = suggestions
+
+    if not existing_names or not suggestions:
+        return suggestions
+
+    try:
+        return filter_suggestions(
+            candidate_names=[s["name"] for s in suggestions],
+            candidate_descriptions=[s["description"] for s in suggestions],
+            existing_names=existing_names,
+        )
+    except Exception:
+        return suggestions

--- a/server/python/onboarding_service.py
+++ b/server/python/onboarding_service.py
@@ -105,7 +105,7 @@ def _ai_label_suggestions_for_turns(turns: list[tuple[int, str]]) -> Optional[di
             "one inner array per message in order."
         )
         response = explore_service._client_get().models.generate_content(
-            model="gemini-2.0-flash",
+            model="gemini-2.5-flash",
             contents=prompt,
         )
         raw = ""

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -488,6 +488,7 @@ def next_message_for_label(
     explore_fraction: Optional[float] = None,
     *,
     extra_decided: Optional[set[tuple[int, int]]] = None,
+    hint_chatlog_id: Optional[int] = None,
 ) -> Optional[dict]:
     eff_explore = (
         max(0.0, min(1.0, explore_fraction))
@@ -586,6 +587,21 @@ def next_message_for_label(
 
     in_progress.sort(key=lambda c: _shuffle_key(label_id, c))
     not_started.sort(key=lambda c: _shuffle_key(label_id, c))
+
+    # If the caller pinned a conversation (e.g. after a label switch), try it first.
+    if hint_chatlog_id is not None and hint_chatlog_id in conv:
+        tup = _first_pending_turn(hint_chatlog_id, conv[hint_chatlog_id], decided)
+        if tup:
+            midx, text, notebook = tup
+            sampling_meta = build_sampling_meta(
+                session, label_id, hint_chatlog_id, midx,
+                len(conv[hint_chatlog_id]), "round_robin",
+            )
+            return _build_focus_payload(
+                session, label_id, hint_chatlog_id, midx, text, notebook,
+                sampling_meta=sampling_meta,
+            )
+        # Hint conversation is fully decided for this label — fall through to normal pick.
 
     cid_pick, pick_mode = _select_next_chatlog_id(
         session,

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -303,9 +303,9 @@ def build_sampling_meta(
 def default_hybrid_explore_fraction() -> float:
     """Server default when `LabelDefinition.hybrid_explore_fraction` is unset."""
     try:
-        v = float(os.environ.get("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0.35"))
+        v = float(os.environ.get("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0.75"))
     except (TypeError, ValueError):
-        v = 0.35
+        v = 0.75
     return max(0.0, min(1.0, v))
 
 

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -496,28 +496,9 @@ def next_message_for_label(
         else default_hybrid_explore_fraction()
     )
 
-    cache_q = select(
-        MessageCache.id,
-        MessageCache.chatlog_id,
-        MessageCache.message_index,
-        MessageCache.message_text,
-        MessageCache.notebook,
-        MessageCache.assignment_id,
-    )
-    if assignment_id is not None:
-        cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
-    cache_rows = session.exec(cache_q).all()
-
-    # Study lock: restrict to the week tied to this label's mode
-    # (single -> Week 8, multi/onboarding -> Week 3). Unconditional; the
-    # client assignment_id filter above only narrows further.
-    _label = session.get(LabelDefinition, label_id)
-    _scope = study_scope.scope_for_mode(_label.mode if _label else "multi")
-    cache_rows = [
-        row for row in cache_rows
-        if study_scope.notebook_in_scope(row[4], _scope)
-    ]
-
+    # Fast path: a brand-new label with an onboarding seed and no decisions yet
+    # can return immediately without scanning the full MessageCache.
+    label = session.get(LabelDefinition, label_id)
     decided = set(
         session.exec(
             select(LabelApplication.chatlog_id, LabelApplication.message_index)
@@ -527,7 +508,6 @@ def next_message_for_label(
     if extra_decided:
         decided |= extra_decided
 
-    label = session.get(LabelDefinition, label_id)
     if (
         label
         and label.onboarding_seed_chatlog_id is not None
@@ -543,7 +523,7 @@ def next_message_for_label(
             .where(MessageCache.chatlog_id == seed_cid)
             .where(MessageCache.message_index == seed_midx)
         ).first()
-        if seed_row and (seed_cid, seed_midx) not in decided:
+        if seed_row:
             text, notebook = seed_row
             sampling_meta = build_sampling_meta(
                 session,
@@ -568,6 +548,27 @@ def next_message_for_label(
                 notebook,
                 sampling_meta=sampling_meta,
             )
+
+    cache_q = select(
+        MessageCache.id,
+        MessageCache.chatlog_id,
+        MessageCache.message_index,
+        MessageCache.message_text,
+        MessageCache.notebook,
+        MessageCache.assignment_id,
+    )
+    if assignment_id is not None:
+        cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
+    cache_rows = session.exec(cache_q).all()
+
+    # Study lock: restrict to the week tied to this label's mode
+    # (single -> Week 8, multi/onboarding -> Week 3). Unconditional; the
+    # client assignment_id filter above only narrows further.
+    _scope = study_scope.scope_for_mode(label.mode if label else "multi")
+    cache_rows = [
+        row for row in cache_rows
+        if study_scope.notebook_in_scope(row[4], _scope)
+    ]
 
     conv: dict[int, list[tuple[int, str, Optional[str]]]] = {}
     assign_by_cid: dict[int, Optional[int]] = {}

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -108,19 +108,35 @@ def compose_explore_pick_explanation(
     chatlog_id: int,
     message_index: int,
     pending_text: str,
+    *,
+    precomputed: Optional[dict] = None,
 ) -> dict:
-    """≤20-word summary + concise score bullets for Explore (frozen per chat)."""
-    unc_nov = neighbor_uncertainty_novelty(session, label_id, chatlog_id, message_index)
-    labeled_centroids = explore_service.labeled_student_centroids(session, label_id)
-    conv_nov = explore_service.conversation_novelty(
-        session, label_id, chatlog_id, labeled_centroids
-    )
-    theme_nov = explore_service.theme_novelty(session, label_id, chatlog_id)
-    rarity = explore_service.student_message_corpus_rarity(session, chatlog_id, message_index)
+    """≤20-word summary + concise score bullets for Explore (frozen per chat).
+
+    Pass `precomputed` (from `_select_next_chatlog_id`) to skip re-running the
+    expensive k-NN and embedding queries for the winning candidate."""
+    if precomputed:
+        unc_nov = precomputed.get("unc_nov")
+        conv_nov = precomputed.get("conv_nov")
+        theme_nov = precomputed.get("theme_nov")
+        rarity = precomputed.get("rarity")
+        spec = precomputed.get("spec")
+    else:
+        unc_nov = neighbor_uncertainty_novelty(session, label_id, chatlog_id, message_index)
+        labeled_centroids = explore_service.labeled_student_centroids(session, label_id)
+        conv_nov = explore_service.conversation_novelty(
+            session, label_id, chatlog_id, labeled_centroids
+        )
+        theme_nov = explore_service.theme_novelty(session, label_id, chatlog_id)
+        rarity = explore_service.student_message_corpus_rarity(session, chatlog_id, message_index)
+        spec = explore_service.student_help_specificity(
+            pending_text or "", corpus_rarity=rarity
+        )
     paste_score = explore_service.student_message_copy_paste_likelihood(pending_text or "")
-    spec = explore_service.student_help_specificity(
-        pending_text or "", corpus_rarity=rarity
-    )
+    if spec is None:
+        spec = explore_service.student_help_specificity(
+            pending_text or "", corpus_rarity=rarity
+        )
     paste = paste_score or 0.0
 
     breakdown: list[str] = []
@@ -337,7 +353,7 @@ def _select_next_chatlog_id(
     in_progress: list[int],
     not_started: list[int],
     explore_fraction: float,
-) -> Tuple[Optional[int], Optional[str]]:
+) -> Tuple[Optional[int], Optional[str], Optional[dict]]:
     ip_pending = [
         c for c in in_progress
         if c in conv and _first_pending_turn(c, conv[c], decided)
@@ -347,21 +363,21 @@ def _select_next_chatlog_id(
         if c in conv and _first_pending_turn(c, conv[c], decided)
     ]
     if not ip_pending and not ns_pending:
-        return None, None
+        return None, None, None
 
     pool = ip_pending if ip_pending else ns_pending
     in_prog_bucket = bool(ip_pending)
 
     if len(pool) == 1:
         if in_prog_bucket:
-            return pool[0], "continue"
-        return pool[0], "round_robin"
+            return pool[0], "continue", None
+        return pool[0], "round_robin", None
 
     explore = random.random() < explore_fraction
     if not explore:
         if in_prog_bucket:
             pool_sorted = sorted(pool, key=lambda c: _shuffle_key(label_id, c))
-            return pool_sorted[0], "continue"
+            return pool_sorted[0], "continue", None
         pool_sorted = sorted(
             pool,
             key=lambda c: (
@@ -370,7 +386,7 @@ def _select_next_chatlog_id(
                 _shuffle_key(label_id, c),
             ),
         )
-        return pool_sorted[0], "round_robin"
+        return pool_sorted[0], "round_robin", None
 
     cap = explore_service.explore_score_pool_cap()
     pool_to_score = pool
@@ -411,14 +427,14 @@ def _select_next_chatlog_id(
     labeled_centroids = explore_service.labeled_student_centroids(session, label_id)
     theme_vectors = explore_service.labeled_theme_vectors(session, label_id)
 
-    def _conversation_utility(cid: int) -> float:
+    def _conversation_utility(cid: int) -> Tuple[float, dict]:
         pending = _first_pending_turn(cid, conv[cid], decided)
         if not pending:
-            return 0.0
+            return 0.0, {}
         midx, text, _notebook = pending
         student_texts = [t for _i, t, _n in conv[cid]]
-        result = neighbor_uncertainty_novelty(session, label_id, cid, midx)
-        uncertainty, msg_nov = (result if result else (None, None))
+        unc_nov = neighbor_uncertainty_novelty(session, label_id, cid, midx)
+        uncertainty, msg_nov = (unc_nov if unc_nov else (None, None))
         conv_nov = explore_service.conversation_novelty(
             session, label_id, cid, labeled_centroids
         )
@@ -428,7 +444,7 @@ def _select_next_chatlog_id(
         rarity = explore_service.student_message_corpus_rarity(session, cid, midx)
         spec = explore_service.student_help_specificity(text, corpus_rarity=rarity)
         spam = explore_service.conversation_spam_penalty(student_texts)
-        return explore_service.blended_explore_utility(
+        score = explore_service.blended_explore_utility(
             uncertainty,
             msg_nov,
             conv_nov,
@@ -437,10 +453,19 @@ def _select_next_chatlog_id(
             rarity,
             spam,
         )
+        components = {
+            "unc_nov": unc_nov,
+            "conv_nov": conv_nov,
+            "theme_nov": theme_nov,
+            "rarity": rarity,
+            "spec": spec,
+        }
+        return score, components
 
-    utility_scores = {
+    utility_results = {
         cid: _conversation_utility(cid) for cid in explore_candidates
     }
+    utility_scores = {cid: score for cid, (score, _) in utility_results.items()}
     scored = sorted(
         explore_candidates,
         key=lambda c: (-utility_scores[c], c),
@@ -448,7 +473,9 @@ def _select_next_chatlog_id(
     top_k = max(1, (len(scored) + 3) // 4)
     explore_choices = [c for c in scored[:top_k]]
 
-    return random.choice(explore_choices), "explore"
+    winner = random.choice(explore_choices)
+    _, winner_components = utility_results[winner]
+    return winner, "explore", winner_components
 
 
 def _synthetic_decided_for_exhausted_conversations(
@@ -604,7 +631,7 @@ def next_message_for_label(
             )
         # Hint conversation is fully decided for this label — fall through to normal pick.
 
-    cid_pick, pick_mode = _select_next_chatlog_id(
+    cid_pick, pick_mode, pick_components = _select_next_chatlog_id(
         session,
         label_id,
         conv,
@@ -623,7 +650,7 @@ def next_message_for_label(
     midx, text, notebook = tup
     if pick_mode == "explore":
         explanation = compose_explore_pick_explanation(
-            session, label_id, cid_pick, midx, text
+            session, label_id, cid_pick, midx, text, precomputed=pick_components
         )
         _ensure_explore_pick_explanation(
             session,

--- a/server/python/queue_service.py
+++ b/server/python/queue_service.py
@@ -15,6 +15,7 @@ from sqlmodel import Session, select
 
 import assist_service
 import explore_service
+import study_scope
 from database import ext_engine
 from models import (
     ConversationCursor,
@@ -505,6 +506,16 @@ def next_message_for_label(
     if assignment_id is not None:
         cache_q = cache_q.where(MessageCache.assignment_id == assignment_id)
     cache_rows = session.exec(cache_q).all()
+
+    # Study lock: restrict to the week tied to this label's mode
+    # (single -> Week 8, multi/onboarding -> Week 3). Unconditional; the
+    # client assignment_id filter above only narrows further.
+    _label = session.get(LabelDefinition, label_id)
+    _scope = study_scope.scope_for_mode(_label.mode if _label else "multi")
+    cache_rows = [
+        row for row in cache_rows
+        if study_scope.notebook_in_scope(row[4], _scope)
+    ]
 
     decided = set(
         session.exec(

--- a/server/python/schemas.py
+++ b/server/python/schemas.py
@@ -516,7 +516,7 @@ class MessageListItem(BaseModel):
     message_index: int
     text: str
     confidence: Optional[float]
-    verdict: Optional[Literal["yes", "no", "review"]]
+    verdict: Optional[Literal["yes", "no", "skip", "review"]]
     applied_by: Optional[Literal["ai", "human"]]
     flagged: bool
     has_note: bool
@@ -541,7 +541,7 @@ class MessageDetailResponse(BaseModel):
     message_index: int
     text: str
     confidence: Optional[float]
-    verdict: Optional[Literal["yes", "no", "review"]]
+    verdict: Optional[Literal["yes", "no", "skip", "review"]]
     applied_by: Optional[Literal["ai", "human"]]
     matched_pattern: Optional[str]
     rationale: Optional[str]

--- a/server/python/study_scope.py
+++ b/server/python/study_scope.py
@@ -8,12 +8,21 @@ https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
 data/milestones/dsc10_wi26.json).
 """
 import os
+import threading
 from typing import Optional
 
+from sqlalchemy import func
 from sqlmodel import Session, select
 
 from assignment_service import _canonical_name
 from models import MessageCache
+
+# Memoized results keyed by (lock_on, frozenset(names), row_count).
+# row_count keeps test suites isolated (each test seeds a different number of
+# MessageCache rows) and picks up the rare case where the cache is filled after
+# a partial startup. Thread-safe for concurrent FastAPI workers.
+_scope_cache: dict = {}
+_scope_cache_lock = threading.Lock()
 
 QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
 RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
@@ -39,7 +48,20 @@ def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
 
 def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
     """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`.
-    When the lock is disabled, every cached message is considered in scope."""
+    When the lock is disabled, every cached message is considered in scope.
+
+    Result is memoized in memory: the scope never changes within a server run,
+    and the row_count fingerprint keeps test suites isolated across tests that
+    seed different MessageCache data."""
+    lock_on = lock_enabled()
+    row_count = int(session.exec(select(func.count(MessageCache.id))).one())
+    cache_key = (lock_on, frozenset(names), row_count)
+
+    with _scope_cache_lock:
+        cached = _scope_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
     rows = session.exec(
         select(
             MessageCache.chatlog_id,
@@ -47,8 +69,13 @@ def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
             MessageCache.notebook,
         )
     ).all()
-    return {
+    result = frozenset(
         (cid, midx)
         for cid, midx, nb in rows
         if notebook_in_scope(nb, names)
-    }
+    )
+
+    with _scope_cache_lock:
+        _scope_cache[cache_key] = result
+
+    return result

--- a/server/python/study_scope.py
+++ b/server/python/study_scope.py
@@ -1,0 +1,43 @@
+"""Study fixture: hard-locked per-week assignment scopes for the user study.
+
+`/queue` (multi-label) is locked to DSC 10 Winter-2026 Week 3 (Lab 1 + HW 1);
+`/run` (single-label) is locked to Week 8 (Lab 5 + HW 5). Scope is expressed in
+canonical assignment names (the same vocabulary as assignment_service) so it does
+not depend on AssignmentMapping rows existing. Weeks come from
+https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
+data/milestones/dsc10_wi26.json).
+"""
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from assignment_service import _canonical_name
+from models import MessageCache
+
+QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
+RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
+
+
+def scope_for_mode(mode: str) -> set[str]:
+    """Single-label runs are Week 8; everything else (multi/onboarding) is Week 3."""
+    return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
+
+
+def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
+    return notebook is not None and _canonical_name(notebook) in names
+
+
+def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
+    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`."""
+    rows = session.exec(
+        select(
+            MessageCache.chatlog_id,
+            MessageCache.message_index,
+            MessageCache.notebook,
+        )
+    ).all()
+    return {
+        (cid, midx)
+        for cid, midx, nb in rows
+        if notebook_in_scope(nb, names)
+    }

--- a/server/python/study_scope.py
+++ b/server/python/study_scope.py
@@ -7,6 +7,7 @@ not depend on AssignmentMapping rows existing. Weeks come from
 https://dsc-courses.github.io/dsc10-2026-wi/ (cross-checked vs
 data/milestones/dsc10_wi26.json).
 """
+import os
 from typing import Optional
 
 from sqlmodel import Session, select
@@ -18,17 +19,27 @@ QUEUE_SCOPE = {"Lab 1", "Homework 1"}   # Week 3 — multi-label
 RUN_SCOPE = {"Lab 5", "Homework 5"}     # Week 8 — single-label
 
 
+def lock_enabled() -> bool:
+    """Whether the study week-lock is active. ON by default (production/study);
+    set CHATSIGHT_STUDY_LOCK=0 to disable (legacy test suite seeds unscoped data).
+    Read at call time so tests can toggle it via monkeypatch."""
+    return os.getenv("CHATSIGHT_STUDY_LOCK", "1") != "0"
+
+
 def scope_for_mode(mode: str) -> set[str]:
     """Single-label runs are Week 8; everything else (multi/onboarding) is Week 3."""
     return RUN_SCOPE if mode == "single" else QUEUE_SCOPE
 
 
 def notebook_in_scope(notebook: Optional[str], names: set[str]) -> bool:
+    if not lock_enabled():
+        return True
     return notebook is not None and _canonical_name(notebook) in names
 
 
 def in_scope_keys(session: Session, names: set[str]) -> set[tuple[int, int]]:
-    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`."""
+    """(chatlog_id, message_index) pairs whose notebook canonicalizes into `names`.
+    When the lock is disabled, every cached message is considered in scope."""
     rows = session.exec(
         select(
             MessageCache.chatlog_id,

--- a/server/python/tests/conftest.py
+++ b/server/python/tests/conftest.py
@@ -5,6 +5,11 @@ import os
 # reads this env var at module load time.
 os.environ.setdefault("PG_PASSWORD", "test_dummy_password")
 
+# The study week-lock (study_scope) is ON by default in production. The legacy
+# test suite seeds unscoped MessageCache rows (notebook=None or other weeks), so
+# disable the lock here. test_study_scope.py re-enables it per-test to validate it.
+os.environ.setdefault("CHATSIGHT_STUDY_LOCK", "0")
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest

--- a/server/python/tests/conftest.py
+++ b/server/python/tests/conftest.py
@@ -17,8 +17,21 @@ from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, create_engine, Session
 from sqlmodel.pool import StaticPool
 
+import study_scope
 from main import app, get_ext_conn
 from database import get_session
+
+
+@pytest.fixture(autouse=True)
+def _clear_scope_cache():
+    """Wipe the in_scope_keys memo cache before each test.
+
+    Tests seed different numbers of MessageCache rows but may collide on the
+    (lock_on, names, row_count) cache key when row counts happen to match.
+    Clearing per-test gives isolation without coupling to any specific fixture."""
+    study_scope._scope_cache.clear()
+    yield
+    study_scope._scope_cache.clear()
 
 
 @pytest.fixture(name="engine")

--- a/server/python/tests/test_autolabel_fixes.py
+++ b/server/python/tests/test_autolabel_fixes.py
@@ -52,7 +52,7 @@ def test_autolabel_excludes_archived_labels(session, engine, monkeypatch):
 
     label_defs_seen = []
 
-    def fake_classify(label_defs, examples_by_label, messages):
+    def fake_classify(label_defs, examples_by_label, messages, multi_select=False):
         label_defs_seen.extend(label_defs)
         return [{"index": 0, "label": label_defs[0]["name"], "confidence": 0.9}]
 
@@ -93,7 +93,7 @@ def test_autolabel_scopes_to_queue_scope(session, engine, monkeypatch):
 
     messages_sent = []
 
-    def fake_classify(label_defs, examples_by_label, messages):
+    def fake_classify(label_defs, examples_by_label, messages, multi_select=False):
         messages_sent.extend(messages)
         return []
 
@@ -131,7 +131,7 @@ def test_autolabel_does_not_query_external_db(session, engine, monkeypatch):
     monkeypatch.setattr(main.ext_engine, "connect", _fake_connect)
 
     # Autolabel should still succeed (no external DB calls)
-    def fake_classify(label_defs, examples_by_label, messages):
+    def fake_classify(label_defs, examples_by_label, messages, multi_select=False):
         return []
 
     monkeypatch.setattr(autolabel_service, "classify_batch", fake_classify)

--- a/server/python/tests/test_autolabel_fixes.py
+++ b/server/python/tests/test_autolabel_fixes.py
@@ -1,0 +1,159 @@
+"""Tests for the three autolabel / explore-fraction fixes validated post user-study:
+
+1. _run_autolabel now skips archived multi-labels (archived_at IS NOT NULL).
+2. _run_autolabel now uses MessageCache + QUEUE_SCOPE filter instead of the
+   external PostgreSQL CTE (no ext_engine calls during autolabel).
+3. default_hybrid_explore_fraction() returns 0.75 (was 0.35).
+"""
+from datetime import datetime
+from unittest.mock import patch
+
+import main
+import queue_service
+import autolabel_service
+from models import LabelApplication, LabelDefinition, MessageCache
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_label(session, name, mode="multi", archived=False, **kw):
+    lbl = LabelDefinition(
+        name=name,
+        mode=mode,
+        archived_at=datetime.utcnow() if archived else None,
+        **kw,
+    )
+    session.add(lbl)
+    session.commit()
+    session.refresh(lbl)
+    return lbl
+
+
+def _seed_msg(session, chatlog_id, message_index, notebook=None, text=None):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id,
+        message_index=message_index,
+        message_text=text or f"msg {chatlog_id}.{message_index}",
+        notebook=notebook,
+    ))
+    session.commit()
+
+
+# ── 1. Archived-label exclusion ───────────────────────────────────────────────
+
+def test_autolabel_excludes_archived_labels(session, engine, monkeypatch):
+    """_run_autolabel must not send archived labels to Gemini and must not write
+    LabelApplication rows for them."""
+    monkeypatch.setattr(main, "engine", engine)
+
+    active = _make_label(session, "active-label")
+    _make_label(session, "archived-label", archived=True)
+    _seed_msg(session, 1, 0, notebook="lab01.ipynb", text="help me")
+
+    label_defs_seen = []
+
+    def fake_classify(label_defs, examples_by_label, messages):
+        label_defs_seen.extend(label_defs)
+        return [{"index": 0, "label": label_defs[0]["name"], "confidence": 0.9}]
+
+    monkeypatch.setattr(autolabel_service, "classify_batch", fake_classify)
+
+    main._run_autolabel()
+
+    names_sent = {d["name"] for d in label_defs_seen}
+    assert "active-label" in names_sent, "Active label should be sent to classify_batch"
+    assert "archived-label" not in names_sent, "Archived label must NOT be sent to classify_batch"
+
+    ai_apps = session.exec(
+        __import__("sqlmodel", fromlist=["select"]).select(LabelApplication)
+        .where(LabelApplication.applied_by == "ai")
+    ).all()
+    written_label_ids = {a.label_id for a in ai_apps}
+    assert active.id in written_label_ids or len(ai_apps) == 0  # depends on fake return
+    assert not any(a.label_id != active.id for a in ai_apps), (
+        "No AI application should reference an archived label"
+    )
+
+
+# ── 2. Study-scope filtering: only Week 3 messages should be classified ────────
+
+def test_autolabel_scopes_to_queue_scope(session, engine, monkeypatch):
+    """_run_autolabel must restrict candidates to QUEUE_SCOPE (Week 3: Lab 1, HW 1).
+    Week 8 messages in MessageCache must be excluded."""
+    monkeypatch.setenv("CHATSIGHT_STUDY_LOCK", "1")
+    monkeypatch.setattr(main, "engine", engine)
+
+    _make_label(session, "scope-label")
+    # In scope: Week 3
+    _seed_msg(session, 10, 0, notebook="lab01.ipynb", text="in scope")
+    _seed_msg(session, 11, 0, notebook="hw01.ipynb", text="also in scope")
+    # Out of scope: Week 8 (single-label week) and unlocked weeks
+    _seed_msg(session, 20, 0, notebook="lab05.ipynb", text="week 8 – out of scope")
+    _seed_msg(session, 21, 0, notebook=None, text="no notebook – out of scope")
+
+    messages_sent = []
+
+    def fake_classify(label_defs, examples_by_label, messages):
+        messages_sent.extend(messages)
+        return []
+
+    monkeypatch.setattr(autolabel_service, "classify_batch", fake_classify)
+    main._run_autolabel()
+
+    sent_cids = {m["chatlog_id"] for m in messages_sent}
+    assert 10 in sent_cids, "Week 3 lab1 message must be classified"
+    assert 11 in sent_cids, "Week 3 hw1 message must be classified"
+    assert 20 not in sent_cids, "Week 8 message must not be classified"
+    assert 21 not in sent_cids, "Message with no notebook must not be classified"
+
+
+# ── 3. No external-DB queries during autolabel (MessageCache used instead) ────
+
+def test_autolabel_does_not_query_external_db(session, engine, monkeypatch):
+    """After the fix, _run_autolabel must not call ext_engine.connect() at all.
+    All data comes from local MessageCache."""
+    monkeypatch.setattr(main, "engine", engine)
+
+    _make_label(session, "no-ext-label")
+    _seed_msg(session, 5, 0, notebook="lab01.ipynb", text="test msg")
+
+    ext_connect_calls = []
+
+    class _FakeConn:
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def execute(self, *a, **kw): raise AssertionError("ext_engine.execute called — should not happen")
+
+    def _fake_connect():
+        ext_connect_calls.append(1)
+        return _FakeConn()
+
+    monkeypatch.setattr(main.ext_engine, "connect", _fake_connect)
+
+    # Autolabel should still succeed (no external DB calls)
+    def fake_classify(label_defs, examples_by_label, messages):
+        return []
+
+    monkeypatch.setattr(autolabel_service, "classify_batch", fake_classify)
+    main._run_autolabel()
+
+    assert ext_connect_calls == [], (
+        "_run_autolabel called ext_engine.connect — it should use MessageCache instead"
+    )
+    assert main._autolabel_status["error"] is None, (
+        f"autolabel should complete without error; got: {main._autolabel_status['error']}"
+    )
+
+
+# ── 4. Explore fraction default ───────────────────────────────────────────────
+
+def test_explore_fraction_default_is_75_pct(monkeypatch):
+    """default_hybrid_explore_fraction() should return 0.75 when no env override."""
+    monkeypatch.delenv("CHATSIGHT_HYBRID_EXPLORE_FRACTION", raising=False)
+    assert queue_service.default_hybrid_explore_fraction() == 0.75
+
+
+def test_explore_fraction_env_override_still_works(monkeypatch):
+    """The env variable override must still function after the default change."""
+    monkeypatch.setenv("CHATSIGHT_HYBRID_EXPLORE_FRACTION", "0.5")
+    assert queue_service.default_hybrid_explore_fraction() == 0.5

--- a/server/python/tests/test_autolabel_fixes.py
+++ b/server/python/tests/test_autolabel_fixes.py
@@ -83,6 +83,7 @@ def test_autolabel_scopes_to_queue_scope(session, engine, monkeypatch):
     Week 8 messages in MessageCache must be excluded."""
     monkeypatch.setenv("CHATSIGHT_STUDY_LOCK", "1")
     monkeypatch.setattr(main, "engine", engine)
+    monkeypatch.setattr(autolabel_service, "MULTILABEL_THRESHOLD", 0.5)
 
     _make_label(session, "scope-label")
     # In scope: Week 3
@@ -114,6 +115,7 @@ def test_autolabel_does_not_query_external_db(session, engine, monkeypatch):
     """After the fix, _run_autolabel must not call ext_engine.connect() at all.
     All data comes from local MessageCache."""
     monkeypatch.setattr(main, "engine", engine)
+    monkeypatch.setattr(autolabel_service, "MULTILABEL_THRESHOLD", 0.5)
 
     _make_label(session, "no-ext-label")
     _seed_msg(session, 5, 0, notebook="lab01.ipynb", text="test msg")

--- a/server/python/tests/test_autolabel_fixes.py
+++ b/server/python/tests/test_autolabel_fixes.py
@@ -45,6 +45,7 @@ def test_autolabel_excludes_archived_labels(session, engine, monkeypatch):
     """_run_autolabel must not send archived labels to Gemini and must not write
     LabelApplication rows for them."""
     monkeypatch.setattr(main, "engine", engine)
+    monkeypatch.setattr(autolabel_service, "MULTILABEL_THRESHOLD", 0.5)
 
     active = _make_label(session, "active-label")
     _make_label(session, "archived-label", archived=True)

--- a/server/python/tests/test_handoff_flow.py
+++ b/server/python/tests/test_handoff_flow.py
@@ -1,8 +1,10 @@
 """Tests for handoff (now background-async), summary, refine, and review-queue endpoints."""
-from datetime import datetime
+import threading
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-from sqlmodel import select
+from sqlmodel import SQLModel, Session, create_engine, select
+from sqlmodel.pool import StaticPool
 
 import main
 from models import LabelApplication, LabelDefinition, MessageCache
@@ -1056,3 +1058,208 @@ def test_handoff_summaries_surfaces_batch_count_fields(client, session):
     assert len(found) == 1
     assert found[0]["batch_total_count"] == 5
     assert found[0]["batch_completed_count"] == 2
+
+
+# ─── Inline classification concurrency gate ───────────────────────────────
+
+
+def _isolated_engine_with_pending(label_name, n_msgs=4):
+    """Build a standalone in-memory engine seeded with a single-label and
+    `n_msgs` undecided cached messages so `_do_classification` reaches the
+    inline classify call. Returns (engine, label_id). Each engine is its own
+    DB so two threads can run `_do_classification` without write contention —
+    the thing under test (the serialization lock) is process-global, not
+    per-DB."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as db:
+        label = LabelDefinition(name=label_name, mode="single", phase="classifying")
+        db.add(label)
+        for i in range(n_msgs):
+            db.add(MessageCache(
+                chatlog_id=700, message_index=i,
+                message_text=f"msg {i}", notebook="lab3.ipynb",
+            ))
+        db.commit()
+        db.refresh(label)
+        return engine, label.id
+
+
+def test_concurrent_inline_classifications_are_serialized():
+    """Two inline classifications running at once must not overlap — the
+    process-wide lock keeps aggregate Gemini concurrency at the tuned value
+    instead of multiplying it per in-flight handoff."""
+    active = {"n": 0, "peak": 0}
+    active_lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def instrumented_classify_in_parallel(db, label, pending, yes_ex, no_ex):
+        with active_lock:
+            active["n"] += 1
+            active["peak"] = max(active["peak"], active["n"])
+        # Hold long enough that an ungated sibling would overlap here.
+        threading.Event().wait(0.1)
+        with active_lock:
+            active["n"] -= 1
+        return [], []
+
+    def fake_summary(*args, **kwargs):
+        return {"included": [], "excluded": []}
+
+    engine_a, label_a = _isolated_engine_with_pending("alpha")
+    engine_b, label_b = _isolated_engine_with_pending("beta")
+
+    def run(engine, label_id):
+        barrier.wait()  # ensure both threads contend for the lock together
+        with Session(engine) as db:
+            label = db.get(LabelDefinition, label_id)
+            main._do_classification(db, label)
+
+    with patch("main._classify_in_parallel", side_effect=instrumented_classify_in_parallel), \
+         patch("binary_autolabel_service.summarize_batch", side_effect=fake_summary):
+        t_a = threading.Thread(target=run, args=(engine_a, label_a))
+        t_b = threading.Thread(target=run, args=(engine_b, label_b))
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=5)
+        t_b.join(timeout=5)
+
+    assert not t_a.is_alive() and not t_b.is_alive(), "classification thread hung"
+    assert active["peak"] == 1, (
+        f"inline classifications overlapped (peak={active['peak']}); "
+        "the serialization lock is not gating them"
+    )
+
+
+def test_batch_classification_not_gated_by_inline_lock(monkeypatch):
+    """The Batch API path must NOT acquire the inline lock — Google manages its
+    own throughput, so a held inline lock should not block a batch job."""
+    # Route any pending to the batch path.
+    monkeypatch.setattr(main, "BATCH_THRESHOLD", 0)
+
+    engine, label_id = _isolated_engine_with_pending("batchy")
+
+    def fake_batch(db, label, pending, yes_ex, no_ex):
+        return [], []
+
+    def fake_summary(*args, **kwargs):
+        return {"included": [], "excluded": []}
+
+    completed = threading.Event()
+
+    def run():
+        with Session(engine) as db:
+            label = db.get(LabelDefinition, label_id)
+            main._do_classification(db, label)
+        completed.set()
+
+    with patch("main._classify_via_batch_api", side_effect=fake_batch), \
+         patch("binary_autolabel_service.summarize_batch", side_effect=fake_summary):
+        # Hold the inline lock for the whole duration — a correctly-scoped gate
+        # leaves the batch path free to proceed.
+        with main._INLINE_CLASSIFY_LOCK:
+            t = threading.Thread(target=run)
+            t.start()
+            finished = completed.wait(timeout=3)
+            t.join(timeout=2)
+
+    assert finished, "batch classification blocked on the inline-only lock"
+
+
+# ─── Handoff ordering (handed_off_at) ─────────────────────────────────────
+
+
+def test_handoff_sets_handed_off_at(client, session):
+    """Initiating a handoff stamps handed_off_at so summaries can order by it."""
+    _seed(session)
+    a = client.post("/api/single-labels", json={"name": "help"}).json()
+    client.post(f"/api/single-labels/{a['id']}/activate")
+    _decide(client, a["id"], 300, 0, "yes")
+    _decide(client, a["id"], 300, 1, "no")
+
+    with patch("main._classify_in_background"):  # don't run the real bg task
+        r = client.post(f"/api/single-labels/{a['id']}/handoff")
+    assert r.status_code == 200
+
+    fresh = session.get(LabelDefinition, a["id"])
+    session.refresh(fresh)
+    assert fresh.handed_off_at is not None
+
+
+def test_handoff_summaries_ordered_by_handed_off_at_desc(client, session):
+    """Most-recently handed-off labels sort first."""
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    # Insert out of chronological order to prove the endpoint sorts, not insert-order.
+    specs = [
+        ("oldest", base),
+        ("newest", base + timedelta(hours=2)),
+        ("middle", base + timedelta(hours=1)),
+    ]
+    for name, ts in specs:
+        session.add(LabelDefinition(
+            name=name, mode="single", phase="handed_off", handed_off_at=ts,
+        ))
+    session.commit()
+
+    items = client.get("/api/handoff-summaries").json()
+    names = [it["label_name"] for it in items]
+    assert names == ["newest", "middle", "oldest"]
+
+
+def test_handoff_summaries_null_handed_off_at_sorts_last(client, session):
+    """Defensive: a handed-off label with no timestamp falls below stamped ones."""
+    session.add(LabelDefinition(
+        name="stamped", mode="single", phase="handed_off",
+        handed_off_at=datetime(2026, 1, 1, 12, 0, 0),
+    ))
+    session.add(LabelDefinition(name="unstamped", mode="single", phase="handed_off", handed_off_at=None))
+    session.commit()
+
+    items = client.get("/api/handoff-summaries").json()
+    names = [it["label_name"] for it in items]
+    assert names.index("stamped") < names.index("unstamped")
+
+
+def test_backfill_handed_off_at_uses_max_ai_row_time_else_created_at(engine, session):
+    """One-time migration backfill: handed-off single-labels get handed_off_at
+    from their most-recent AI row's created_at, falling back to the label's own
+    created_at when there are no AI rows. Other labels are left untouched."""
+    import database
+
+    t_created = datetime(2026, 1, 1, 9, 0, 0)
+    t_ai_old = datetime(2026, 1, 2, 9, 0, 0)
+    t_ai_new = datetime(2026, 1, 2, 15, 0, 0)
+
+    with_ai = LabelDefinition(name="with-ai", mode="single", phase="handed_off",
+                              created_at=t_created, handed_off_at=None)
+    no_ai = LabelDefinition(name="no-ai", mode="single", phase="failed",
+                            created_at=t_created, handed_off_at=None)
+    still_labeling = LabelDefinition(name="labeling", mode="single", phase="labeling",
+                                     created_at=t_created, handed_off_at=None)
+    multi = LabelDefinition(name="multi", mode="multi", phase="handed_off",
+                            created_at=t_created, handed_off_at=None)
+    session.add_all([with_ai, no_ai, still_labeling, multi])
+    session.commit()
+    session.refresh(with_ai)
+
+    # AI rows for `with_ai` — the max created_at should win.
+    session.add(LabelApplication(label_id=with_ai.id, chatlog_id=1, message_index=0,
+                                 applied_by="ai", value="yes", confidence=0.9, created_at=t_ai_old))
+    session.add(LabelApplication(label_id=with_ai.id, chatlog_id=1, message_index=1,
+                                 applied_by="ai", value="no", confidence=0.9, created_at=t_ai_new))
+    session.commit()
+
+    from sqlalchemy import text
+    with engine.connect() as conn:
+        database._backfill_handed_off_at(conn, text)
+        conn.commit()
+
+    session.expire_all()
+    assert session.get(LabelDefinition, with_ai.id).handed_off_at == t_ai_new
+    assert session.get(LabelDefinition, no_ai.id).handed_off_at == t_created  # fallback
+    assert session.get(LabelDefinition, still_labeling.id).handed_off_at is None  # wrong phase
+    assert session.get(LabelDefinition, multi.id).handed_off_at is None  # wrong mode

--- a/server/python/tests/test_handoff_flow.py
+++ b/server/python/tests/test_handoff_flow.py
@@ -1263,3 +1263,33 @@ def test_backfill_handed_off_at_uses_max_ai_row_time_else_created_at(engine, ses
     assert session.get(LabelDefinition, no_ai.id).handed_off_at == t_created  # fallback
     assert session.get(LabelDefinition, still_labeling.id).handed_off_at is None  # wrong phase
     assert session.get(LabelDefinition, multi.id).handed_off_at is None  # wrong mode
+
+
+# ─── Human decisions listing (undo-history seed) ──────────────────────────
+
+
+def test_get_human_decisions_returns_human_rows_in_order(client, session):
+    """GET /decisions feeds the frontend's undo-history seed: human decisions
+    only, in chronological order. AI rows are excluded."""
+    _seed(session)
+    a = _make_active_label(client)
+    _decide(client, a["id"], 300, 0, "yes")
+    _decide(client, a["id"], 300, 1, "no")
+    _decide(client, a["id"], 301, 0, "yes")
+    # An AI row must not appear in the undo seed.
+    session.add(LabelApplication(
+        label_id=a["id"], chatlog_id=301, message_index=1,
+        applied_by="ai", value="yes", confidence=0.9,
+    ))
+    session.commit()
+
+    rows = client.get(f"/api/single-labels/{a['id']}/decisions").json()
+    assert rows == [
+        {"chatlog_id": 300, "message_index": 0},
+        {"chatlog_id": 300, "message_index": 1},
+        {"chatlog_id": 301, "message_index": 0},
+    ]
+
+
+def test_get_human_decisions_404_for_missing_label(client, session):
+    assert client.get("/api/single-labels/99999/decisions").status_code == 404

--- a/server/python/tests/test_hybrid_sampling.py
+++ b/server/python/tests/test_hybrid_sampling.py
@@ -31,7 +31,7 @@ def test_select_next_always_baseline_when_explore_fraction_zero(session, monkeyp
         201: [(0, "a", None), (1, "b", None)],
         202: [(0, "c", None)],
     }
-    cid, mode = queue_service._select_next_chatlog_id(
+    cid, mode, _ = queue_service._select_next_chatlog_id(
         session,
         label_id=1,
         conv=conv,
@@ -53,7 +53,7 @@ def test_select_next_continue_when_multiple_in_progress(session, monkeypatch):
         203: [(0, "e", None)],
     }
     decided = {(201, 0), (202, 0)}
-    cid, mode = queue_service._select_next_chatlog_id(
+    cid, mode, _ = queue_service._select_next_chatlog_id(
         session,
         label_id=1,
         conv=conv,
@@ -74,7 +74,7 @@ def test_select_next_continue_when_single_in_progress(session):
         203: [(0, "d", None)],
     }
     decided = {(201, 0)}
-    cid, mode = queue_service._select_next_chatlog_id(
+    cid, mode, _ = queue_service._select_next_chatlog_id(
         session,
         label_id=1,
         conv=conv,
@@ -118,7 +118,7 @@ def test_select_next_explore_when_fraction_one(session, monkeypatch):
         return seq[0]
 
     monkeypatch.setattr(queue_service.random, "choice", _pick_one)
-    cid, mode = queue_service._select_next_chatlog_id(
+    cid, mode, _ = queue_service._select_next_chatlog_id(
         session,
         label_id=1,
         conv=conv,

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -129,4 +129,6 @@ def test_run_autolabel_applies_multiple_labels_and_gates(session, engine, monkey
     assert c.id not in by_label, "label-c (0.2) below threshold must NOT be applied"
     # Message index 1 got no entries -> stays unlabeled.
     assert all(app.chatlog_id == 1 for app in ai_apps), "only message 1 should be labeled"
+    for app in ai_apps:
+        assert app.confidence is not None and app.confidence >= 0.5
     assert main._autolabel_status["error"] is None

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -134,6 +134,27 @@ def test_run_autolabel_applies_multiple_labels_and_gates(session, engine, monkey
     assert main._autolabel_status["error"] is None
 
 
+def test_run_autolabel_skips_nonnumeric_confidence(session, engine, monkeypatch):
+    monkeypatch.setattr(main, "engine", engine)
+    monkeypatch.setattr(_als, "MULTILABEL_THRESHOLD", 0.5)
+
+    a = _make_label(session, "label-a")
+    _seed_msg(session, 1, 0, "lab01.ipynb", "msg one")
+
+    def fake_classify(label_defs, examples_by_label, messages, multi_select=False):
+        # Non-numeric confidence -> treated as below threshold, not persisted.
+        return [{"index": 0, "label": "label-a", "confidence": "not-a-number"}]
+
+    monkeypatch.setattr(_als, "classify_batch", fake_classify)
+    main._run_autolabel()
+
+    ai_apps = session.exec(
+        select(LabelApplication).where(LabelApplication.applied_by == "ai")
+    ).all()
+    assert ai_apps == [], "non-numeric confidence must not be persisted"
+    assert main._autolabel_status["error"] is None
+
+
 import inspect
 
 

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -27,8 +27,12 @@ def test_build_prompt_multi_select_wording():
     single = autolabel_service.build_prompt(label_defs, {}, messages, multi_select=False)
     multi = autolabel_service.build_prompt(label_defs, {}, messages, multi_select=True)
     assert "each message" in single
+    assert single != multi, "multi_select prompt must differ from single-select prompt"
     # Multi prompt must tell the model multiple/zero labels are allowed.
     assert "all that apply" in multi.lower() or "every label" in multi.lower()
+    assert "none" in multi.lower() or "omit" in multi.lower(), (
+        "multi prompt must state that zero labels (no match) is allowed"
+    )
 
 
 def test_classify_batch_uses_multi_config(monkeypatch):

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -68,3 +68,65 @@ def test_classify_batch_uses_multi_config(monkeypatch):
 
     autolabel_service.classify_batch(label_defs, {}, messages, multi_select=False)
     assert captured["config"] is autolabel_service.CONFIG
+
+
+from sqlmodel import select
+import main
+import autolabel_service as _als
+from models import LabelApplication, LabelDefinition, MessageCache
+
+
+def _make_label(session, name):
+    lbl = LabelDefinition(name=name, mode="multi", archived_at=None)
+    session.add(lbl)
+    session.commit()
+    session.refresh(lbl)
+    return lbl
+
+
+def _seed_msg(session, chatlog_id, message_index, notebook, text):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id,
+        message_index=message_index,
+        message_text=text,
+        notebook=notebook,
+    ))
+    session.commit()
+
+
+def test_run_autolabel_applies_multiple_labels_and_gates(session, engine, monkeypatch):
+    monkeypatch.setattr(main, "engine", engine)
+    monkeypatch.setattr(_als, "MULTILABEL_THRESHOLD", 0.5)
+
+    a = _make_label(session, "label-a")
+    b = _make_label(session, "label-b")
+    c = _make_label(session, "label-c")
+    _seed_msg(session, 1, 0, "lab01.ipynb", "msg one")
+    _seed_msg(session, 2, 0, "lab01.ipynb", "msg two")
+
+    multi_select_seen = {}
+
+    def fake_classify(label_defs, examples_by_label, messages, multi_select=False):
+        multi_select_seen["value"] = multi_select
+        # message index 0 -> two labels above threshold + one below; index 1 -> none
+        return [
+            {"index": 0, "label": "label-a", "confidence": 0.9},
+            {"index": 0, "label": "label-b", "confidence": 0.8},
+            {"index": 0, "label": "label-c", "confidence": 0.2},  # below threshold
+        ]
+
+    monkeypatch.setattr(_als, "classify_batch", fake_classify)
+    main._run_autolabel()
+
+    assert multi_select_seen["value"] is True, "general autolabel must call with multi_select=True"
+
+    ai_apps = session.exec(
+        select(LabelApplication).where(LabelApplication.applied_by == "ai")
+    ).all()
+    by_label = {app.label_id for app in ai_apps}
+    assert a.id in by_label, "label-a (0.9) should be applied"
+    assert b.id in by_label, "label-b (0.8) should be applied"
+    assert c.id not in by_label, "label-c (0.2) below threshold must NOT be applied"
+    # Message index 1 got no entries -> stays unlabeled.
+    assert all(app.chatlog_id == 1 for app in ai_apps), "only message 1 should be labeled"
+    assert main._autolabel_status["error"] is None

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -1,7 +1,4 @@
 """Tests for multi-label auto-labeling (multi_select + confidence threshold)."""
-from datetime import datetime
-from unittest.mock import patch
-
 import autolabel_service
 
 
@@ -18,6 +15,7 @@ def test_multilabel_threshold_env_override(monkeypatch):
     import importlib
     importlib.reload(autolabel_service)
     assert autolabel_service.MULTILABEL_THRESHOLD == 0.3
-    # Restore default so later tests are not affected by the reloaded module.
+    # monkeypatch restores the env on teardown but can't un-reload the module;
+    # reload with the var absent so MULTILABEL_THRESHOLD resets for later tests.
     monkeypatch.delenv("CHATSIGHT_MULTILABEL_THRESHOLD", raising=False)
     importlib.reload(autolabel_service)

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -1,0 +1,23 @@
+"""Tests for multi-label auto-labeling (multi_select + confidence threshold)."""
+from datetime import datetime
+from unittest.mock import patch
+
+import autolabel_service
+
+
+def test_multilabel_threshold_default_is_half(monkeypatch):
+    monkeypatch.delenv("CHATSIGHT_MULTILABEL_THRESHOLD", raising=False)
+    # Re-read the env the same way the module does at import.
+    import importlib
+    importlib.reload(autolabel_service)
+    assert autolabel_service.MULTILABEL_THRESHOLD == 0.5
+
+
+def test_multilabel_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("CHATSIGHT_MULTILABEL_THRESHOLD", "0.3")
+    import importlib
+    importlib.reload(autolabel_service)
+    assert autolabel_service.MULTILABEL_THRESHOLD == 0.3
+    # Restore default so later tests are not affected by the reloaded module.
+    monkeypatch.delenv("CHATSIGHT_MULTILABEL_THRESHOLD", raising=False)
+    importlib.reload(autolabel_service)

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -132,3 +132,16 @@ def test_run_autolabel_applies_multiple_labels_and_gates(session, engine, monkey
     for app in ai_apps:
         assert app.confidence is not None and app.confidence >= 0.5
     assert main._autolabel_status["error"] is None
+
+
+import inspect
+
+
+def test_split_flow_calls_classify_batch_single_select():
+    """The label-split background function must NOT pass multi_select=True;
+    splits are a 1-of-2 partition and must keep exactly-one-label semantics.
+    Only the general autolabel flow (_run_autolabel) opts into multi_select."""
+    src = inspect.getsource(main)
+    assert src.count("multi_select=True") == 1, (
+        "Exactly one call site (the general autolabel) should pass multi_select=True"
+    )

--- a/server/python/tests/test_multilabel_autolabel.py
+++ b/server/python/tests/test_multilabel_autolabel.py
@@ -19,3 +19,48 @@ def test_multilabel_threshold_env_override(monkeypatch):
     # reload with the var absent so MULTILABEL_THRESHOLD resets for later tests.
     monkeypatch.delenv("CHATSIGHT_MULTILABEL_THRESHOLD", raising=False)
     importlib.reload(autolabel_service)
+
+
+def test_build_prompt_multi_select_wording():
+    label_defs = [{"name": "confused", "description": "student is confused"}]
+    messages = [{"message_text": "I don't get it", "message_index": 0, "chatlog_id": 1}]
+    single = autolabel_service.build_prompt(label_defs, {}, messages, multi_select=False)
+    multi = autolabel_service.build_prompt(label_defs, {}, messages, multi_select=True)
+    assert "each message" in single
+    # Multi prompt must tell the model multiple/zero labels are allowed.
+    assert "all that apply" in multi.lower() or "every label" in multi.lower()
+
+
+def test_classify_batch_uses_multi_config(monkeypatch):
+    captured = {}
+
+    class _FakeFn:
+        name = "classify_messages"
+        args = {"classifications": [{"index": 0, "label": "confused", "confidence": 0.9}]}
+
+    class _FakePart:
+        function_call = _FakeFn()
+
+    class _FakeContent:
+        parts = [_FakePart()]
+
+    class _FakeCandidate:
+        content = _FakeContent()
+
+    class _FakeResp:
+        candidates = [_FakeCandidate()]
+
+    def fake_generate(model, contents, config):
+        captured["config"] = config
+        return _FakeResp()
+
+    monkeypatch.setattr(autolabel_service.client.models, "generate_content", fake_generate)
+
+    label_defs = [{"name": "confused", "description": ""}]
+    messages = [{"message_text": "huh", "message_index": 0, "chatlog_id": 1}]
+
+    autolabel_service.classify_batch(label_defs, {}, messages, multi_select=True)
+    assert captured["config"] is autolabel_service.MULTI_SELECT_CONFIG
+
+    autolabel_service.classify_batch(label_defs, {}, messages, multi_select=False)
+    assert captured["config"] is autolabel_service.CONFIG

--- a/server/python/tests/test_name_suggestions.py
+++ b/server/python/tests/test_name_suggestions.py
@@ -1,0 +1,79 @@
+import math
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _emb(values):
+    e = MagicMock()
+    e.values = values
+    return e
+
+
+def _mock_embed(*batches):
+    """Return a mock embed_content that yields embeddings from `batches` in order."""
+    responses = []
+    for vecs in batches:
+        r = MagicMock()
+        r.embeddings = [_emb(v) for v in vecs]
+        responses.append(r)
+    m = MagicMock(side_effect=responses)
+    return m
+
+
+# ── _cosine_sim ──────────────────────────────────────────────────────────────
+
+def test_cosine_sim_identical_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_sim_orthogonal_vectors():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0]) == pytest.approx(0.0)
+
+
+def test_cosine_sim_zero_vector_returns_zero():
+    from name_suggestion_service import _cosine_sim
+    assert _cosine_sim([0.0, 0.0, 0.0], [1.0, 0.0, 0.0]) == 0.0
+
+
+# ── filter_suggestions ───────────────────────────────────────────────────────
+
+def test_filter_removes_synonym(monkeypatch):
+    """'puzzled' should be filtered when 'confusion' exists (cos_sim ≈ 0.99 > 0.75)."""
+    import name_suggestion_service as svc
+
+    # candidates: ["puzzled", "code syntax help"], existing: ["confusion"]
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        result = svc.filter_suggestions(
+            candidate_names=["puzzled", "code syntax help"],
+            candidate_descriptions=["lost student", "syntax questions"],
+            existing_names=["confusion"],
+        )
+
+    names = [r["name"] for r in result]
+    assert "puzzled" not in names          # cos([0.99,0.14,0],[1,0,0]) ≈ 0.99 > 0.75
+    assert "code syntax help" in names     # cos([0,0,1],[1,0,0]) = 0.0 < 0.75
+
+
+def test_filter_returns_all_when_no_existing_labels():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=["error tracing"],
+        candidate_descriptions=["tracing errors"],
+        existing_names=[],
+    )
+    assert result == [{"name": "error tracing", "description": "tracing errors"}]
+
+
+def test_filter_returns_empty_when_no_candidates():
+    import name_suggestion_service as svc
+    result = svc.filter_suggestions(
+        candidate_names=[],
+        candidate_descriptions=[],
+        existing_names=["confusion"],
+    )
+    assert result == []

--- a/server/python/tests/test_name_suggestions.py
+++ b/server/python/tests/test_name_suggestions.py
@@ -1,4 +1,3 @@
-import math
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -61,12 +60,33 @@ def test_filter_removes_synonym(monkeypatch):
 
 def test_filter_returns_all_when_no_existing_labels():
     import name_suggestion_service as svc
-    result = svc.filter_suggestions(
-        candidate_names=["error tracing"],
-        candidate_descriptions=["tracing errors"],
-        existing_names=[],
-    )
+    with patch.object(svc.client.models, "embed_content") as mock_embed:
+        result = svc.filter_suggestions(
+            candidate_names=["error tracing"],
+            candidate_descriptions=["tracing errors"],
+            existing_names=[],
+        )
     assert result == [{"name": "error tracing", "description": "tracing errors"}]
+    mock_embed.assert_not_called()
+
+
+def test_filter_keeps_candidate_at_exact_threshold(monkeypatch):
+    """Candidate with sim == 0.75 must be kept (threshold is strictly >)."""
+    import math
+    import name_suggestion_service as svc
+
+    # cos_sim(a, b) = 0.75 when a=[0.75, sqrt(1-0.75^2), 0], b=[1,0,0]
+    a = [0.75, math.sqrt(1 - 0.75**2), 0.0]
+    b = [1.0, 0.0, 0.0]
+
+    mock = _mock_embed([a, b])
+    with patch.object(svc.client.models, "embed_content", mock):
+        result = svc.filter_suggestions(
+            candidate_names=["borderline"],
+            candidate_descriptions=["exactly at threshold"],
+            existing_names=["existing"],
+        )
+    assert result == [{"name": "borderline", "description": "exactly at threshold"}]
 
 
 def test_filter_returns_empty_when_no_candidates():

--- a/server/python/tests/test_name_suggestions.py
+++ b/server/python/tests/test_name_suggestions.py
@@ -97,3 +97,56 @@ def test_filter_returns_empty_when_no_candidates():
         existing_names=["confusion"],
     )
     assert result == []
+
+
+# ── endpoint ─────────────────────────────────────────────────────────────────
+
+def test_endpoint_returns_empty_when_no_candidates(client):
+    resp = client.get("/api/concepts/name-suggestions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_endpoint_filters_and_returns_suggestions(client, session):
+    from models import LabelDefinition, ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(LabelDefinition(name="confusion", mode="single", description=""))
+    session.add(ConceptCandidate(
+        name="puzzled", description="student seems lost",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.add(ConceptCandidate(
+        name="code syntax help", description="syntax questions",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    mock = _mock_embed(
+        [[0.99, 0.14, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+    )
+    with patch.object(svc.client.models, "embed_content", mock):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    names = [s["name"] for s in resp.json()]
+    assert "puzzled" not in names
+    assert "code syntax help" in names
+
+
+def test_endpoint_returns_empty_on_gemini_error(client, session):
+    from models import LabelDefinition, ConceptCandidate
+    import name_suggestion_service as svc
+
+    session.add(LabelDefinition(name="existing label", mode="single", description=""))
+    session.add(ConceptCandidate(
+        name="scope clarification", description="...",
+        status="pending", source_run_id="r1", example_messages="[]",
+    ))
+    session.commit()
+
+    with patch.object(svc.client.models, "embed_content", side_effect=Exception("network")):
+        resp = client.get("/api/concepts/name-suggestions")
+
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/server/python/tests/test_single_label_run_detail.py
+++ b/server/python/tests/test_single_label_run_detail.py
@@ -164,6 +164,27 @@ def test_run_detail_ai_coverage(client, session):
     assert cov == {"covered": 3, "total": 10, "pct": 30}
 
 
+def test_run_detail_ai_coverage_total_is_study_scoped(client, session, monkeypatch):
+    """The coverage denominator must be the in-scope study sample (Week 8 for
+    single-label runs), not the entire MessageCache. Regression: `total` counted
+    every cached message across all weeks, so coverage of the scoped sample read
+    as a tiny fraction (e.g. 3326/30102 = 11%) instead of ~100%."""
+    monkeypatch.setenv("CHATSIGHT_STUDY_LOCK", "1")
+    rid = _make_run(session)
+    # 4 in-scope (Week 8 = Lab 5) + 6 out-of-scope (Week 3 = Lab 1) = 10 cached.
+    for i in range(4):
+        session.add(MessageCache(chatlog_id=1, message_index=i, message_text=f"m{i}", notebook="lab5.ipynb"))
+    for i in range(6):
+        session.add(MessageCache(chatlog_id=2, message_index=i, message_text=f"o{i}", notebook="lab1.ipynb"))
+    session.commit()
+    # AI classified 2 of the in-scope messages.
+    _add(session, rid, 1, 0, "yes", applied_by="ai", confidence=0.9)
+    _add(session, rid, 1, 1, "no", applied_by="ai", confidence=0.8)
+
+    cov = client.get(f"/api/analysis/single-label/runs/{rid}").json()["ai_coverage"]
+    assert cov == {"covered": 2, "total": 4, "pct": 50}
+
+
 def test_run_detail_examples_capped_at_8(client, session):
     rid = _make_run(session)
     # 20 yes humans

--- a/server/python/tests/test_single_labels.py
+++ b/server/python/tests/test_single_labels.py
@@ -120,6 +120,24 @@ def test_list_messages_filter_review(client, session):
     assert len(items) == 2  # _seed_label_with_rows creates 2 review-bucket rows
 
 
+def test_list_messages_includes_skip_verdict(client, session):
+    """Skipped human decisions (value='skip') must not 500 the listing endpoint.
+
+    Regression: MessageListItem.verdict only allowed yes/no/review, so a
+    'skip' row raised a pydantic ValidationError → 500.
+    """
+    label = _seed_label_with_rows(session, yes=0, no=0, review=0, human_gold=0)
+    session.add(LabelApplication(
+        label_id=label.id, chatlog_id=9000, message_index=0,
+        applied_by="human", value="skip",
+    ))
+    session.commit()
+    r = client.get(f"/api/single-labels/{label.id}/messages?limit=200")
+    assert r.status_code == 200, r.text
+    verdicts = [it["verdict"] for it in r.json()["items"]]
+    assert "skip" in verdicts
+
+
 def test_list_messages_pagination(client, session):
     label = _seed_label_with_rows(session, yes=30, no=0, review=0, human_gold=0)
     r = client.get(f"/api/single-labels/{label.id}/messages?offset=10&limit=10")

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -1,7 +1,16 @@
+import pytest
+
 import study_scope
 import queue_service
 import decision_service
 from models import MessageCache, LabelDefinition
+
+
+@pytest.fixture(autouse=True)
+def _force_study_lock(monkeypatch):
+    """These tests validate the lock itself, so force it ON regardless of the
+    suite-wide default set in conftest."""
+    monkeypatch.setenv("CHATSIGHT_STUDY_LOCK", "1")
 
 
 def _seed(session, chatlog_id, message_index, notebook):
@@ -69,3 +78,36 @@ def test_run_next_returns_only_week8(session):
             picks.add(payload["chatlog_id"])
     assert picks <= {10}
     assert 11 not in picks
+
+
+def test_readiness_total_convs_scoped_to_week8(session):
+    _seed(session, 20, 0, "lab5.ipynb")   # Week 8
+    _seed(session, 21, 0, "lab1.ipynb")   # Week 3
+    _seed(session, 22, 0, "lab2.ipynb")   # other
+    label = LabelDefinition(name="x", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+    state = decision_service.compute_readiness(session, label.id)
+    assert state["total_conversations"] == 1
+
+
+def test_classification_pending_excludes_out_of_scope(session, monkeypatch):
+    import main
+    _seed(session, 30, 0, "lab5.ipynb")   # Week 8 — should be classified
+    _seed(session, 31, 0, "lab1.ipynb")   # Week 3 — must be skipped
+    label = LabelDefinition(name="y", mode="single", phase="labeling",
+                            review_threshold=0.5)
+    session.add(label)
+    session.commit()
+
+    captured = {}
+
+    def fake_parallel(db, label, pending, yes_examples, no_examples):
+        captured["pending"] = pending
+        return ([], [])
+
+    monkeypatch.setattr(main, "_classify_in_parallel", fake_parallel)
+    main._do_classification(session, label)
+    keys = {(c, i) for (c, i, _t) in captured["pending"]}
+    assert (30, 0) in keys
+    assert (31, 0) not in keys

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -1,0 +1,34 @@
+import study_scope
+from models import MessageCache
+
+
+def _seed(session, chatlog_id, message_index, notebook):
+    session.add(MessageCache(
+        chatlog_id=chatlog_id, message_index=message_index,
+        message_text=f"msg {chatlog_id}.{message_index}", notebook=notebook,
+    ))
+    session.commit()
+
+
+def test_queue_scope_matches_week3_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab1.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("lab01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw01.ipynb", study_scope.QUEUE_SCOPE)
+    assert study_scope.notebook_in_scope("hw1.ipynb", study_scope.QUEUE_SCOPE)
+
+
+def test_run_scope_matches_week8_lab_and_hw():
+    assert study_scope.notebook_in_scope("lab5.ipynb", study_scope.RUN_SCOPE)
+    assert study_scope.notebook_in_scope("hw05.ipynb", study_scope.RUN_SCOPE)
+
+
+def test_out_of_scope_and_none():
+    assert not study_scope.notebook_in_scope("lab2.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab15.ipynb", study_scope.QUEUE_SCOPE)
+    assert not study_scope.notebook_in_scope("lab1.ipynb", study_scope.RUN_SCOPE)
+    assert not study_scope.notebook_in_scope(None, study_scope.QUEUE_SCOPE)
+
+
+def test_scope_for_mode():
+    assert study_scope.scope_for_mode("single") == study_scope.RUN_SCOPE
+    assert study_scope.scope_for_mode("multi") == study_scope.QUEUE_SCOPE

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -32,3 +32,21 @@ def test_out_of_scope_and_none():
 def test_scope_for_mode():
     assert study_scope.scope_for_mode("single") == study_scope.RUN_SCOPE
     assert study_scope.scope_for_mode("multi") == study_scope.QUEUE_SCOPE
+
+
+def test_queue_returns_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")   # in scope (Week 3)
+    _seed(session, 2, 0, "lab5.ipynb")   # out of scope (Week 8)
+    _seed(session, 3, 0, "lab2.ipynb")   # out of scope
+    resp = client.get("/api/queue?limit=50")
+    assert resp.status_code == 200
+    ids = {row["chatlog_id"] for row in resp.json()}
+    assert ids == {1}
+
+
+def test_queue_stats_counts_only_week3(client, session):
+    _seed(session, 1, 0, "lab1.ipynb")
+    _seed(session, 2, 0, "hw1.ipynb")
+    _seed(session, 3, 0, "lab5.ipynb")
+    stats = client.get("/api/queue/stats").json()
+    assert stats["total_messages"] == 2

--- a/server/python/tests/test_study_scope.py
+++ b/server/python/tests/test_study_scope.py
@@ -1,5 +1,7 @@
 import study_scope
-from models import MessageCache
+import queue_service
+import decision_service
+from models import MessageCache, LabelDefinition
 
 
 def _seed(session, chatlog_id, message_index, notebook):
@@ -50,3 +52,20 @@ def test_queue_stats_counts_only_week3(client, session):
     _seed(session, 3, 0, "lab5.ipynb")
     stats = client.get("/api/queue/stats").json()
     assert stats["total_messages"] == 2
+
+
+def test_run_next_returns_only_week8(session):
+    # Seed an in-scope (Week 8) and an out-of-scope conversation.
+    _seed(session, 10, 0, "lab5.ipynb")   # Week 8 — in scope for single mode
+    _seed(session, 11, 0, "lab1.ipynb")   # Week 3 — out of scope for single mode
+    label = LabelDefinition(name="needs help", mode="single", phase="labeling")
+    session.add(label)
+    session.commit()
+
+    picks = set()
+    for _ in range(10):
+        payload = queue_service.next_message_for_label(session, label.id)
+        if payload:
+            picks.add(payload["chatlog_id"])
+    assert picks <= {10}
+    assert 11 not in picks

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -27,7 +27,6 @@ export function Navigation() {
     mode === 'single'
       ? [
           labelingLink,
-          { to: '/assignments', label: 'Assignments' },
           { to: '/summaries', label: 'Summaries' },
           { to: '/analysis', label: 'Analysis' },
         ]
@@ -35,7 +34,6 @@ export function Navigation() {
           labelingLink,
           { to: '/history', label: 'History' },
           { to: '/labels', label: 'Labels' },
-          { to: '/assignments', label: 'Assignments' },
           { to: '/summaries', label: 'Summaries' },
           { to: '/analysis', label: 'Analysis' },
         ]

--- a/src/components/decision/DecisionWorkspace.tsx
+++ b/src/components/decision/DecisionWorkspace.tsx
@@ -67,8 +67,12 @@ export function DecisionWorkspace({
         h.onSkip?.()
       } else if (pressedKey === k.undo) {
         h.onUndo?.()
-      } else if (pressedKey === 'enter' || rawKey === 'enter') {
-        h.onAcceptAi?.()
+      } else if (rawKey === 'enter') {
+        if (h.onAcceptAi) {
+          h.onAcceptAi()
+        } else {
+          h.onSkip?.()
+        }
       }
     }
     window.addEventListener('keydown', onKey)

--- a/src/components/decision/KeybindSettingsModal.tsx
+++ b/src/components/decision/KeybindSettingsModal.tsx
@@ -41,6 +41,13 @@ export function KeybindSettingsModal({ open, onClose }: KeybindSettingsModalProp
 
   const formatKey = (key: string) => {
     if (key === ' ') return 'Space'
+    if (key === 'arrowleft') return '← Left'
+    if (key === 'arrowright') return '→ Right'
+    if (key === 'arrowup') return '↑ Up'
+    if (key === 'arrowdown') return '↓ Down'
+    if (key === 'enter') return 'Enter'
+    if (key === 'backspace') return 'Backspace'
+    if (key === 'escape') return 'Escape'
     if (key.length === 1) return key.toUpperCase()
     return key
   }

--- a/src/components/queue/MessageCard.tsx
+++ b/src/components/queue/MessageCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
@@ -10,6 +10,19 @@ import type {
 	ConversationMessage,
 } from "../../types";
 import { ConversationPanel } from "./ConversationPanel";
+import { useKeybinds } from "../../hooks/useKeybinds";
+
+function fmtKey(key: string): string {
+	if (key === " ") return "Space";
+	if (key === "arrowleft") return "←";
+	if (key === "arrowright") return "→";
+	if (key === "arrowup") return "↑";
+	if (key === "arrowdown") return "↓";
+	if (key === "enter") return "↵";
+	if (key === "backspace") return "⌫";
+	if (key === "escape") return "Esc";
+	return key.toUpperCase();
+}
 
 function stripMarkdown(md: string): string {
 	return md
@@ -106,6 +119,7 @@ export function MessageCard({
 	onCreateLabelForMessage,
 	tutorialDisabled = false,
 }: Props) {
+	const { keybinds } = useKeybinds();
 	const [showRationale, setShowRationale] = useState(false);
 	const [beforeExpanded, setBeforeExpanded] = useState(false);
 	const [afterExpanded, setAfterExpanded] = useState(false);
@@ -177,14 +191,14 @@ export function MessageCard({
 								onToggleConversation?.()
 							}
 							disabled={conversationLoading || conversationError}
-							className={`flex items-center gap-1 text-[9px] transition-colors ${
+							className={`flex items-center gap-1.5 text-[11px] font-semibold border rounded px-2 py-1 transition-colors ${
 								conversationLoading
-									? "text-disabled cursor-default"
+									? "text-disabled border-edge cursor-default"
 									: conversationError
-										? "text-faint cursor-default"
+										? "text-faint border-edge cursor-default"
 										: showConversation
-											? "text-ochre hover:text-paper"
-											: "text-muted hover:text-ochre"
+											? "text-ochre border-ochre hover:text-paper hover:border-paper"
+											: "text-ochre border-ochre/50 hover:border-ochre"
 							}`}
 							title={
 								conversationError
@@ -192,7 +206,7 @@ export function MessageCard({
 									: "View full conversation"
 							}
 						>
-							<MessageSquare size={11} />
+							<MessageSquare size={13} />
 							<span>
 								{conversationError
 									? "Conversation unavailable"
@@ -256,7 +270,7 @@ export function MessageCard({
 						</span>
 					) : !aiUnlocked ? (
 						<span className="text-[8px] text-disabled bg-surface border border-edge-subtle rounded px-1.5 py-0.5">
-							AI unlocks at 20
+							AI unlocks at 10
 						</span>
 					) : null}
 				</div>
@@ -331,34 +345,40 @@ export function MessageCard({
 						{!isReviewing && !isRecalibrating && canGoBack && (
 							<button
 								onClick={onBack}
-								className="font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors"
+								className="font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors inline-flex items-center gap-1.5"
+								title={`Go back (${fmtKey(keybinds.undo)})`}
 							>
 								← Back
+								<Kbd>{fmtKey(keybinds.undo)}</Kbd>
 							</button>
 						)}
 						{!isReviewing && !isRecalibrating && (
 							<button
 								onClick={onSkip}
 								disabled={tutorialDisabled}
-								className={`font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors ${tutorialDisabled ? 'opacity-50 pointer-events-none' : ''}`}
+								className={`font-serif text-xs text-muted border border-edge rounded px-3 py-1.5 hover:text-on-surface hover:border-edge-strong transition-colors inline-flex items-center gap-1.5 ${tutorialDisabled ? 'opacity-50 pointer-events-none' : ''}`}
+								title={`Skip this message (${fmtKey(keybinds.skip)})`}
 							>
 								Skip
+								<Kbd>{fmtKey(keybinds.skip)}</Kbd>
 							</button>
 						)}
 						<button
 							onClick={onNext}
 							disabled={(!isReviewing && !isRecalibrating && !hasLabelsApplied) || tutorialDisabled}
-							className={`font-serif text-xs rounded-sm px-3 py-1.5 disabled:opacity-40 disabled:cursor-not-allowed transition-all ${
+							className={`font-serif text-xs rounded-sm px-3 py-1.5 disabled:opacity-40 disabled:cursor-not-allowed transition-all inline-flex items-center gap-1.5 ${
 								isRecalibrating
 									? recalibrationPhase === 'reconcile'
 										? 'border border-warning bg-warning text-bg-warm hover:brightness-110'
 										: 'border border-ochre bg-ochre text-bg-warm hover:brightness-110'
 									: 'border border-ochre bg-ochre text-bg-warm hover:brightness-110'
 							}`}
+							title={isReviewing ? undefined : `Next message (${fmtKey(keybinds.yes)} or ↵)`}
 						>
 							{isReviewing ? "Back to queue" : isRecalibrating
 								? recalibrationPhase === 'reconcile' ? 'Confirm →' : 'Next →'
 								: "Next →"}
+							{!isReviewing && <Kbd className="opacity-70">{fmtKey(keybinds.yes)}</Kbd>}
 						</button>
 					</>
 				)}
@@ -379,5 +399,13 @@ export function MessageCard({
 					/>
 				)}
 		</div>
+	);
+}
+
+function Kbd({ children, className }: { children: React.ReactNode; className?: string }) {
+	return (
+		<span className={`font-mono text-[9px] border border-current/30 rounded px-[3px] py-px opacity-60 ${className ?? ''}`}>
+			{children}
+		</span>
 	);
 }

--- a/src/components/queue/NewLabelPopover.tsx
+++ b/src/components/queue/NewLabelPopover.tsx
@@ -20,6 +20,7 @@ export function NewLabelPopover({ onConfirm, onCancel }: Props) {
       <p className="font-serif text-xs text-paper mb-2">New label</p>
       <input
         autoFocus
+        autoComplete="off"
         value={name}
         onChange={e => setName(e.target.value)}
         onKeyDown={e => e.key === 'Enter' && handleConfirm()}

--- a/src/components/queue/NewLabelPopover.tsx
+++ b/src/components/queue/NewLabelPopover.tsx
@@ -20,7 +20,7 @@ export function NewLabelPopover({ onConfirm, onCancel }: Props) {
       <p className="font-serif text-xs text-paper mb-2">New label</p>
       <input
         autoFocus
-        autoComplete="off"
+        autoComplete="new-password"
         value={name}
         onChange={e => setName(e.target.value)}
         onKeyDown={e => e.key === 'Enter' && handleConfirm()}

--- a/src/components/queue/ProgressSidebar.tsx
+++ b/src/components/queue/ProgressSidebar.tsx
@@ -26,6 +26,8 @@ interface Props {
   onCreateAndApply: (name: string, description?: string) => void
   onUpdateLabel: (id: number, body: UpdateLabelRequest) => void
   onStartAutolabel: () => void
+  onClearAutolabel: () => void
+  onStopAutolabel: () => void
   autolabelStatus: AutolabelStatus | null
   remaining: number | null
   history: HistoryItem[]
@@ -154,7 +156,7 @@ function SortableLabelItem({
 export function ProgressSidebar({
   session: _session, labels, stats, skippedCount,
   appliedLabelIds, onToggleLabel, onCreateAndApply, onUpdateLabel,
-  onStartAutolabel, autolabelStatus, remaining, history, onSelectHistoryItem, reviewingKey, onReorderLabels,
+  onStartAutolabel, onClearAutolabel, onStopAutolabel, autolabelStatus, remaining, history, onSelectHistoryItem, reviewingKey, onReorderLabels,
   onDeleteLabel, candidates, onDiscover, onOpenDiscoverModal, discovering,
   recalibration, recalibrationStats,
   tutorialDisabled = false,
@@ -196,7 +198,7 @@ export function ProgressSidebar({
   const suggestPct = Math.min(100, Math.round((labeled / suggestThreshold) * 100))
   const suggestUnlocked = labeled >= suggestThreshold
 
-  const autolabelThreshold = Math.min(Math.ceil(total * 0.3), 20)
+  const autolabelThreshold = 25
   const autolabelPct = autolabelThreshold > 0 ? Math.min(100, Math.round((labeled / autolabelThreshold) * 100)) : 0
   const autolabelUnlocked = labeled >= autolabelThreshold && autolabelThreshold > 0
 
@@ -250,8 +252,9 @@ export function ProgressSidebar({
   }, [labels, onReorderLabels])
 
   return (
-    <aside className="w-52 shrink-0 border-r border-edge bg-canvas p-4 flex flex-col h-full min-h-0 gap-5">
-      <div className="shrink-0">
+    <aside className="w-52 shrink-0 border-r border-edge bg-canvas flex flex-col h-full min-h-0">
+      {/* Labeled — always pinned at top */}
+      <div className="shrink-0 p-4 pb-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-faint mb-2">Labeled</p>
         <div className="h-1.5 bg-elevated rounded-sm mb-1.5">
           <div className="h-1.5 bg-ochre rounded-sm transition-all" style={{ width: `${pct}%` }} />
@@ -265,7 +268,10 @@ export function ProgressSidebar({
         )}
       </div>
 
-      <div className="shrink-0 flex flex-col gap-3" data-tutorial="ai-milestones">
+      {/* Everything below scrolls as one unit */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-4 flex flex-col gap-5 [scrollbar-color:theme(colors.neutral.600)_transparent]">
+
+      <div className="flex flex-col gap-3" data-tutorial="ai-milestones">
         <div>
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-faint mb-1.5">AI suggestions</p>
           {suggestUnlocked ? (
@@ -283,24 +289,49 @@ export function ProgressSidebar({
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-faint mb-1.5">Auto-labeling</p>
           {autolabelStatus?.running ? (
             <>
-              <div className="h-1 bg-elevated rounded-full mb-1">
-                <div
-                  className="h-1 bg-ochre rounded-full transition-all"
-                  style={{ width: `${autolabelStatus.total > 0 ? Math.round((autolabelStatus.processed / autolabelStatus.total) * 100) : 0}%` }}
-                />
+              <div className="h-1 bg-elevated rounded-full mb-1 overflow-hidden">
+                {autolabelStatus.total > 0 && autolabelStatus.processed > 0 ? (
+                  <div
+                    className="h-1 bg-ochre rounded-full transition-all duration-500"
+                    style={{ width: `${Math.round((autolabelStatus.processed / autolabelStatus.total) * 100)}%` }}
+                  />
+                ) : (
+                  <div className="h-1 bg-ochre rounded-full w-full animate-pulse" />
+                )}
               </div>
-              <p className="text-[10px] text-ochre">
-                Labeling... {autolabelStatus.processed.toLocaleString()} / {autolabelStatus.total.toLocaleString()}
-              </p>
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[10px] text-ochre flex items-center gap-1">
+                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-ochre animate-ping shrink-0" />
+                  {autolabelStatus.total > 0
+                    ? `Labeling… ${autolabelStatus.processed.toLocaleString()} / ${autolabelStatus.total.toLocaleString()}`
+                    : 'Starting…'}
+                </p>
+                <button
+                  onClick={onStopAutolabel}
+                  title="Stop after current batch — saves progress"
+                  className="font-mono text-[9px] border border-edge text-faint rounded-sm px-1.5 py-0.5 hover:border-brick hover:text-brick transition-colors shrink-0"
+                >
+                  Stop
+                </button>
+              </div>
             </>
           ) : autolabelUnlocked ? (
             <>
-              <button
-                onClick={onStartAutolabel}
-                className="w-full font-mono text-[10px] border border-ochre bg-ochre text-bg-warm rounded-sm px-2 py-1.5 hover:brightness-110 transition-all"
-              >
-                Auto-label {(total - labeled).toLocaleString()} remaining
-              </button>
+              <div className="flex gap-1">
+                <button
+                  onClick={onStartAutolabel}
+                  className="flex-1 font-mono text-[10px] border border-ochre bg-ochre text-bg-warm rounded-sm px-2 py-1.5 hover:brightness-110 transition-all"
+                >
+                  Auto-label {(total - labeled).toLocaleString()} remaining
+                </button>
+                <button
+                  onClick={onClearAutolabel}
+                  title="Delete all AI-applied labels (reset for re-testing)"
+                  className="font-mono text-[10px] border border-edge text-faint rounded-sm px-2 py-1.5 hover:border-brick hover:text-brick transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
               {autolabelStatus?.error && (
                 <p className="text-[10px] text-danger-text mt-1">{autolabelStatus.error}</p>
               )}
@@ -327,14 +358,14 @@ export function ProgressSidebar({
         />
       </div>
 
-      <div className="flex-1 min-h-0 flex flex-col overflow-hidden" data-tutorial="label-list">
+      <div data-tutorial="label-list">
         <p className="text-[10px] uppercase tracking-widest text-faint mb-2">
           {recalibration?.phase === 'reconcile' ? 'Reconcile Labels' : 'Labels'}
         </p>
         {recalibration?.phase === 'reconcile' && (
           <p className="text-[10px] text-disabled mb-2">Toggle with 1-9 keys, {formatKey(keybinds.yes)} to confirm</p>
         )}
-        <div className="flex flex-col gap-1.5 overflow-y-auto flex-1 min-h-0">
+        <div className="flex flex-col gap-1.5">
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={labels.map(l => l.id)} strategy={verticalListSortingStrategy}>
               {labels.map((label, idx) => {
@@ -404,7 +435,7 @@ export function ProgressSidebar({
         </div>
       </div>
 
-      <div className="shrink-0 flex flex-col gap-3">
+      <div className="flex flex-col gap-3">
         <RecentHistory items={history} onSelect={onSelectHistoryItem} reviewingKey={reviewingKey} />
         {recalibrationStats && recalibrationStats.total_recalibrations > 0 && (
           <div className="border-t border-edge-subtle pt-3">
@@ -447,6 +478,7 @@ export function ProgressSidebar({
         </div>
         )}
       </div>
+      </div>{/* end scrollable area */}
       {contextMenu && (
         <LabelContextMenu
           x={contextMenu.x}

--- a/src/components/queue/ProgressSidebar.tsx
+++ b/src/components/queue/ProgressSidebar.tsx
@@ -191,11 +191,12 @@ export function ProgressSidebar({
   const total = stats?.total_messages ?? 0
   const pct = total > 0 ? Math.round((labeled / total) * 100) : 0
 
-  const suggestThreshold = 20
+  // Thresholds lowered for the week-scoped study build (small Week-3 pool).
+  const suggestThreshold = 10
   const suggestPct = Math.min(100, Math.round((labeled / suggestThreshold) * 100))
   const suggestUnlocked = labeled >= suggestThreshold
 
-  const autolabelThreshold = Math.min(Math.ceil(total * 0.4), 100)
+  const autolabelThreshold = Math.min(Math.ceil(total * 0.3), 20)
   const autolabelPct = autolabelThreshold > 0 ? Math.min(100, Math.round((labeled / autolabelThreshold) * 100)) : 0
   const autolabelUnlocked = labeled >= autolabelThreshold && autolabelThreshold > 0
 
@@ -318,7 +319,7 @@ export function ProgressSidebar({
       <div className="shrink-0">
         <DiscoverSection
           candidates={candidates}
-          aiUnlocked={(stats?.labeled_count ?? 0) >= 20}
+          aiUnlocked={(stats?.labeled_count ?? 0) >= 10}
           labeledCount={stats?.labeled_count ?? 0}
           onDiscover={onDiscover}
           onOpenModal={onOpenDiscoverModal}

--- a/src/components/run/DecisionDock.tsx
+++ b/src/components/run/DecisionDock.tsx
@@ -38,6 +38,13 @@ export function DecisionDock({
 
   const formatKey = (key: string) => {
     if (key === ' ') return '␣'
+    if (key === 'arrowleft') return '←'
+    if (key === 'arrowright') return '→'
+    if (key === 'arrowup') return '↑'
+    if (key === 'arrowdown') return '↓'
+    if (key === 'enter') return '↵'
+    if (key === 'backspace') return '⌫'
+    if (key === 'escape') return 'Esc'
     return key.toUpperCase()
   }
 
@@ -85,7 +92,7 @@ export function DecisionDock({
           </div>
         ) : skipOnly ? (
           <p className="mx-auto mt-3.5 max-w-[760px] text-center font-mono text-[10px] tracking-[0.08em] text-faint">
-            <KeyChip>{formatKey(keybinds.skip)}</KeyChip> next message ·{' '}
+            <KeyChip>{formatKey(keybinds.skip)}</KeyChip> or <KeyChip>↵</KeyChip> next message ·{' '}
             <KeyChip>⇧{formatKey(keybinds.skip)}</KeyChip> another conversation
           </p>
         ) : (
@@ -104,9 +111,9 @@ export function DecisionDock({
               type="button"
               onClick={onHandoff}
               className="hover:text-on-canvas transition-colors"
-              title="Open handoff readiness (Enter)"
+              title="Open handoff readiness"
             >
-              <KeyChip>⏎</KeyChip> hand off
+              hand off
             </button>
             <button
               onClick={() => setSettingsOpen(true)}
@@ -140,6 +147,10 @@ function RecentLine({
   const word = recent.value === 'yes' ? 'Yes' : recent.value === 'no' ? 'No' : 'Skip'
   const formatKey = (key: string) => {
     if (key === ' ') return 'Space'
+    if (key === 'arrowleft') return '←'
+    if (key === 'arrowright') return '→'
+    if (key === 'enter') return '↵'
+    if (key === 'backspace') return '⌫'
     return key.toUpperCase()
   }
 

--- a/src/components/run/HandoffReadyModal.tsx
+++ b/src/components/run/HandoffReadyModal.tsx
@@ -1,0 +1,44 @@
+interface HandoffReadyModalProps {
+  onHandoff: () => void
+  onDismiss: () => void
+}
+
+export function HandoffReadyModal({ onHandoff, onDismiss }: HandoffReadyModalProps) {
+  return (
+    <>
+      <div className="fixed inset-0 bg-overlay z-40" onClick={onDismiss} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(420px,92vw)] bg-bg-warm border border-edge rounded-md shadow-2xl z-50"
+      >
+        <div className="px-[22px] pt-[20px] pb-3 border-b border-edge-subtle">
+          <div className="font-mono text-[9px] tracking-[0.18em] uppercase text-moss mb-1.5">
+            ✦ Ready
+          </div>
+          <h3 className="font-serif font-medium text-[22px] text-paper m-0 tracking-[-0.014em] leading-[1.2]">
+            Handoff is ready
+          </h3>
+          <p className="mt-2 font-serif text-[13px] text-muted leading-[1.5]">
+            You've labeled enough examples for Gemini to take over the rest. You can hand off now
+            or keep labeling to improve accuracy.
+          </p>
+        </div>
+        <div className="flex items-center gap-3 px-[22px] py-[18px]">
+          <button
+            onClick={onDismiss}
+            className="appearance-none border border-edge bg-transparent text-on-surface px-4 py-[9px] rounded-sm cursor-pointer font-sans font-medium text-[13px] hover:text-on-canvas hover:border-faint transition-colors"
+          >
+            Keep labeling
+          </button>
+          <button
+            onClick={onHandoff}
+            className="appearance-none border border-moss bg-moss/10 text-moss px-4 py-[9px] rounded-sm cursor-pointer font-sans font-semibold text-[13px] hover:bg-moss/20 transition-colors"
+          >
+            Hand off to Gemini →
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react'
+import type { LabelNameSuggestion } from '../../types'
+
+interface LabelNameInputProps {
+  value: string
+  onChange: (value: string) => void
+  onCommit?: () => void
+  suggestions: LabelNameSuggestion[]
+  placeholder?: string
+  readOnly?: boolean
+  autoFocus?: boolean
+  className?: string
+  onBlur?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  'data-tutorial'?: string
+}
+
+export function LabelNameInput({
+  value,
+  onChange,
+  onCommit,
+  suggestions,
+  placeholder,
+  readOnly,
+  autoFocus,
+  className,
+  onBlur,
+  onKeyDown,
+  ...rest
+}: LabelNameInputProps) {
+  const [open, setOpen] = useState(false)
+  const [highlighted, setHighlighted] = useState(0)
+
+  const filtered = suggestions.filter(
+    (s) =>
+      value.length > 0 &&
+      s.name.toLowerCase().includes(value.toLowerCase()) &&
+      s.name.toLowerCase() !== value.toLowerCase()
+  )
+  const showDropdown = open && filtered.length > 0
+
+  useEffect(() => {
+    setHighlighted(0)
+  }, [value])
+
+  function select(name: string) {
+    onChange(name)
+    setOpen(false)
+    onCommit?.()
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (showDropdown) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setHighlighted((h) => Math.min(h + 1, filtered.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setHighlighted((h) => Math.max(h - 1, 0))
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        select(filtered[highlighted].name)
+        return
+      }
+      if (e.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+    }
+    onKeyDown?.(e)
+  }
+
+  return (
+    <div className="relative">
+      <input
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={showDropdown}
+        aria-haspopup="listbox"
+        type="text"
+        autoComplete="off"
+        value={value}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        className={className}
+        onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => { setTimeout(() => setOpen(false), 150); onBlur?.() }}
+        onKeyDown={handleKeyDown}
+        {...rest}
+      />
+      {showDropdown && (
+        <ul
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-lg"
+        >
+          {filtered.map((s, i) => (
+            <li
+              key={s.name}
+              role="option"
+              aria-selected={i === highlighted}
+              className={`cursor-pointer px-3 py-2 ${
+                i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
+              }`}
+              onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
+              onMouseEnter={() => setHighlighted(i)}
+            >
+              <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
+              {s.description && (
+                <div className="truncate text-xs text-muted">{s.description}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -13,6 +13,7 @@ interface LabelNameInputProps {
   onBlur?: () => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
   'data-tutorial'?: string
+  'data-note-input'?: string
 }
 
 export function LabelNameInput({

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -119,6 +119,7 @@ export function LabelNameInput({
 
   return (
     <>
+      <form autoComplete="off" onSubmit={(e) => e.preventDefault()} style={{ display: 'contents' }}>
       <input
         ref={inputRef}
         role="combobox"
@@ -138,6 +139,7 @@ export function LabelNameInput({
         onKeyDown={handleKeyDown}
         {...rest}
       />
+      </form>
       {dropdown}
     </>
   )

--- a/src/components/run/LabelNameInput.tsx
+++ b/src/components/run/LabelNameInput.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import type { LabelNameSuggestion } from '../../types'
 
 interface LabelNameInputProps {
@@ -31,18 +32,26 @@ export function LabelNameInput({
 }: LabelNameInputProps) {
   const [open, setOpen] = useState(false)
   const [highlighted, setHighlighted] = useState(0)
+  const [dropdownRect, setDropdownRect] = useState<DOMRect | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const filtered = suggestions.filter(
     (s) =>
-      value.length > 0 &&
-      s.name.toLowerCase().includes(value.toLowerCase()) &&
-      s.name.toLowerCase() !== value.toLowerCase()
+      s.name.toLowerCase() !== value.toLowerCase() &&
+      (value.length === 0 || s.name.toLowerCase().includes(value.toLowerCase()))
   )
   const showDropdown = open && filtered.length > 0
 
   useEffect(() => {
     setHighlighted(0)
   }, [value])
+
+  // Measure input position whenever dropdown opens so the portal is positioned correctly
+  useEffect(() => {
+    if (showDropdown && inputRef.current) {
+      setDropdownRect(inputRef.current.getBoundingClientRect())
+    }
+  }, [showDropdown])
 
   function select(name: string) {
     onChange(name)
@@ -75,15 +84,49 @@ export function LabelNameInput({
     onKeyDown?.(e)
   }
 
+  const dropdown = showDropdown && dropdownRect ? createPortal(
+    <ul
+      role="listbox"
+      style={{
+        position: 'fixed',
+        top: dropdownRect.bottom + 2,
+        left: dropdownRect.left,
+        width: dropdownRect.width,
+        zIndex: 9999,
+      }}
+      className="max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-xl"
+    >
+      {filtered.map((s, i) => (
+        <li
+          key={s.name}
+          role="option"
+          aria-selected={i === highlighted}
+          className={`cursor-pointer px-3 py-2 ${
+            i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
+          }`}
+          onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
+          onMouseEnter={() => setHighlighted(i)}
+        >
+          <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
+          {s.description && (
+            <div className="truncate text-xs text-muted">{s.description}</div>
+          )}
+        </li>
+      ))}
+    </ul>,
+    document.body
+  ) : null
+
   return (
-    <div className="relative">
+    <>
       <input
+        ref={inputRef}
         role="combobox"
         aria-autocomplete="list"
         aria-expanded={showDropdown}
         aria-haspopup="listbox"
         type="text"
-        autoComplete="off"
+        autoComplete="new-password"
         value={value}
         readOnly={readOnly}
         autoFocus={autoFocus}
@@ -95,30 +138,7 @@ export function LabelNameInput({
         onKeyDown={handleKeyDown}
         {...rest}
       />
-      {showDropdown && (
-        <ul
-          role="listbox"
-          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-48 overflow-y-auto rounded-sm border border-edge bg-elevated shadow-lg"
-        >
-          {filtered.map((s, i) => (
-            <li
-              key={s.name}
-              role="option"
-              aria-selected={i === highlighted}
-              className={`cursor-pointer px-3 py-2 ${
-                i === highlighted ? 'bg-ochre/10' : 'hover:bg-surface'
-              }`}
-              onMouseDown={(e) => { e.preventDefault(); select(s.name) }}
-              onMouseEnter={() => setHighlighted(i)}
-            >
-              <div className="text-sm font-semibold text-on-canvas">{s.name}</div>
-              {s.description && (
-                <div className="truncate text-xs text-muted">{s.description}</div>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+      {dropdown}
+    </>
   )
 }

--- a/src/components/run/NoteLabelPopover.tsx
+++ b/src/components/run/NoteLabelPopover.tsx
@@ -1,19 +1,23 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { LabelNameInput } from './LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
 
 interface NoteLabelPopoverProps {
   open: boolean
   onClose: () => void
   onSubmit: (name: string, description: string) => void
+  suggestions?: LabelNameSuggestion[]
 }
 
-export function NoteLabelPopover({ open, onClose, onSubmit }: NoteLabelPopoverProps) {
+export function NoteLabelPopover({ open, onClose, onSubmit, suggestions = [] }: NoteLabelPopoverProps) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
-  const nameRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (open) {
-      requestAnimationFrame(() => nameRef.current?.focus())
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLInputElement>('[data-note-input]')?.focus()
+      })
     } else {
       setName('')
       setDescription('')
@@ -26,7 +30,10 @@ export function NoteLabelPopover({ open, onClose, onSubmit }: NoteLabelPopoverPr
       if (e.key === 'Escape') {
         e.preventDefault()
         onClose()
-      } else if (e.key === 'Enter' && document.activeElement === nameRef.current) {
+      } else if (
+        e.key === 'Enter' &&
+        (document.activeElement as HTMLElement)?.dataset?.noteInput !== undefined
+      ) {
         e.preventDefault()
         if (name.trim()) onSubmit(name.trim(), description.trim())
       }
@@ -62,14 +69,15 @@ export function NoteLabelPopover({ open, onClose, onSubmit }: NoteLabelPopoverPr
         </div>
         <div className="px-[22px] pt-4 pb-3 flex flex-col gap-3.5">
           <Field label="Name">
-            <input
-              ref={nameRef}
-              type="text"
-              autoComplete="off"
+            <LabelNameInput
+              data-note-input=""
+              autoFocus
               placeholder="e.g. frustration"
               value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="appearance-none bg-canvas border border-edge text-on-canvas px-[11px] py-[9px] rounded-sm font-sans text-[13px] focus:outline-none focus:border-ochre-dim"
+              suggestions={suggestions}
+              onChange={setName}
+              onCommit={() => { if (name.trim()) onSubmit(name.trim(), description.trim()) }}
+              className="appearance-none bg-canvas border border-edge text-on-canvas px-[11px] py-[9px] rounded-sm font-sans text-[13px] focus:outline-none focus:border-ochre-dim w-full"
             />
           </Field>
           <Field label="Description (optional)">

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount } from '../../types'
 import { api } from '../../services/api'
-import { AssignmentPicker } from './AssignmentPicker'
 import { ReadinessChip } from './ReadinessChip'
 import { HoverTip } from './HoverTip'
 import { isPlaceholderLabelName } from './labelPlaceholder'
@@ -34,10 +33,9 @@ export interface StripBarProps {
 export function StripBar({
   label,
   readiness,
-  assignments,
-  unmapped,
-  selectedAssignmentId,
-  onSelectAssignment,
+  // assignment-picker props (assignments/unmapped/selectedAssignmentId/
+  // onSelectAssignment) are intentionally unused: the route is week-locked
+  // server-side, so the picker is replaced by a static scope label.
   onHandoff,
   onLabelMetaUpdated,
   onSampleHandoff,
@@ -181,12 +179,10 @@ export function StripBar({
         {/* Conversations: assignment filter + explore sampling (menu portals) */}
         <div className="relative z-10 min-w-0 md:flex md:justify-end">
           <div className="flex w-max max-w-full flex-wrap items-center gap-6 md:justify-end">
-            <AssignmentPicker
-              assignments={assignments}
-              unmapped={unmapped}
-              selectedId={selectedAssignmentId}
-              onSelect={onSelectAssignment}
-            />
+            <span className="inline-flex items-center gap-2 font-mono text-[11px] text-muted">
+              <span className="text-[9px] tracking-[0.06em] uppercase text-faint">scope</span>
+              <span className="text-fg">Week 8 — Lab 5 &amp; HW 5</span>
+            </span>
             {!draftMode && onLabelMetaUpdated && (
               <div className="inline-flex items-center gap-2 font-mono text-[11px] text-muted">
                 <HoverTip

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -14,7 +14,6 @@ export interface StripBarProps {
   onSelectAssignment: (id: number | null) => void
   onHandoff?: () => void
   onLabelMetaUpdated?: () => void | Promise<void>
-  onSampleHandoff?: (n: number) => void
   readinessOpen?: boolean
   onReadinessOpenChange?: (open: boolean) => void
   labelNameDraft?: string
@@ -38,7 +37,6 @@ export function StripBar({
   // server-side, so the picker is replaced by a static scope label.
   onHandoff,
   onLabelMetaUpdated,
-  onSampleHandoff,
   readinessOpen,
   onReadinessOpenChange,
   labelNameDraft,
@@ -63,7 +61,6 @@ export function StripBar({
 
   const [explorePct, setExplorePct] = useState(0)
   const [exploreBusy, setExploreBusy] = useState(false)
-  const [sampleN, setSampleN] = useState(50)
 
   useEffect(() => {
     const eff = label.hybrid_explore_effective ?? 0.35
@@ -220,44 +217,6 @@ export function StripBar({
                     default
                   </button>
                 )}
-              </div>
-            )}
-            {!draftMode && import.meta.env.DEV && onSampleHandoff && (
-              <div className="inline-flex items-center gap-2 rounded-full border border-dashed border-edge px-2.5 py-1 font-mono text-[11px]">
-                <HoverTip
-                  label="dev · sample handoff"
-                  className="text-[9px] tracking-[0.06em] uppercase text-faint"
-                  tip={
-                    'Developer smoke test for the Hand off pipeline. The number is how many ' +
-                    'random unlabeled messages Gemini classifies, not a new conversation sample.'
-                  }
-                />
-                <input
-                  type="number"
-                  min={1}
-                  value={sampleN}
-                  onChange={(e) => setSampleN(parseInt(e.target.value, 10) || 0)}
-                  aria-label="Sample handoff message count"
-                  className="w-10 border-b border-edge bg-transparent text-center tabular-nums focus:outline-none"
-                />
-                <HoverTip
-                  label={
-                    <button
-                      type="button"
-                      disabled={!Number.isFinite(sampleN) || sampleN <= 0}
-                      onClick={() => onSampleHandoff(sampleN)}
-                      className="border-0 bg-transparent p-0 font-inherit text-inherit text-on-surface hover:text-ochre disabled:opacity-40 cursor-pointer"
-                    >
-                      Sample →
-                    </button>
-                  }
-                  className="normal-case tracking-normal"
-                  tip={
-                    'Runs Hand off on this label for N random pending messages, then deactivates it. ' +
-                    'Progress on Summaries. /run switches to the next queued label, or the draft ' +
-                    'screen if none is queued, not another explore pick.'
-                  }
-                />
               </div>
             )}
           </div>

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -125,7 +125,7 @@ export function StripBar({
                     if (draftMode || labelNameLocked) return
                     onLabelNameCommit?.()
                   }}
-                  placeholder="Label name…"
+                  placeholder="Type a label…"
                   className="box-border w-full min-w-[10rem] max-w-[18rem] rounded-sm border border-edge bg-surface px-2.5 py-1.5 font-sans text-sm text-on-canvas placeholder:text-faint focus:outline-none focus:border-ochre-dim disabled:opacity-70"
                 />
               ) : (

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -101,6 +101,7 @@ export function StripBar({
               {showNameInput ? (
                 <input
                   type="text"
+                  autoComplete="off"
                   data-tutorial="label-name"
                   value={labelNameDraft ?? ''}
                   readOnly={labelNameLocked}

--- a/src/components/run/StripBar.tsx
+++ b/src/components/run/StripBar.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount } from '../../types'
+import type { SingleLabel, ReadinessState, AssignmentMapping, UnmappedCount, LabelNameSuggestion } from '../../types'
 import { api } from '../../services/api'
 import { ReadinessChip } from './ReadinessChip'
 import { HoverTip } from './HoverTip'
 import { isPlaceholderLabelName } from './labelPlaceholder'
+import { LabelNameInput } from './LabelNameInput'
 
 export interface StripBarProps {
   label: SingleLabel
@@ -27,6 +28,7 @@ export interface StripBarProps {
   onClearAll?: () => void
   onSwitchQueued?: (id: number) => void
   onRemoveQueued?: (id: number) => void
+  suggestions?: LabelNameSuggestion[]
 }
 
 export function StripBar({
@@ -50,6 +52,7 @@ export function StripBar({
   onClearAll,
   onSwitchQueued,
   onRemoveQueued,
+  suggestions = [],
 }: StripBarProps) {
   const showNameInput =
     draftMode ||
@@ -99,13 +102,18 @@ export function StripBar({
             <div className="flex min-w-0 max-w-full items-center gap-2.5">
               <span className="text-ochre text-[11px]">◆</span>
               {showNameInput ? (
-                <input
-                  type="text"
-                  autoComplete="off"
+                <LabelNameInput
                   data-tutorial="label-name"
                   value={labelNameDraft ?? ''}
                   readOnly={labelNameLocked}
-                  onChange={(e) => onLabelNameDraftChange?.(e.target.value)}
+                  suggestions={suggestions}
+                  onChange={(v) => onLabelNameDraftChange?.(v)}
+                  onCommit={() => {
+                    const name = (labelNameDraft ?? '').trim()
+                    if (name && !isPlaceholderLabelName(name) && !labelNameLocked) {
+                      commitName?.()
+                    }
+                  }}
                   onKeyDown={(e) => {
                     const name = (labelNameDraft ?? '').trim()
                     if (e.key === 'Enter' && name && !isPlaceholderLabelName(name) && !labelNameLocked) {

--- a/src/hooks/useKeybinds.tsx
+++ b/src/hooks/useKeybinds.tsx
@@ -7,10 +7,10 @@ export type KeybindMap = Record<Action, string>
 const STORAGE_KEY = 'chatsight-keybinds'
 
 const DEFAULT_KEYBINDS: KeybindMap = {
-  yes: 'a',
+  yes: 'z',
   no: 'd',
-  skip: ' ', // Space
-  undo: 's',
+  skip: 'arrowright',
+  undo: 'arrowleft',
 }
 
 type KeybindContextValue = {

--- a/src/hooks/useKeybinds.tsx
+++ b/src/hooks/useKeybinds.tsx
@@ -7,10 +7,10 @@ export type KeybindMap = Record<Action, string>
 const STORAGE_KEY = 'chatsight-keybinds'
 
 const DEFAULT_KEYBINDS: KeybindMap = {
-  yes: 'z',
+  yes: 'a',
   no: 'd',
   skip: 'arrowright',
-  undo: 'arrowleft',
+  undo: 'z',
 }
 
 type KeybindContextValue = {

--- a/src/hooks/useLabelSuggestions.ts
+++ b/src/hooks/useLabelSuggestions.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react'
+import { api } from '../services/api'
+import type { LabelNameSuggestion } from '../types'
+
+export function useLabelSuggestions() {
+  const [suggestions, setSuggestions] = useState<LabelNameSuggestion[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getNameSuggestions()
+      .then(setSuggestions)
+      .catch(() => setSuggestions([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { suggestions, loading }
+}

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -538,17 +538,39 @@ export function LabelRunPage() {
   const handleSwitchToQueued = useCallback(
     async (id: number) => {
       if (busy) return
+      const hintChatlogId = focused?.chatlog_id
       setBusyMessage('Switching label…')
       setBusy(true)
       try {
         await api.switchToLabel(id)
         setBusyMessage('Loading label…')
-        await refresh()
+        // Use hintChatlogId so the new label opens on the same conversation.
+        // refresh() is still called but we override getNextFocused with the hint.
+        const [active, a, um] = await Promise.all([
+          api.getActiveSingleLabel(),
+          api.listAssignments(),
+          api.getUnmappedCount(),
+        ])
+        setAssignments(a)
+        setUnmapped(um)
+        if (active) {
+          const [next, ready, q] = await Promise.all([
+            api.getNextFocused(active.id, selectedAssignmentId ?? undefined, hintChatlogId),
+            api.getReadiness(active.id),
+            api.listSingleLabels({ phase: 'queued' }),
+          ])
+          setActiveLabel(active)
+          setFocused(next)
+          setReadiness(ready)
+          setQueued(q)
+          setReviewQueue(null)
+          setReviewIdx(0)
+        }
       } finally {
         setBusy(false)
       }
     },
-    [busy, refresh]
+    [busy, focused?.chatlog_id, selectedAssignmentId]
   )
 
   const progressActive = loading || busy || handoffPending

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -458,23 +458,6 @@ export function LabelRunPage() {
     }
   }, [activeLabel, handoffPending, refresh])
 
-  const handleSampleHandoff = useCallback(async (n: number) => {
-    if (!activeLabel || handoffPending) return
-    setHandoffPending(true)
-    setLoadError(null)
-    try {
-      await api.handoffSingleLabel(activeLabel.id, n)
-      await refresh()
-    } catch (e) {
-      console.error('sample handoff failed', e)
-      setLoadError(
-        e instanceof Error ? e.message : 'Sample handoff failed. Check the server logs.',
-      )
-    } finally {
-      setHandoffPending(false)
-    }
-  }, [activeLabel, handoffPending, refresh])
-
   const handleContinueToReview = useCallback(async () => {
     setSummaryOpen(false)
     if (!activeLabel) return
@@ -696,7 +679,6 @@ export function LabelRunPage() {
                 onSelectAssignment={() => {}}
                 onHandoff={handleHandoff}
                 onLabelMetaUpdated={refresh}
-                onSampleHandoff={handleSampleHandoff}
                 readinessOpen={readinessOpen}
                 onReadinessOpenChange={setReadinessOpen}
                 queued={queued}
@@ -776,7 +758,6 @@ export function LabelRunPage() {
               labelNameLocked={tutorialActive}
               onHandoff={draftMode ? undefined : handleHandoff}
               onLabelMetaUpdated={draftMode ? undefined : refresh}
-              onSampleHandoff={draftMode ? undefined : handleSampleHandoff}
               readinessOpen={readinessOpen}
               onReadinessOpenChange={setReadinessOpen}
               queued={queued}

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -20,6 +20,7 @@ import {
 import { DecisionDock } from '../components/run/DecisionDock'
 import { RunProgressOverlay } from '../components/run/RunProgressOverlay'
 import { NoteLabelPopover } from '../components/run/NoteLabelPopover'
+import { HandoffReadyModal } from '../components/run/HandoffReadyModal'
 import { SummaryModal } from '../components/run/SummaryModal'
 import { AbortConfirmModal } from '../components/run/AbortConfirmModal'
 import { DecisionWorkspace } from '../components/decision/DecisionWorkspace'
@@ -63,6 +64,9 @@ export function LabelRunPage() {
   const [assistNeighbors, setAssistNeighbors] = useState<AssistNeighbor[]>([])
   const [abortOpen, setAbortOpen] = useState(false)
   const [readinessOpen, setReadinessOpen] = useState(false)
+  const [handoffReadyOpen, setHandoffReadyOpen] = useState(false)
+  // Track which label IDs have already shown the handoff-ready popup so it only fires once.
+  const handoffReadyShownRef = useRef<Set<number>>(new Set())
   const [loadError, setLoadError] = useState<string | null>(null)
   const [tutorialStep, setTutorialStep] = useState<RunTutorialStep | null>(null)
   const [labelNameDraft, setLabelNameDraft] = useState('')
@@ -75,6 +79,20 @@ export function LabelRunPage() {
   useEffect(() => {
     activeLabelIdRef.current = activeLabel?.id ?? null
   }, [activeLabel?.id])
+
+  // Show handoff-ready popup once when readiness first hits green for this label.
+  useEffect(() => {
+    const labelId = activeLabel?.id
+    if (
+      labelId != null &&
+      readiness?.tier === 'green' &&
+      activeLabel?.phase === 'labeling' &&
+      !handoffReadyShownRef.current.has(labelId)
+    ) {
+      handoffReadyShownRef.current.add(labelId)
+      setHandoffReadyOpen(true)
+    }
+  }, [readiness?.tier, activeLabel?.id, activeLabel?.phase])
 
   const syncActiveLabelCounts = useCallback(
     (labelId: number, state: ReadinessState) => {
@@ -862,6 +880,12 @@ export function LabelRunPage() {
           noCount={activeLabel.no_count}
           onConfirm={handleAbortActive}
           onCancel={() => setAbortOpen(false)}
+        />
+      )}
+      {handoffReadyOpen && (
+        <HandoffReadyModal
+          onHandoff={() => { setHandoffReadyOpen(false); void handleHandoff() }}
+          onDismiss={() => setHandoffReadyOpen(false)}
         />
       )}
     </>

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -72,6 +72,17 @@ export function LabelRunPage() {
   const [labelNameDraft, setLabelNameDraft] = useState('')
   const [browseExhausted, setBrowseExhausted] = useState<number[]>([])
 
+  // Cross-label undo history. Each entry is the (labelId, chatlogId, messageIndex)
+  // of a message that was decided on. Undo pops from the end, switches labels
+  // if needed, and calls the backend undo for that specific label.
+  const [decisionHistory, setDecisionHistory] = useState<
+    Array<{ labelId: number; chatlogId: number; messageIndex: number }>
+  >([])
+
+  // Flips to true after the first history seed from the DB. Subsequent
+  // refresh() calls won't overwrite cross-label history built up this session.
+  const hasSeededHistory = useRef(false)
+
   // Mirrors activeLabel.id so async handlers can detect a label switch that
   // occurred while a decide/undo/skip was in flight, and avoid clobbering
   // state of the new active label with the old one's response.
@@ -183,6 +194,17 @@ export function LabelRunPage() {
       setReviewIdx(0)
       if (isPlaceholderLabelName(active.name)) {
         setLabelNameDraft('')
+      }
+      // Seed undo history from DB on first load only. Subsequent refreshes
+      // (after label switch, etc.) don't overwrite history built this session.
+      if (!hasSeededHistory.current) {
+        hasSeededHistory.current = true
+        const decisions = await api.getHumanDecisions(active.id)
+        setDecisionHistory(decisions.map(d => ({
+          labelId: active.id,
+          chatlogId: d.chatlog_id,
+          messageIndex: d.message_index,
+        })))
       }
     }
 
@@ -408,6 +430,11 @@ export function LabelRunPage() {
           value,
         }, selectedAssignmentId ?? undefined)
         if (activeLabelIdRef.current !== labelId) return
+        setDecisionHistory(prev => [...prev, {
+          labelId,
+          chatlogId: decided.chatlog_id,
+          messageIndex: decided.message_index,
+        }])
         setFocused(res.next)
         setReadiness(res.readiness)
         syncActiveLabelCounts(labelId, res.readiness)
@@ -419,20 +446,29 @@ export function LabelRunPage() {
   )
 
   const handleUndo = useCallback(async () => {
-    if (!activeLabel || busy) return
+    if (!activeLabel || busy || decisionHistory.length === 0) return
+    const entry = decisionHistory[decisionHistory.length - 1]
     setBusy(true)
-    const labelId = activeLabel.id
     try {
-      const res = await api.undoLastDecision(labelId, selectedAssignmentId ?? undefined)
-      if (activeLabelIdRef.current !== labelId) return
+      // If the decision to undo was on a different label, switch to it first.
+      if (entry.labelId !== activeLabel.id) {
+        const switched = await api.switchToLabel(entry.labelId)
+        setActiveLabel(switched)
+        activeLabelIdRef.current = switched.id
+        // Refresh the queued list since the previously active label is now queued.
+        const q = await api.listSingleLabels({ phase: 'queued' })
+        setQueued(q)
+      }
+      const res = await api.undoLastDecision(entry.labelId, selectedAssignmentId ?? undefined)
+      setDecisionHistory(prev => prev.slice(0, -1))
       setFocused(res.next)
       setReadiness(res.readiness)
-      syncActiveLabelCounts(labelId, res.readiness)
+      syncActiveLabelCounts(entry.labelId, res.readiness)
       setRecent(null)
     } finally {
       setBusy(false)
     }
-  }, [activeLabel, busy, selectedAssignmentId, syncActiveLabelCounts])
+  }, [activeLabel, busy, decisionHistory, selectedAssignmentId, syncActiveLabelCounts])
 
   const handleSkip = useCallback(() => {
     if (!activeLabel) void handleBrowseSkip()
@@ -467,6 +503,8 @@ export function LabelRunPage() {
     // label without a reload. Classification continues in the background and shows
     // up on /summaries with a progress meter.
     setHandoffPending(true)
+    setDecisionHistory([])
+    hasSeededHistory.current = false
     try {
       await api.handoffSingleLabel(activeLabel.id)
       await refresh()

--- a/src/pages/LabelRunPage.tsx
+++ b/src/pages/LabelRunPage.tsx
@@ -25,6 +25,7 @@ import { AbortConfirmModal } from '../components/run/AbortConfirmModal'
 import { DecisionWorkspace } from '../components/decision/DecisionWorkspace'
 import { AiReviewDock } from '../components/decision/AiReviewDock'
 import { useKeybinds } from '../hooks/useKeybinds'
+import { useLabelSuggestions } from '../hooks/useLabelSuggestions'
 import { api } from '../services/api'
 import type {
   DecisionValue,
@@ -532,6 +533,7 @@ export function LabelRunPage() {
   )
 
   const { keybinds } = useKeybinds()
+  const { suggestions } = useLabelSuggestions()
 
   const handleSwitchToQueued = useCallback(
     async (id: number) => {
@@ -686,6 +688,7 @@ export function LabelRunPage() {
                 onClearAll={handleClearQueue}
                 onSwitchQueued={(id) => void handleSwitchToQueued(id)}
                 onRemoveQueued={(id) => void handleRemoveQueued(id)}
+                suggestions={suggestions}
               />
               <ConversationMeta
                 chatlogId={item.chatlog_id}
@@ -721,6 +724,7 @@ export function LabelRunPage() {
           open={noteOpen}
           onClose={() => setNoteOpen(false)}
           onSubmit={handleNoteSubmit}
+          suggestions={suggestions}
         />
         {abortOpen && (
           <AbortConfirmModal
@@ -767,6 +771,7 @@ export function LabelRunPage() {
               onClearAll={handleClearQueue}
               onSwitchQueued={(id) => void handleSwitchToQueued(id)}
               onRemoveQueued={(id) => void handleRemoveQueued(id)}
+              suggestions={suggestions}
             />
             <ConversationMeta
               chatlogId={focused.chatlog_id}
@@ -819,6 +824,7 @@ export function LabelRunPage() {
         open={noteOpen}
         onClose={() => setNoteOpen(false)}
         onSubmit={handleNoteSubmit}
+        suggestions={suggestions}
       />
       <SummaryModal
         summary={summary}

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -590,8 +590,9 @@ function SplitSessionModal({
           <div className="space-y-4">
             <div>
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category A (Left Arrow)</label>
-              <input 
+              <input
                 autoFocus
+                autoComplete="off"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Theory"
                 value={nameA}
@@ -601,7 +602,8 @@ function SplitSessionModal({
             </div>
             <div>
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category B (Right Arrow)</label>
-              <input 
+              <input
+                autoComplete="off"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Implementation"
                 value={nameB}

--- a/src/pages/LabelsPage.tsx
+++ b/src/pages/LabelsPage.tsx
@@ -592,7 +592,7 @@ function SplitSessionModal({
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category A (Left Arrow)</label>
               <input
                 autoFocus
-                autoComplete="off"
+                autoComplete="new-password"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Theory"
                 value={nameA}
@@ -603,7 +603,7 @@ function SplitSessionModal({
             <div>
               <label className="block text-[10px] font-bold text-faint uppercase tracking-widest mb-1.5">Category B (Right Arrow)</label>
               <input
-                autoComplete="off"
+                autoComplete="new-password"
                 className="w-full px-3 py-2 bg-canvas border border-edge rounded text-sm text-on-canvas placeholder-disabled focus:outline-none focus:border-accent transition-all"
                 placeholder="e.g. Implementation"
                 value={nameB}

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -116,7 +116,7 @@ export function QueuePage() {
 
 	const currentMessage = queue[currentIdx] ?? null;
 
-	const formatKey = (key: string) => {
+	const formatKey = (key: string): string => {
 		if (key === " ") return "Space";
 		if (key === "enter") return "Enter";
 		if (key === "arrowleft") return "←";
@@ -347,6 +347,23 @@ export function QueuePage() {
 	// Fetch applied labels and AI suggestion per message
 	useEffect(() => {
 		if (!displayedMessage) return;
+		const blindRecalibration = recalibration?.phase === "blind";
+		const reconcileRecalibration = recalibration?.phase === "reconcile";
+		if (blindRecalibration) {
+			// Blind check: don't load saved labels from the DB or the sidebar
+			// reveals the answer we're asking the instructor to reproduce.
+			setAppliedLabelIds(new Set());
+			setSuggestion(null);
+			setSuggestionLoading(false);
+			return;
+		}
+		if (reconcileRecalibration) {
+			// Keep the toggles from the blind attempt; the DB still holds the
+			// original labels, so don't overwrite the in-progress comparison.
+			setSuggestion(null);
+			setSuggestionLoading(false);
+			return;
+		}
 		api
 			.getAppliedLabels(
 				displayedMessage.chatlog_id,
@@ -380,6 +397,7 @@ export function QueuePage() {
 		displayedMessage?.chatlog_id,
 		displayedMessage?.message_index,
 		aiUnlocked,
+		recalibration?.phase,
 	]);
 
 	const advance = useCallback(() => {
@@ -473,55 +491,55 @@ export function QueuePage() {
 	};
 
 	const handleNextInner = useCallback(async () => {
-		// // Recalibration: blind phase → check match → reconcile or auto-advance
-		// if (recalibration && recalibration.phase === "blind") {
-		// 	const relabelIds = new Set(appliedLabelIds);
-		// 	const originalSet = new Set(recalibration.item.original_label_ids);
-		// 	const matched =
-		// 		relabelIds.size === originalSet.size &&
-		// 		[...relabelIds].every((id) => originalSet.has(id));
+		// Recalibration: blind phase → check match → reconcile or auto-advance
+		if (recalibration && recalibration.phase === "blind") {
+			const relabelIds = new Set(appliedLabelIds);
+			const originalSet = new Set(recalibration.item.original_label_ids);
+			const matched =
+				relabelIds.size === originalSet.size &&
+				[...relabelIds].every((id) => originalSet.has(id));
 
-		// 	if (matched) {
-		// 		await api.saveRecalibration({
-		// 			chatlog_id: recalibration.item.chatlog_id,
-		// 			message_index: recalibration.item.message_index,
-		// 			original_label_ids: recalibration.item.original_label_ids,
-		// 			relabel_ids: [...relabelIds],
-		// 			final_label_ids: [...relabelIds],
-		// 		});
-		// 		setRecalibration(null);
-		// 		setRecalibrationToast("match");
-		// 		setTimeout(() => setRecalibrationToast(null), 2000);
-		// 		setAppliedLabelIds(new Set());
-		// 		api
-		// 			.getRecalibrationStats()
-		// 			.then(setRecalibrationStats)
-		// 			.catch(() => {});
-		// 	} else {
-		// 		setRecalibration((prev) =>
-		// 			prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
-		// 		);
-		// 	}
-		// 	return;
-		// }
+			if (matched) {
+				await api.saveRecalibration({
+					chatlog_id: recalibration.item.chatlog_id,
+					message_index: recalibration.item.message_index,
+					original_label_ids: recalibration.item.original_label_ids,
+					relabel_ids: [...relabelIds],
+					final_label_ids: [...relabelIds],
+				});
+				setRecalibration(null);
+				setRecalibrationToast("match");
+				setTimeout(() => setRecalibrationToast(null), 2000);
+				setAppliedLabelIds(new Set());
+				api
+					.getRecalibrationStats()
+					.then(setRecalibrationStats)
+					.catch(() => {});
+			} else {
+				setRecalibration((prev) =>
+					prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
+				);
+			}
+			return;
+		}
 
-		// // Recalibration: reconcile phase → save final labels and exit
-		// if (recalibration && recalibration.phase === "reconcile") {
-		// 	await api.saveRecalibration({
-		// 		chatlog_id: recalibration.item.chatlog_id,
-		// 		message_index: recalibration.item.message_index,
-		// 		original_label_ids: recalibration.item.original_label_ids,
-		// 		relabel_ids: [...recalibration.relabelIds],
-		// 		final_label_ids: [...appliedLabelIds],
-		// 	});
-		// 	setRecalibration(null);
-		// 	setAppliedLabelIds(new Set());
-		// 	api
-		// 		.getRecalibrationStats()
-		// 		.then(setRecalibrationStats)
-		// 		.catch(() => {});
-		// 	return;
-		// }
+		// Recalibration: reconcile phase → save final labels and exit
+		if (recalibration && recalibration.phase === "reconcile") {
+			await api.saveRecalibration({
+				chatlog_id: recalibration.item.chatlog_id,
+				message_index: recalibration.item.message_index,
+				original_label_ids: recalibration.item.original_label_ids,
+				relabel_ids: [...recalibration.relabelIds],
+				final_label_ids: [...appliedLabelIds],
+			});
+			setRecalibration(null);
+			setAppliedLabelIds(new Set());
+			api
+				.getRecalibrationStats()
+				.then(setRecalibrationStats)
+				.catch(() => {});
+			return;
+		}
 
 		if (isBackNav) {
 			setNavPos(null);
@@ -570,16 +588,16 @@ export function QueuePage() {
 		api.getQueuePosition().then((p) => setRemaining(p.total_remaining));
 		api.getRecentHistory(5).then(setHistory);
 
-		// // Check if recalibration is due after advancing (disabled)
-		// api
-		// 	.getRecalibration()
-		// 	.then((item) => {
-		// 		if (item) {
-		// 			setRecalibration({ item, phase: "blind", relabelIds: new Set() });
-		// 			setAppliedLabelIds(new Set());
-		// 		}
-		// 	})
-		// 	.catch(() => {});
+		// Check if recalibration is due after advancing
+		api
+			.getRecalibration()
+			.then((item) => {
+				if (item) {
+					setRecalibration({ item, phase: "blind", relabelIds: new Set() });
+					setAppliedLabelIds(new Set());
+				}
+			})
+			.catch(() => {});
 	}, [
 		recalibration,
 		isBackNav,
@@ -720,7 +738,30 @@ export function QueuePage() {
 				handleUndo();
 				return;
 			}
-			// if (e.key === "Escape" && recalibration) { /* recalibration disabled */ }
+			if (e.key === "Escape" && recalibration) {
+				if (recalibration.phase === "blind") {
+					setRecalibration(null);
+					setAppliedLabelIds(new Set());
+				} else {
+					api
+						.saveRecalibration({
+							chatlog_id: recalibration.item.chatlog_id,
+							message_index: recalibration.item.message_index,
+							original_label_ids: recalibration.item.original_label_ids,
+							relabel_ids: [...recalibration.relabelIds],
+							final_label_ids: recalibration.item.original_label_ids,
+						})
+						.then(() => {
+							api
+								.getRecalibrationStats()
+								.then(setRecalibrationStats)
+								.catch(() => {});
+						});
+					setRecalibration(null);
+					setAppliedLabelIds(new Set());
+				}
+				return;
+			}
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
@@ -997,7 +1038,71 @@ export function QueuePage() {
 				<span className="text-[9px] uppercase tracking-[0.06em] text-faint">scope</span>
 				<span className="text-fg">Week 3 — Lab 1 &amp; HW 1</span>
 			</div>
-			{/* Recalibration banners disabled */}
+			{recalibration && recalibration.phase === "blind" && (
+				<div className="bg-elevated border-b border-edge px-4 py-2 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<span className="bg-ochre text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
+							RECALIBRATION
+						</span>
+						<span className="text-muted text-xs">
+							Re-label this previously seen message to check consistency
+						</span>
+					</div>
+					<div className="flex gap-3 text-[10px] text-faint">
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
+							toggle
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">
+								{formatKey(keybinds.yes)}
+							</kbd>{" "}
+							submit
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
+							cancel
+						</span>
+					</div>
+				</div>
+			)}
+			{recalibration && recalibration.phase === "reconcile" && (
+				<div className="bg-warning-surface border-b border-warning-border px-4 py-2 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<span className="bg-warning text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
+							MISMATCH
+						</span>
+						<span className="text-warning-name text-xs">
+							Labels differ from original — toggle labels to reconcile, then
+							press {formatKey(keybinds.yes)}
+						</span>
+					</div>
+					<div className="flex gap-3 text-[10px] text-faint">
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
+							toggle
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">
+								{formatKey(keybinds.yes)}
+							</kbd>{" "}
+							confirm
+						</span>
+						<span>
+							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
+							keep original
+						</span>
+					</div>
+				</div>
+			)}
+			{recalibrationToast === "match" && (
+				<div className="bg-success-surface border-b border-success-border px-4 py-2 flex items-center gap-2">
+					<span className="text-success text-sm">✓</span>
+					<span className="text-success text-xs font-medium">
+						Consistent! Your labels matched your original labeling.
+					</span>
+				</div>
+			)}
 			<div className="flex-1 flex min-h-0">
 				<ProgressSidebar
 					session={session}
@@ -1022,8 +1127,18 @@ export function QueuePage() {
 					onDiscover={handleDiscover}
 					onOpenDiscoverModal={() => setDiscoverModalOpen(true)}
 					discovering={discovering}
-					recalibration={null /* recalibration disabled */}
-					recalibrationStats={null}
+					recalibration={
+						recalibration
+							? {
+									phase: recalibration.phase,
+									originalLabelIds: new Set(
+										recalibration.item.original_label_ids,
+									),
+									relabelIds: recalibration.relabelIds,
+								}
+							: null
+					}
+					recalibrationStats={recalibrationStats}
 					tutorialDisabled={tutorialActive}
 				/>
 				<div className="flex-1 flex flex-col min-h-0">

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -1008,6 +1008,10 @@ export function QueuePage() {
 
 	return (
 		<div className="flex-1 flex flex-col min-h-0">
+			<div className="flex items-center gap-2 border-b border-edge-subtle px-4 py-1.5 font-mono text-[11px] text-muted">
+				<span className="text-[9px] uppercase tracking-[0.06em] text-faint">scope</span>
+				<span className="text-fg">Week 3 — Lab 1 &amp; HW 1</span>
+			</div>
 			{recalibration && recalibration.phase === "blind" && (
 				<div className="bg-elevated border-b border-edge px-4 py-2 flex items-center justify-between">
 					<div className="flex items-center gap-2">

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -158,7 +158,7 @@ export function QueuePage() {
 		};
 	})();
 	const isReviewing = displayMode === "history-review";
-	const aiUnlocked = (stats?.labeled_count ?? 0) >= 20;
+	const aiUnlocked = (stats?.labeled_count ?? 0) >= 10;
 
 	const loadQueue = useCallback(async () => {
 		const q = await api.getQueue(20);

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -119,8 +119,15 @@ export function QueuePage() {
 	const formatKey = (key: string) => {
 		if (key === " ") return "Space";
 		if (key === "enter") return "Enter";
+		if (key === "arrowleft") return "←";
+		if (key === "arrowright") return "→";
+		if (key === "arrowup") return "↑";
+		if (key === "arrowdown") return "↓";
+		if (key === "backspace") return "⌫";
+		if (key === "escape") return "Esc";
 		if (key.startsWith("shift+")) {
-			return "⇧" + key.split("+")[1].toUpperCase();
+			const base = key.split("+")[1];
+			return "⇧" + formatKey(base);
 		}
 		return key.toUpperCase();
 	};
@@ -466,55 +473,55 @@ export function QueuePage() {
 	};
 
 	const handleNextInner = useCallback(async () => {
-		// Recalibration: blind phase → check match → reconcile or auto-advance
-		if (recalibration && recalibration.phase === "blind") {
-			const relabelIds = new Set(appliedLabelIds);
-			const originalSet = new Set(recalibration.item.original_label_ids);
-			const matched =
-				relabelIds.size === originalSet.size &&
-				[...relabelIds].every((id) => originalSet.has(id));
+		// // Recalibration: blind phase → check match → reconcile or auto-advance
+		// if (recalibration && recalibration.phase === "blind") {
+		// 	const relabelIds = new Set(appliedLabelIds);
+		// 	const originalSet = new Set(recalibration.item.original_label_ids);
+		// 	const matched =
+		// 		relabelIds.size === originalSet.size &&
+		// 		[...relabelIds].every((id) => originalSet.has(id));
 
-			if (matched) {
-				await api.saveRecalibration({
-					chatlog_id: recalibration.item.chatlog_id,
-					message_index: recalibration.item.message_index,
-					original_label_ids: recalibration.item.original_label_ids,
-					relabel_ids: [...relabelIds],
-					final_label_ids: [...relabelIds],
-				});
-				setRecalibration(null);
-				setRecalibrationToast("match");
-				setTimeout(() => setRecalibrationToast(null), 2000);
-				setAppliedLabelIds(new Set());
-				api
-					.getRecalibrationStats()
-					.then(setRecalibrationStats)
-					.catch(() => {});
-			} else {
-				setRecalibration((prev) =>
-					prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
-				);
-			}
-			return;
-		}
+		// 	if (matched) {
+		// 		await api.saveRecalibration({
+		// 			chatlog_id: recalibration.item.chatlog_id,
+		// 			message_index: recalibration.item.message_index,
+		// 			original_label_ids: recalibration.item.original_label_ids,
+		// 			relabel_ids: [...relabelIds],
+		// 			final_label_ids: [...relabelIds],
+		// 		});
+		// 		setRecalibration(null);
+		// 		setRecalibrationToast("match");
+		// 		setTimeout(() => setRecalibrationToast(null), 2000);
+		// 		setAppliedLabelIds(new Set());
+		// 		api
+		// 			.getRecalibrationStats()
+		// 			.then(setRecalibrationStats)
+		// 			.catch(() => {});
+		// 	} else {
+		// 		setRecalibration((prev) =>
+		// 			prev ? { ...prev, phase: "reconcile", relabelIds } : prev,
+		// 		);
+		// 	}
+		// 	return;
+		// }
 
-		// Recalibration: reconcile phase → save final labels and exit
-		if (recalibration && recalibration.phase === "reconcile") {
-			await api.saveRecalibration({
-				chatlog_id: recalibration.item.chatlog_id,
-				message_index: recalibration.item.message_index,
-				original_label_ids: recalibration.item.original_label_ids,
-				relabel_ids: [...recalibration.relabelIds],
-				final_label_ids: [...appliedLabelIds],
-			});
-			setRecalibration(null);
-			setAppliedLabelIds(new Set());
-			api
-				.getRecalibrationStats()
-				.then(setRecalibrationStats)
-				.catch(() => {});
-			return;
-		}
+		// // Recalibration: reconcile phase → save final labels and exit
+		// if (recalibration && recalibration.phase === "reconcile") {
+		// 	await api.saveRecalibration({
+		// 		chatlog_id: recalibration.item.chatlog_id,
+		// 		message_index: recalibration.item.message_index,
+		// 		original_label_ids: recalibration.item.original_label_ids,
+		// 		relabel_ids: [...recalibration.relabelIds],
+		// 		final_label_ids: [...appliedLabelIds],
+		// 	});
+		// 	setRecalibration(null);
+		// 	setAppliedLabelIds(new Set());
+		// 	api
+		// 		.getRecalibrationStats()
+		// 		.then(setRecalibrationStats)
+		// 		.catch(() => {});
+		// 	return;
+		// }
 
 		if (isBackNav) {
 			setNavPos(null);
@@ -563,16 +570,16 @@ export function QueuePage() {
 		api.getQueuePosition().then((p) => setRemaining(p.total_remaining));
 		api.getRecentHistory(5).then(setHistory);
 
-		// Check if recalibration is due after advancing
-		api
-			.getRecalibration()
-			.then((item) => {
-				if (item) {
-					setRecalibration({ item, phase: "blind", relabelIds: new Set() });
-					setAppliedLabelIds(new Set());
-				}
-			})
-			.catch(() => {});
+		// // Check if recalibration is due after advancing (disabled)
+		// api
+		// 	.getRecalibration()
+		// 	.then((item) => {
+		// 		if (item) {
+		// 			setRecalibration({ item, phase: "blind", relabelIds: new Set() });
+		// 			setAppliedLabelIds(new Set());
+		// 		}
+		// 	})
+		// 	.catch(() => {});
 	}, [
 		recalibration,
 		isBackNav,
@@ -686,9 +693,8 @@ export function QueuePage() {
 			const rawKey = e.key.toLowerCase();
 			const pressedKey = e.shiftKey ? `shift+${rawKey}` : rawKey;
 
-			// Submit/advance. `n` and Enter are convenience aliases for the
-			// configurable yes key. Deliberately NOT plain `z` — it would shadow
-			// the Ctrl+Z undo below (both have rawKey "z"), so Ctrl+Z never fired.
+			// Submit/advance. Enter and `n` are convenience aliases for the
+			// configurable yes key (default: z).
 			if (
 				pressedKey === keybinds.yes ||
 				rawKey === "enter" ||
@@ -704,38 +710,17 @@ export function QueuePage() {
 			if (pressedKey === keybinds.skip || rawKey === "s") {
 				if (!isReviewing && !isBackNav) {
 					if (rawKey === " ") e.preventDefault(); // prevent scroll if space is bound to skip
+					if (rawKey === "arrowright") e.preventDefault(); // prevent browser scroll
 					handleSkip();
 				}
 				return;
 			}
 			if (pressedKey === keybinds.undo || (e.ctrlKey && rawKey === "z")) {
+				if (rawKey === "arrowleft") e.preventDefault(); // prevent browser back navigation
 				handleUndo();
 				return;
 			}
-			if (e.key === "Escape" && recalibration) {
-				if (recalibration.phase === "blind") {
-					setRecalibration(null);
-					setAppliedLabelIds(new Set());
-				} else {
-					api
-						.saveRecalibration({
-							chatlog_id: recalibration.item.chatlog_id,
-							message_index: recalibration.item.message_index,
-							original_label_ids: recalibration.item.original_label_ids,
-							relabel_ids: [...recalibration.relabelIds],
-							final_label_ids: recalibration.item.original_label_ids,
-						})
-						.then(() => {
-							api
-								.getRecalibrationStats()
-								.then(setRecalibrationStats)
-								.catch(() => {});
-						});
-					setRecalibration(null);
-					setAppliedLabelIds(new Set());
-				}
-				return;
-			}
+			// if (e.key === "Escape" && recalibration) { /* recalibration disabled */ }
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
@@ -756,6 +741,18 @@ export function QueuePage() {
 	const handleUpdateLabel = async (id: number, body: UpdateLabelRequest) => {
 		const updated = await api.updateLabel(id, body);
 		setLabels((prev) => prev.map((l) => (l.id === id ? updated : l)));
+	};
+
+	const handleStopAutolabel = async () => {
+		await api.stopAutolabel().catch(() => {});
+	};
+
+	const handleClearAutolabel = async () => {
+		if (!confirm("Delete all AI-applied labels? This cannot be undone.")) return;
+		await api.clearAutolabelResults();
+		setAutolabelStatus(null);
+		const st = await api.getQueueStats();
+		setStats(st);
 	};
 
 	const handleStartAutolabel = async () => {
@@ -1000,71 +997,7 @@ export function QueuePage() {
 				<span className="text-[9px] uppercase tracking-[0.06em] text-faint">scope</span>
 				<span className="text-fg">Week 3 — Lab 1 &amp; HW 1</span>
 			</div>
-			{recalibration && recalibration.phase === "blind" && (
-				<div className="bg-elevated border-b border-edge px-4 py-2 flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<span className="bg-ochre text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
-							RECALIBRATION
-						</span>
-						<span className="text-muted text-xs">
-							Re-label this previously seen message to check consistency
-						</span>
-					</div>
-					<div className="flex gap-3 text-[10px] text-faint">
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
-							toggle
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">
-								{formatKey(keybinds.yes)}
-							</kbd>{" "}
-							submit
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
-							cancel
-						</span>
-					</div>
-				</div>
-			)}
-			{recalibration && recalibration.phase === "reconcile" && (
-				<div className="bg-warning-surface border-b border-warning-border px-4 py-2 flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<span className="bg-warning text-bg-warm text-[10px] font-semibold px-2 py-0.5 rounded-sm">
-							MISMATCH
-						</span>
-						<span className="text-warning-name text-xs">
-							Labels differ from original — toggle labels to reconcile, then
-							press {formatKey(keybinds.yes)}
-						</span>
-					</div>
-					<div className="flex gap-3 text-[10px] text-faint">
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">1-9</kbd>{" "}
-							toggle
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">
-								{formatKey(keybinds.yes)}
-							</kbd>{" "}
-							confirm
-						</span>
-						<span>
-							<kbd className="bg-elevated px-1 rounded text-muted">Esc</kbd>{" "}
-							keep original
-						</span>
-					</div>
-				</div>
-			)}
-			{recalibrationToast === "match" && (
-				<div className="bg-success-surface border-b border-success-border px-4 py-2 flex items-center gap-2">
-					<span className="text-success text-sm">✓</span>
-					<span className="text-success text-xs font-medium">
-						Consistent! Your labels matched your original labeling.
-					</span>
-				</div>
-			)}
+			{/* Recalibration banners disabled */}
 			<div className="flex-1 flex min-h-0">
 				<ProgressSidebar
 					session={session}
@@ -1076,6 +1009,8 @@ export function QueuePage() {
 					onCreateAndApply={handleCreateAndApply}
 					onUpdateLabel={handleUpdateLabel}
 					onStartAutolabel={handleStartAutolabel}
+				onStopAutolabel={handleStopAutolabel}
+				onClearAutolabel={handleClearAutolabel}
 					autolabelStatus={autolabelStatus}
 					remaining={remaining}
 					history={history}
@@ -1087,18 +1022,8 @@ export function QueuePage() {
 					onDiscover={handleDiscover}
 					onOpenDiscoverModal={() => setDiscoverModalOpen(true)}
 					discovering={discovering}
-					recalibration={
-						recalibration
-							? {
-									phase: recalibration.phase,
-									originalLabelIds: new Set(
-										recalibration.item.original_label_ids,
-									),
-									relabelIds: recalibration.relabelIds,
-								}
-							: null
-					}
-					recalibrationStats={recalibrationStats}
+					recalibration={null /* recalibration disabled */}
+					recalibrationStats={null}
 					tutorialDisabled={tutorialActive}
 				/>
 				<div className="flex-1 flex flex-col min-h-0">

--- a/src/pages/QueuePage.tsx
+++ b/src/pages/QueuePage.tsx
@@ -822,18 +822,6 @@ export function QueuePage() {
 		[labels],
 	);
 
-	const handleForceRecalibration = useCallback(async () => {
-		if (recalibration) return;
-		const item = await api.getRecalibration(true);
-		if (item) {
-			setRecalibration({ item, phase: "blind", relabelIds: new Set() });
-			setAppliedLabelIds(new Set());
-		} else {
-			console.warn(
-				"[DEV] Force recalibration returned null — no labeled messages yet?",
-			);
-		}
-	}, [recalibration]);
 
 	const handleDeleteLabel = useCallback(
 		(labelId: number) => {
@@ -1195,15 +1183,6 @@ export function QueuePage() {
 					onAdvance={advanceTutorial}
 					onSkip={finishTutorial}
 				/>
-			)}
-			{import.meta.env.DEV && !recalibration && (
-				<button
-					onClick={handleForceRecalibration}
-					className="fixed bottom-4 left-57 z-50 text-[10px] font-mono text-faint bg-surface border border-edge rounded-sm px-2.5 py-1.5 hover:border-ochre-dim hover:text-muted transition-colors"
-					title="Dev-only: force-trigger a recalibration round"
-				>
-					DEV · trigger recalibration
-				</button>
 			)}
 		</div>
 	);

--- a/src/pages/summaries/SummariesPageSingle.tsx
+++ b/src/pages/summaries/SummariesPageSingle.tsx
@@ -8,6 +8,10 @@ import { DeleteConfirmModal } from '../../components/summaries/DeleteConfirmModa
 import { api } from '../../services/api'
 import type { HandoffSummaryItem, SingleLabelDetail } from '../../types'
 
+// Matches SummariesPageMulti's cadence. We only poll while a handoff is in
+// flight, so an idle page makes no requests.
+const POLL_MS = 2000
+
 export function SummariesPageSingle() {
   const [items, setItems] = useState<HandoffSummaryItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -38,7 +42,29 @@ export function SummariesPageSingle() {
       setLoading(false)
     })
   }, [])
-  useEffect(() => { refreshDetail() }, [refreshDetail])
+
+  // Auto-refresh the label list while any handoff is still classifying so
+  // progress updates live without a manual refresh. The effect re-arms whenever
+  // `items` changes; once nothing is classifying it returns early and the page
+  // goes quiet again (a new handoff flips an item back to 'classifying', which
+  // re-arms it).
+  useEffect(() => {
+    const anyClassifying = items.some((it) => it.phase === 'classifying')
+    if (!anyClassifying) return
+    const id = setInterval(() => {
+      api.listHandoffSummaries().then(setItems).catch(() => {})
+    }, POLL_MS)
+    return () => clearInterval(id)
+  }, [items])
+
+  // Refresh the open detail pane when the active label's progress or phase
+  // changes (e.g. it finishes classifying → show its final counts + summary).
+  // `activeProgress` is stable while that label is untouched, so unrelated poll
+  // ticks don't trigger detail fetches.
+  const activeItem = items.find((it) => it.label_id === activeId)
+  const activeProgress = activeItem ? `${activeItem.phase}:${activeItem.classified_count}` : null
+  useEffect(() => { refreshDetail() }, [refreshDetail, activeProgress])
+
   useEffect(() => {
     if (activeId !== null) localStorage.setItem('summaries.active_label_id', String(activeId))
   }, [activeId])

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -404,6 +404,11 @@ export const api = {
           { method: 'POST', ...json(body) }
         ),
 
+  getHumanDecisions: (id: number): Promise<{ chatlog_id: number; message_index: number }[]> =>
+    USE_MOCK
+      ? Promise.resolve([])
+      : req(`/api/single-labels/${id}/decisions`),
+
   undoLastDecision: (id: number, assignmentId?: number): Promise<DecideResult> =>
     USE_MOCK
       ? Promise.resolve({ next: mockFocusedMessage, readiness: mockReadiness })

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -382,10 +382,15 @@ export const api = {
     USE_MOCK ? Promise.resolve({ ...mockActiveLabel, is_active: false, phase: 'complete' })
              : req(`/api/single-labels/${id}/close`, { method: 'POST' }),
 
-  getNextFocused: (id: number, assignmentId?: number): Promise<FocusedMessage | null> =>
-    USE_MOCK
+  getNextFocused: (id: number, assignmentId?: number, hintChatlogId?: number): Promise<FocusedMessage | null> => {
+    const params = new URLSearchParams()
+    if (assignmentId != null) params.set('assignment_id', String(assignmentId))
+    if (hintChatlogId != null) params.set('hint_chatlog_id', String(hintChatlogId))
+    const qs = params.toString()
+    return USE_MOCK
       ? Promise.resolve(mockFocusedMessage)
-      : req(`/api/single-labels/${id}/next${assignmentId ? `?assignment_id=${assignmentId}` : ''}`),
+      : req(`/api/single-labels/${id}/next${qs ? '?' + qs : ''}`)
+  },
 
   decide: (
     id: number,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -181,6 +181,14 @@ export const api = {
     USE_MOCK ? Promise.resolve({ ok: true })
              : req('/api/queue/autolabel', { method: 'POST' }),
 
+  clearAutolabelResults: (): Promise<{ ok: boolean; deleted: number }> =>
+    USE_MOCK ? Promise.resolve({ ok: true, deleted: 0 })
+             : req('/api/queue/autolabel/results', { method: 'DELETE' }),
+
+  stopAutolabel: (): Promise<{ ok: boolean }> =>
+    USE_MOCK ? Promise.resolve({ ok: true })
+             : req('/api/queue/autolabel/stop', { method: 'POST' }),
+
   getAutolabelStatus: (): Promise<{ running: boolean; processed: number; total: number; error: string | null }> =>
     USE_MOCK ? Promise.resolve({ running: false, processed: 0, total: 0, error: null })
              : req('/api/queue/autolabel/status'),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import type {
   LabelDefinition, QueueItem, LabelingSession, SuggestResponse,
   QueueStats, ApplyLabelRequest, CreateLabelRequest, UpdateLabelRequest,
   HistoryItem, LabelReviewItem,
-  ConceptCandidate, EmbedStatus, ConversationMessage, AnalysisSummary, TemporalAnalysis,
+  ConceptCandidate, LabelNameSuggestion, EmbedStatus, ConversationMessage, AnalysisSummary, TemporalAnalysis,
   LabelExample, SplitAutoLabelRequest, ApplyBatchRequest, ConciseResponse,
   RecalibrationItem, RecalibrationStats, SaveRecalibrationRequest, SaveRecalibrationResponse,
   SingleLabel, FocusedMessage, ReadinessState, DecideResult, DecisionValue,
@@ -129,6 +129,10 @@ export const api = {
   getCandidates: (): Promise<ConceptCandidate[]> =>
     USE_MOCK ? Promise.resolve([])
              : req('/api/concepts/candidates'),
+
+  getNameSuggestions: (): Promise<LabelNameSuggestion[]> =>
+    USE_MOCK ? Promise.resolve([])
+             : req('/api/concepts/name-suggestions'),
 
   resolveCandidate: (id: number, action: 'accept' | 'reject', name?: string): Promise<LabelDefinition | { ok: boolean }> =>
     USE_MOCK ? Promise.resolve({ ok: true })

--- a/src/tests/ProgressSidebar.test.tsx
+++ b/src/tests/ProgressSidebar.test.tsx
@@ -42,8 +42,9 @@ test('shows skipped count when non-zero', () => {
 })
 
 test('shows AI suggestions unlock progress', () => {
-  render(<ProgressSidebar {...defaultProps} />)
-  expect(screen.getByText('14 / 20 to unlock')).toBeInTheDocument()
+  const stats = { total_messages: 100, labeled_count: 7, skipped_count: 0 }
+  render(<ProgressSidebar {...defaultProps} stats={stats} />)
+  expect(screen.getByText('7 / 10 to unlock')).toBeInTheDocument()
 })
 
 test('renders clickable label buttons', () => {

--- a/src/tests/decision/DecisionWorkspace.test.tsx
+++ b/src/tests/decision/DecisionWorkspace.test.tsx
@@ -106,7 +106,7 @@ beforeEach(() => {
 // The yes-key bindings (a / A) are covered in DecisionWorkspaceKeybinds.test.tsx.
 // This asserts the remaining default decision keys dispatch to their handlers,
 // including plain Enter -> onAcceptAi (only covered here).
-test('default keys dispatch handlers: no=d, skip=Space, undo=s, acceptAi=Enter', () => {
+test('default keys dispatch handlers: no=d, skip=ArrowRight, undo=ArrowLeft, acceptAi=Enter', () => {
   const onNo = vi.fn()
   const onSkip = vi.fn()
   const onUndo = vi.fn()
@@ -123,8 +123,8 @@ test('default keys dispatch handlers: no=d, skip=Space, undo=s, acceptAi=Enter',
     />,
   )
   fireEvent.keyDown(window, { key: 'd' })
-  fireEvent.keyDown(window, { key: ' ' })
-  fireEvent.keyDown(window, { key: 's' })
+  fireEvent.keyDown(window, { key: 'ArrowRight' })
+  fireEvent.keyDown(window, { key: 'ArrowLeft' })
   fireEvent.keyDown(window, { key: 'Enter' })
   expect(onNo).toHaveBeenCalledTimes(1)
   expect(onSkip).toHaveBeenCalledTimes(1)

--- a/src/tests/decision/DecisionWorkspaceKeybinds.test.tsx
+++ b/src/tests/decision/DecisionWorkspaceKeybinds.test.tsx
@@ -22,10 +22,10 @@ const renderWorkspace = (props = {}) => {
 }
 
 describe('DecisionWorkspace Keybinds', () => {
-  it('calls onYes when "a" is pressed (default)', () => {
+  it('calls onYes when "z" is pressed (default)', () => {
     const onYes = vi.fn()
     renderWorkspace({ onYes })
-    fireEvent.keyDown(window, { key: 'a' })
+    fireEvent.keyDown(window, { key: 'z' })
     expect(onYes).toHaveBeenCalled()
   })
 
@@ -36,33 +36,40 @@ describe('DecisionWorkspace Keybinds', () => {
     expect(onNo).toHaveBeenCalled()
   })
 
-  it('calls onSkip when " " (Space) is pressed (default)', () => {
+  it('calls onSkip when ArrowRight is pressed (default)', () => {
     const onSkip = vi.fn()
     renderWorkspace({ onSkip })
-    fireEvent.keyDown(window, { key: ' ' })
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
     expect(onSkip).toHaveBeenCalled()
   })
 
-  it('calls onUndo when "s" is pressed (default)', () => {
+  it('calls onSkip when Enter is pressed and no onAcceptAi handler', () => {
+    const onSkip = vi.fn()
+    renderWorkspace({ onSkip })
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(onSkip).toHaveBeenCalled()
+  })
+
+  it('calls onUndo when ArrowLeft is pressed (default)', () => {
     const onUndo = vi.fn()
     renderWorkspace({ onUndo })
-    fireEvent.keyDown(window, { key: 's' })
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
     expect(onUndo).toHaveBeenCalled()
   })
 
-  it('prevents default behavior when Space is pressed', () => {
+  it('does not call onSkip on Enter when onAcceptAi is provided', () => {
     const onSkip = vi.fn()
-    renderWorkspace({ onSkip })
-    const event = createEvent.keyDown(window, { key: ' ' })
-    vi.spyOn(event, 'preventDefault')
-    fireEvent(window, event)
-    expect(event.preventDefault).toHaveBeenCalled()
+    const onAcceptAi = vi.fn()
+    renderWorkspace({ onSkip, onAcceptAi })
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(onAcceptAi).toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
   })
 
   it('respects case-insensitivity', () => {
     const onYes = vi.fn()
     renderWorkspace({ onYes })
-    fireEvent.keyDown(window, { key: 'A' })
+    fireEvent.keyDown(window, { key: 'Z' })
     expect(onYes).toHaveBeenCalled()
   })
 

--- a/src/tests/run/LabelNameInput.test.tsx
+++ b/src/tests/run/LabelNameInput.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LabelNameInput } from '../../components/run/LabelNameInput'
+import type { LabelNameSuggestion } from '../../types'
+
+const suggestions: LabelNameSuggestion[] = [
+  { name: 'confusion', description: 'Student shows confusion about a concept' },
+  { name: 'code help', description: 'Requesting help with code' },
+]
+
+describe('LabelNameInput', () => {
+  it('shows filtered suggestions when focused and typing', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('confusion')).toBeInTheDocument()
+    expect(screen.queryByText('code help')).not.toBeInTheDocument()
+  })
+
+  it('hides dropdown when typed value exactly matches a suggestion', () => {
+    render(<LabelNameInput value="confusion" onChange={() => {}} suggestions={suggestions} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('calls onChange and onCommit when suggestion is clicked', () => {
+    const onChange = vi.fn()
+    const onCommit = vi.fn()
+    render(
+      <LabelNameInput value="con" onChange={onChange} onCommit={onCommit} suggestions={suggestions} />
+    )
+    fireEvent.focus(screen.getByRole('combobox'))
+    fireEvent.mouseDown(screen.getByText('confusion'))
+    expect(onChange).toHaveBeenCalledWith('confusion')
+    expect(onCommit).toHaveBeenCalled()
+  })
+
+  it('selects first suggestion on Enter when dropdown is open', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="con" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('confusion')
+  })
+
+  it('navigates to second suggestion with ArrowDown then selects with Enter', () => {
+    const onChange = vi.fn()
+    render(<LabelNameInput value="c" onChange={onChange} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith('code help')
+  })
+
+  it('closes dropdown on Escape', () => {
+    render(<LabelNameInput value="con" onChange={() => {}} suggestions={suggestions} />)
+    const input = screen.getByRole('combobox')
+    fireEvent.focus(input)
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('passes unhandled keyDown events to the onKeyDown prop', () => {
+    const onKeyDown = vi.fn()
+    render(
+      <LabelNameInput value="" onChange={() => {}} suggestions={[]} onKeyDown={onKeyDown} />
+    )
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' })
+    expect(onKeyDown).toHaveBeenCalled()
+  })
+
+  it('renders as a plain input when suggestions is empty', () => {
+    render(<LabelNameInput value="any" onChange={() => {}} suggestions={[]} />)
+    fireEvent.focus(screen.getByRole('combobox'))
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})

--- a/src/tests/summaries/SummariesPageSingle.test.tsx
+++ b/src/tests/summaries/SummariesPageSingle.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, act } from '@testing-library/react'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
+import { SummariesPageSingle } from '../../pages/summaries/SummariesPageSingle'
+import type { HandoffSummaryItem } from '../../types'
+
+const { mockListSummaries, mockGetDetail } = vi.hoisted(() => ({
+  mockListSummaries: vi.fn(),
+  mockGetDetail: vi.fn(),
+}))
+
+vi.mock('../../services/api', () => ({
+  api: {
+    listHandoffSummaries: mockListSummaries,
+    getSingleLabelDetail: mockGetDetail,
+    exportOneHotCsv: vi.fn(),
+  },
+}))
+
+function item(overrides: Partial<HandoffSummaryItem> = {}): HandoffSummaryItem {
+  return {
+    label_id: 9,
+    label_name: 'verification',
+    description: null,
+    phase: 'classifying',
+    yes_count: 0,
+    no_count: 0,
+    review_count: 0,
+    review_threshold: 0.7,
+    included: [],
+    excluded: [],
+    classified_count: 350,
+    classification_total: 3500,
+    error: null,
+    error_kind: null,
+    batch_state: null,
+    batch_submitted_at: null,
+    batch_polled_at: null,
+    batch_total_count: null,
+    batch_completed_count: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.useFakeTimers()
+  mockGetDetail.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks() // also drains any unconsumed mockResolvedValueOnce queue
+})
+
+const tick = (ms: number) => act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+
+test('progress auto-updates while a label is classifying, without remounting', async () => {
+  mockListSummaries
+    .mockResolvedValueOnce([item({ classified_count: 350 })]) // mount → 10%
+    .mockResolvedValueOnce([item({ classified_count: 700 })]) // poll → 20%
+
+  render(<SummariesPageSingle />)
+
+  await tick(0) // flush mount fetch
+  expect(screen.getByText(/10%/)).toBeInTheDocument()
+
+  await tick(2000) // one poll tick
+  expect(screen.getByText(/20%/)).toBeInTheDocument()
+})
+
+test('polling stops once nothing is classifying', async () => {
+  mockListSummaries
+    .mockResolvedValueOnce([item({ classified_count: 350 })]) // mount → classifying
+    .mockResolvedValueOnce([
+      item({ phase: 'handed_off', classified_count: 3500, yes_count: 1000, no_count: 2500 }),
+    ]) // poll → done
+    .mockResolvedValue([item({ phase: 'handed_off', classified_count: 3500 })])
+
+  render(<SummariesPageSingle />)
+  await tick(0)
+  expect(screen.getByText(/10%/)).toBeInTheDocument()
+
+  await tick(2000) // poll observes handed_off → should stop polling
+  const callsAfterDone = mockListSummaries.mock.calls.length
+
+  await tick(2000 * 5) // idle page should not poll further
+  expect(mockListSummaries.mock.calls.length).toBe(callsAfterDone)
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -657,7 +657,7 @@ export interface SingleLabelDetail {
   confidence_histogram: ConfidenceHistogramBin[]
 }
 
-export type MessageVerdict = 'yes' | 'no' | 'review'
+export type MessageVerdict = 'yes' | 'no' | 'skip' | 'review'
 
 export interface MessageListItem {
   chatlog_id: number

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,6 +200,11 @@ export interface ConceptCandidate {
   created_at: string
 }
 
+export interface LabelNameSuggestion {
+  name: string
+  description: string
+}
+
 export interface EmbedStatus {
   cached: number
   total_unlabeled: number


### PR DESCRIPTION
## Summary
- Add `LabelDefinition.handed_off_at` (with one-time migration backfill) and order handoff summaries by most-recent handoff first.
- Serialize inline classification jobs process-wide via `_INLINE_CLASSIFY_LOCK` so concurrent handoffs don't multiply the Gemini request rate past quota (Batch API path intentionally left ungated).
- Scope the run-detail AI-coverage denominator to the in-scope study sample (Week 8 for single-label) instead of the entire `MessageCache`.
- Allow `'skip'` in `MessageVerdict` (Pydantic schema + TS type) so skipped human rows don't 500 the message-listing endpoint.
- Auto-refresh single-label summaries while a handoff is still classifying (polls only while in-flight).

## Test Plan
- [x] Backend: `cd server/python && uv run pytest` — 369 passed.
- [x] New frontend test: `npx vitest run src/tests/summaries/SummariesPageSingle.test.tsx` — passes.
- [ ] Note: 21 pre-existing frontend failures in `MessageCard.test.tsx` / `Recalibration.test.tsx` (`useKeybinds must be used within KeybindProvider` harness issue) are unrelated to this change and fail at branch HEAD without these edits.